### PR TITLE
Keep the parse_tree input alive so the string pointers remain valid

### DIFF
--- a/GraphQLService.cpp
+++ b/GraphQLService.cpp
@@ -381,10 +381,9 @@ Request::Request(TypeMap&& operationTypes)
 
 rapidjson::Document Request::resolve(const peg::ast_node& root, const std::string& operationName, const rapidjson::Document::ConstObject& variables) const
 {
-	const auto& document = *root.children.front();
 	FragmentDefinitionVisitor fragmentVisitor;
 
-	peg::for_each_child<peg::fragment_definition>(document,
+	peg::for_each_child<peg::fragment_definition>(root,
 		[&fragmentVisitor](const peg::ast_node& child)
 	{
 		fragmentVisitor.visit(child);
@@ -393,7 +392,7 @@ rapidjson::Document Request::resolve(const peg::ast_node& root, const std::strin
 	auto fragments = fragmentVisitor.getFragments();
 	OperationDefinitionVisitor operationVisitor(_operations, operationName, variables, fragments);
 
-	peg::for_each_child<peg::operation_definition>(document,
+	peg::for_each_child<peg::operation_definition>(root,
 		[&operationVisitor](const peg::ast_node& child)
 	{
 		operationVisitor.visit(child);

--- a/GraphQLTree.cpp
+++ b/GraphQLTree.cpp
@@ -552,12 +552,6 @@ struct ast_selector<input_object_type_extension>
 {
 };
 
-template <>
-struct ast_selector<document>
-	: std::true_type
-{
-};
-
 std::unique_ptr<ast<std::string>> parseString(std::string&& input)
 {
 	std::unique_ptr<ast<std::string>> result(new ast<std::string> { std::move(input), nullptr });

--- a/GraphQLTree.cpp
+++ b/GraphQLTree.cpp
@@ -558,21 +558,38 @@ struct ast_selector<document>
 {
 };
 
-std::unique_ptr<ast_node> parseString(const char* text)
+std::unique_ptr<ast<std::string>> parseString(std::string&& input)
 {
-	return parse_tree::parse<document, ast_node, ast_selector>(memory_input<>(text, "GraphQL"));
+	std::unique_ptr<ast<std::string>> result(new ast<std::string> { std::move(input), nullptr });
+	memory_input<> in(result->input.c_str(), result->input.size(), "GraphQL");
+
+	result->root = parse_tree::parse<document, ast_node, ast_selector>(std::move(in));
+
+	return result;
 }
 
-std::unique_ptr<ast_node> parseFile(file_input<>&& in)
+std::unique_ptr<ast<std::unique_ptr<file_input<>>>> parseFile(const char* filename)
 {
-	return parse_tree::parse<document, ast_node, ast_selector>(std::move(in));
+	std::unique_ptr<ast<std::unique_ptr<file_input<>>>> result(new ast<std::unique_ptr<file_input<>>> {
+		std::unique_ptr<file_input<>>(new file_input<>(std::string(filename))),
+		nullptr
+		});
+
+	result->root = parse_tree::parse<document, ast_node, ast_selector>(std::move(*result->input));
+
+	return result;
 }
 
 } /* namespace peg */
 
-std::unique_ptr<peg::ast_node> operator "" _graphql(const char* text, size_t size)
+std::unique_ptr<peg::ast<const char*>> operator "" _graphql(const char* text, size_t size)
 {
-	return tao::graphqlpeg::parse_tree::parse<peg::document, peg::ast_node, peg::ast_selector>(tao::graphqlpeg::memory_input<>(text, size, "GraphQL"));
+	std::unique_ptr<peg::ast<const char*>> result(new peg::ast<const char*> { text, nullptr });
+	peg::memory_input<> in(text, size, "GraphQL");
+
+	result->root = peg::parse_tree::parse<peg::document, peg::ast_node, peg::ast_selector>(std::move(in));
+
+	return result;
 }
 
 } /* namespace graphql */

--- a/GraphQLTree.h
+++ b/GraphQLTree.h
@@ -23,12 +23,19 @@ struct ast_node
 	std::string unescaped;
 };
 
-std::unique_ptr<ast_node> parseString(const char* text);
-std::unique_ptr<ast_node> parseFile(file_input<>&& in);
+template <typename _Input>
+struct ast
+{
+	_Input input;
+	std::unique_ptr<ast_node> root;
+};
+
+std::unique_ptr<ast<std::string>> parseString(std::string&& input);
+std::unique_ptr<ast<std::unique_ptr<file_input<>>>> parseFile(const char* filename);
 
 } /* namespace peg */
 
-std::unique_ptr<peg::ast_node> operator "" _graphql(const char* text, size_t size);
+std::unique_ptr<peg::ast<const char*>> operator "" _graphql(const char* text, size_t size);
 
 } /* namespace graphql */
 } /* namespace facebook */

--- a/SchemaGenerator.cpp
+++ b/SchemaGenerator.cpp
@@ -144,7 +144,7 @@ Generator::Generator()
 		throw std::logic_error("Unable to parse the introspection schema, but there was no error message from the parser!");
 	}
 
-	for (const auto& child : ast->children.front()->children)
+	for (const auto& child : ast->root->children.front()->children)
 	{
 		visitDefinition(*child);
 	}
@@ -160,15 +160,14 @@ Generator::Generator(std::string schemaFileName, std::string filenamePrefix, std
 	, _filenamePrefix(std::move(filenamePrefix))
 	, _schemaNamespace(std::move(schemaNamespace))
 {
-	tao::graphqlpeg::file_input<> in(schemaFileName.c_str());
-	auto ast = peg::parseFile(std::move(in));
+	auto ast = peg::parseFile(schemaFileName.c_str());
 
 	if (!ast)
 	{
 		throw std::logic_error("Unable to parse the service schema, but there was no error message from the parser!");
 	}
 
-	for (const auto& child : ast->children.front()->children)
+	for (const auto& child : ast->root->children.front()->children)
 	{
 		visitDefinition(*child);
 	}

--- a/SchemaGenerator.cpp
+++ b/SchemaGenerator.cpp
@@ -144,7 +144,7 @@ Generator::Generator()
 		throw std::logic_error("Unable to parse the introspection schema, but there was no error message from the parser!");
 	}
 
-	for (const auto& child : ast->root->children.front()->children)
+	for (const auto& child : ast->root->children)
 	{
 		visitDefinition(*child);
 	}
@@ -167,7 +167,7 @@ Generator::Generator(std::string schemaFileName, std::string filenamePrefix, std
 		throw std::logic_error("Unable to parse the service schema, but there was no error message from the parser!");
 	}
 
-	for (const auto& child : ast->root->children.front()->children)
+	for (const auto& child : ast->root->children)
 	{
 		visitDefinition(*child);
 	}

--- a/test_today.cpp
+++ b/test_today.cpp
@@ -60,17 +60,18 @@ int main(int argc, char** argv)
 
 	try
 	{
-		std::string input;
-		std::unique_ptr<tao::graphqlpeg::file_input<>> file;
-		std::unique_ptr<peg::ast_node> ast;
+		const peg::ast_node* ast = nullptr;
+		std::unique_ptr<peg::ast<std::string>> ast_input;
+		std::unique_ptr<peg::ast<std::unique_ptr<peg::file_input<>>>> ast_file;
 
 		if (argc > 1)
 		{
-			file.reset(new tao::graphqlpeg::file_input<>(argv[1]));
-			ast = peg::parseFile(std::move(*file));
+			ast_file = peg::parseFile(argv[1]);
+			ast = ast_file->root.get();
 		}
 		else
 		{
+			std::string input;
 			std::string line;
 
 			while (std::getline(std::cin, line))
@@ -78,7 +79,8 @@ int main(int argc, char** argv)
 				input.append(line);
 			}
 
-			ast = peg::parseString(input.c_str());
+			ast_input = peg::parseString(std::move(input));
+			ast = ast_input->root.get();
 		}
 
 		if (!ast)

--- a/tests.cpp
+++ b/tests.cpp
@@ -123,7 +123,7 @@ TEST_F(TodayServiceCase, QueryEverything)
 			}
 		})"_graphql;
 	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	const auto result = _service->resolve(*ast, "Everything", variables.GetObject());
+	const auto result = _service->resolve(*ast->root, "Everything", variables.GetObject());
 	EXPECT_EQ(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_EQ(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
 	EXPECT_EQ(size_t(1), _getUnreadCountsCount) << "today service lazy loads the unreadCounts and caches the result";
@@ -197,7 +197,7 @@ TEST_F(TodayServiceCase, QueryAppointments)
 			}
 		})"_graphql;
 	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	const auto result = _service->resolve(*ast, "", variables.GetObject());
+	const auto result = _service->resolve(*ast->root, "", variables.GetObject());
 	EXPECT_EQ(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_GE(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
 	EXPECT_GE(size_t(1), _getUnreadCountsCount) << "today service lazy loads the unreadCounts and caches the result";
@@ -252,7 +252,7 @@ TEST_F(TodayServiceCase, QueryTasks)
 			}
 		})gql"_graphql;
 	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	const auto result = _service->resolve(*ast, "", variables.GetObject());
+	const auto result = _service->resolve(*ast->root, "", variables.GetObject());
 	EXPECT_GE(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_EQ(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
 	EXPECT_GE(size_t(1), _getUnreadCountsCount) << "today service lazy loads the unreadCounts and caches the result";
@@ -306,7 +306,7 @@ TEST_F(TodayServiceCase, QueryUnreadCounts)
 			}
 		})"_graphql;
 	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	const auto result = _service->resolve(*ast, "", variables.GetObject());
+	const auto result = _service->resolve(*ast->root, "", variables.GetObject());
 	EXPECT_GE(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_GE(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
 	EXPECT_EQ(size_t(1), _getUnreadCountsCount) << "today service lazy loads the unreadCounts and caches the result";
@@ -359,7 +359,7 @@ TEST_F(TodayServiceCase, MutateCompleteTask)
 			}
 		})"_graphql;
 	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	const auto result = _service->resolve(*ast, "", variables.GetObject());
+	const auto result = _service->resolve(*ast->root, "", variables.GetObject());
 
 	try
 	{
@@ -434,7 +434,7 @@ TEST_F(TodayServiceCase, Introspection)
 			}
 		})"_graphql;
 	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	const auto result = _service->resolve(*ast, "", variables.GetObject());
+	const auto result = _service->resolve(*ast->root, "", variables.GetObject());
 
 	try
 	{


### PR DESCRIPTION
The `tao::pegtl::parse_tree` keeps pointers to the parsed input buffer instead of making deep copies. If the parse_tree outlives the buffer it parsed (e.g. the `file_input<>` is closed or the `std::string` is deleted or goes out of scope) the pointers inside of the `parse_tree` are all invalidated.

To fix this potential bug, I'm bundling the lifetimes of these two objects in a single template struct called `ast` which declares the input holder before the `parse_tree` holder so it's always destroyed last. This also preserves the input in case it's useful in the future, e.g. caching a query.
