### PR TITLE
Use a single rapidjson::Document and allocator for the entire result set

### DIFF
--- a/Today.cpp
+++ b/Today.cpp
@@ -154,7 +154,7 @@ struct EdgeConstraints
 	{
 	}
 
-	std::shared_ptr<_Connection> operator()(const int* first, const rapidjson::Document* after, const int* last, const rapidjson::Document* before) const
+	std::shared_ptr<_Connection> operator()(const int* first, const rapidjson::Value* after, const int* last, const rapidjson::Value* before) const
 	{
 		auto itrFirst = _objects.cbegin();
 		auto itrLast = _objects.cend();
@@ -233,7 +233,7 @@ private:
 	const vec_type& _objects;
 };
 
-std::shared_ptr<object::AppointmentConnection> Query::getAppointments(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Document>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Document>&& before) const
+std::shared_ptr<object::AppointmentConnection> Query::getAppointments(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
 {
 	loadAppointments();
 
@@ -243,7 +243,7 @@ std::shared_ptr<object::AppointmentConnection> Query::getAppointments(std::uniqu
 	return std::static_pointer_cast<object::AppointmentConnection>(connection);
 }
 
-std::shared_ptr<object::TaskConnection> Query::getTasks(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Document>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Document>&& before) const
+std::shared_ptr<object::TaskConnection> Query::getTasks(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
 {
 	loadTasks();
 
@@ -253,7 +253,7 @@ std::shared_ptr<object::TaskConnection> Query::getTasks(std::unique_ptr<int>&& f
 	return std::static_pointer_cast<object::TaskConnection>(connection);
 }
 
-std::shared_ptr<object::FolderConnection> Query::getUnreadCounts(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Document>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Document>&& before) const
+std::shared_ptr<object::FolderConnection> Query::getUnreadCounts(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
 {
 	loadUnreadCounts();
 

--- a/Today.h
+++ b/Today.h
@@ -23,9 +23,9 @@ public:
 	explicit Query(appointmentsLoader&& getAppointments, tasksLoader&& getTasks, unreadCountsLoader&& getUnreadCounts);
 
 	std::shared_ptr<service::Object> getNode(std::vector<uint8_t>&& id) const override;
-	std::shared_ptr<object::AppointmentConnection> getAppointments(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Document>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Document>&& before) const override;
-	std::shared_ptr<object::TaskConnection> getTasks(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Document>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Document>&& before) const override;
-	std::shared_ptr<object::FolderConnection> getUnreadCounts(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Document>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Document>&& before) const override;
+	std::shared_ptr<object::AppointmentConnection> getAppointments(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const override;
+	std::shared_ptr<object::TaskConnection> getTasks(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const override;
+	std::shared_ptr<object::FolderConnection> getUnreadCounts(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const override;
 	std::vector<std::shared_ptr<object::Appointment>> getAppointmentsById(std::vector<std::vector<uint8_t>>&& ids) const override;
 	std::vector<std::shared_ptr<object::Task>> getTasksById(std::vector<std::vector<uint8_t>>&& ids) const override;
 	std::vector<std::shared_ptr<object::Folder>> getUnreadCountsById(std::vector<std::vector<uint8_t>>&& ids) const override;
@@ -79,11 +79,11 @@ public:
 	explicit Appointment(std::vector<uint8_t>&& id, std::string&& when, std::string&& subject, bool isNow);
 
 	std::vector<uint8_t> getId() const override { return _id; }
-	std::unique_ptr<rapidjson::Document> getWhen() const override
+	std::unique_ptr<rapidjson::Value> getWhen(rapidjson::Document::AllocatorType& allocator) const override
 	{
-		std::unique_ptr<rapidjson::Document> result(new rapidjson::Document(rapidjson::Type::kStringType));
+		std::unique_ptr<rapidjson::Value> result(new rapidjson::Value(rapidjson::Type::kStringType));
 
-		result->SetString(_when.c_str(), result->GetAllocator());
+		result->SetString(_when.c_str(), allocator);
 
 		return result;
 	}
@@ -110,11 +110,11 @@ public:
 		return std::static_pointer_cast<object::Appointment>(_appointment);
 	}
 
-	rapidjson::Document getCursor() const override
+	rapidjson::Value getCursor(rapidjson::Document::AllocatorType& allocator) const override
 	{
-		rapidjson::Document result(rapidjson::Type::kStringType);
+		rapidjson::Value result(rapidjson::Type::kStringType);
 
-		result.SetString(service::Base64::toBase64(_appointment->getId()).c_str(), result.GetAllocator());
+		result.SetString(service::Base64::toBase64(_appointment->getId()).c_str(), allocator);
 
 		return result;
 	}
@@ -184,11 +184,11 @@ public:
 		return std::static_pointer_cast<object::Task>(_task);
 	}
 
-	rapidjson::Document getCursor() const override
+	rapidjson::Value getCursor(rapidjson::Document::AllocatorType& allocator) const override
 	{
-		rapidjson::Document result(rapidjson::Type::kStringType);
+		rapidjson::Value result(rapidjson::Type::kStringType);
 
-		result.SetString(service::Base64::toBase64(_task->getId()).c_str(), result.GetAllocator());
+		result.SetString(service::Base64::toBase64(_task->getId()).c_str(), allocator);
 
 		return result;
 	}
@@ -257,11 +257,11 @@ public:
 		return std::static_pointer_cast<object::Folder>(_folder);
 	}
 
-	rapidjson::Document getCursor() const override
+	rapidjson::Value getCursor(rapidjson::Document::AllocatorType& allocator) const override
 	{
-		rapidjson::Document result(rapidjson::Type::kStringType);
+		rapidjson::Value result(rapidjson::Type::kStringType);
 
-		result.SetString(service::Base64::toBase64(_folder->getId()).c_str(), result.GetAllocator());
+		result.SetString(service::Base64::toBase64(_folder->getId()).c_str(), allocator);
 
 		return result;
 	}

--- a/samples/IntrospectionSchema.cpp
+++ b/samples/IntrospectionSchema.cpp
@@ -15,7 +15,7 @@ namespace graphql {
 namespace service {
 
 template <>
-introspection::__TypeKind ModifiedArgument<introspection::__TypeKind>::convert(const rapidjson::Value& value)
+introspection::__TypeKind ModifiedArgument<introspection::__TypeKind>::convert(rapidjson::Document::AllocatorType&, const rapidjson::Value& value)
 {
 	static const std::unordered_map<std::string, introspection::__TypeKind> s_names = {
 		{ "SCALAR", introspection::__TypeKind::SCALAR },
@@ -39,7 +39,7 @@ introspection::__TypeKind ModifiedArgument<introspection::__TypeKind>::convert(c
 }
 
 template <>
-rapidjson::Document service::ModifiedResult<introspection::__TypeKind>::convert(introspection::__TypeKind&& value, ResolverParams&&)
+rapidjson::Value service::ModifiedResult<introspection::__TypeKind>::convert(introspection::__TypeKind&& value, ResolverParams&&)
 {
 	static const std::string s_names[] = {
 		"SCALAR",
@@ -52,7 +52,7 @@ rapidjson::Document service::ModifiedResult<introspection::__TypeKind>::convert(
 		"NON_NULL"
 	};
 
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef(s_names[static_cast<size_t>(value)].c_str()));
 
@@ -60,7 +60,7 @@ rapidjson::Document service::ModifiedResult<introspection::__TypeKind>::convert(
 }
 
 template <>
-introspection::__DirectiveLocation ModifiedArgument<introspection::__DirectiveLocation>::convert(const rapidjson::Value& value)
+introspection::__DirectiveLocation ModifiedArgument<introspection::__DirectiveLocation>::convert(rapidjson::Document::AllocatorType&, const rapidjson::Value& value)
 {
 	static const std::unordered_map<std::string, introspection::__DirectiveLocation> s_names = {
 		{ "QUERY", introspection::__DirectiveLocation::QUERY },
@@ -94,7 +94,7 @@ introspection::__DirectiveLocation ModifiedArgument<introspection::__DirectiveLo
 }
 
 template <>
-rapidjson::Document service::ModifiedResult<introspection::__DirectiveLocation>::convert(introspection::__DirectiveLocation&& value, ResolverParams&&)
+rapidjson::Value service::ModifiedResult<introspection::__DirectiveLocation>::convert(introspection::__DirectiveLocation&& value, ResolverParams&&)
 {
 	static const std::string s_names[] = {
 		"QUERY",
@@ -117,7 +117,7 @@ rapidjson::Document service::ModifiedResult<introspection::__DirectiveLocation>:
 		"INPUT_FIELD_DEFINITION"
 	};
 
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef(s_names[static_cast<size_t>(value)].c_str()));
 
@@ -143,44 +143,44 @@ __Schema::__Schema()
 {
 }
 
-rapidjson::Document __Schema::resolveTypes(service::ResolverParams&& params)
+rapidjson::Value __Schema::resolveTypes(service::ResolverParams&& params)
 {
 	auto result = getTypes();
 
 	return service::ModifiedResult<__Type>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Schema::resolveQueryType(service::ResolverParams&& params)
+rapidjson::Value __Schema::resolveQueryType(service::ResolverParams&& params)
 {
 	auto result = getQueryType();
 
 	return service::ModifiedResult<__Type>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Schema::resolveMutationType(service::ResolverParams&& params)
+rapidjson::Value __Schema::resolveMutationType(service::ResolverParams&& params)
 {
 	auto result = getMutationType();
 
 	return service::ModifiedResult<__Type>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Schema::resolveSubscriptionType(service::ResolverParams&& params)
+rapidjson::Value __Schema::resolveSubscriptionType(service::ResolverParams&& params)
 {
 	auto result = getSubscriptionType();
 
 	return service::ModifiedResult<__Type>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Schema::resolveDirectives(service::ResolverParams&& params)
+rapidjson::Value __Schema::resolveDirectives(service::ResolverParams&& params)
 {
 	auto result = getDirectives();
 
 	return service::ModifiedResult<__Directive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Schema::resolve__typename(service::ResolverParams&&)
+rapidjson::Value __Schema::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("__Schema"));
 
@@ -205,108 +205,108 @@ __Type::__Type()
 {
 }
 
-rapidjson::Document __Type::resolveKind(service::ResolverParams&& params)
+rapidjson::Value __Type::resolveKind(service::ResolverParams&& params)
 {
 	auto result = getKind();
 
 	return service::ModifiedResult<__TypeKind>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Type::resolveName(service::ResolverParams&& params)
+rapidjson::Value __Type::resolveName(service::ResolverParams&& params)
 {
 	auto result = getName();
 
 	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Type::resolveDescription(service::ResolverParams&& params)
+rapidjson::Value __Type::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription();
 
 	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Type::resolveFields(service::ResolverParams&& params)
+rapidjson::Value __Type::resolveFields(service::ResolverParams&& params)
 {
 	const auto defaultArguments = []()
 	{
 		rapidjson::Document values(rapidjson::Type::kObjectType);
-		auto& allocator = values.GetAllocator();
+		auto& valuesAllocator = values.GetAllocator();
 		rapidjson::Document parsed;
 		rapidjson::Value entry;
 
 		parsed.Parse(R"js(false)js");
-		entry.CopyFrom(parsed, allocator);
-		values.AddMember(rapidjson::StringRef("includeDeprecated"), entry, allocator);
+		entry.CopyFrom(parsed, valuesAllocator);
+		values.AddMember(rapidjson::StringRef("includeDeprecated"), entry, valuesAllocator);
 
 		return values;
 	}();
 
-	auto pairIncludeDeprecated = service::ModifiedArgument<bool>::find<service::TypeModifier::Nullable>("includeDeprecated", params.arguments);
+	auto pairIncludeDeprecated = service::ModifiedArgument<bool>::find<service::TypeModifier::Nullable>(params.allocator, "includeDeprecated", params.arguments);
 	auto argIncludeDeprecated = (pairIncludeDeprecated.second
 		? std::move(pairIncludeDeprecated.first)
-		: service::ModifiedArgument<bool>::require<service::TypeModifier::Nullable>("includeDeprecated", defaultArguments.GetObject()));
+		: service::ModifiedArgument<bool>::require<service::TypeModifier::Nullable>(params.allocator, "includeDeprecated", defaultArguments.GetObject()));
 	auto result = getFields(std::move(argIncludeDeprecated));
 
 	return service::ModifiedResult<__Field>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Type::resolveInterfaces(service::ResolverParams&& params)
+rapidjson::Value __Type::resolveInterfaces(service::ResolverParams&& params)
 {
 	auto result = getInterfaces();
 
 	return service::ModifiedResult<__Type>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Type::resolvePossibleTypes(service::ResolverParams&& params)
+rapidjson::Value __Type::resolvePossibleTypes(service::ResolverParams&& params)
 {
 	auto result = getPossibleTypes();
 
 	return service::ModifiedResult<__Type>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Type::resolveEnumValues(service::ResolverParams&& params)
+rapidjson::Value __Type::resolveEnumValues(service::ResolverParams&& params)
 {
 	const auto defaultArguments = []()
 	{
 		rapidjson::Document values(rapidjson::Type::kObjectType);
-		auto& allocator = values.GetAllocator();
+		auto& valuesAllocator = values.GetAllocator();
 		rapidjson::Document parsed;
 		rapidjson::Value entry;
 
 		parsed.Parse(R"js(false)js");
-		entry.CopyFrom(parsed, allocator);
-		values.AddMember(rapidjson::StringRef("includeDeprecated"), entry, allocator);
+		entry.CopyFrom(parsed, valuesAllocator);
+		values.AddMember(rapidjson::StringRef("includeDeprecated"), entry, valuesAllocator);
 
 		return values;
 	}();
 
-	auto pairIncludeDeprecated = service::ModifiedArgument<bool>::find<service::TypeModifier::Nullable>("includeDeprecated", params.arguments);
+	auto pairIncludeDeprecated = service::ModifiedArgument<bool>::find<service::TypeModifier::Nullable>(params.allocator, "includeDeprecated", params.arguments);
 	auto argIncludeDeprecated = (pairIncludeDeprecated.second
 		? std::move(pairIncludeDeprecated.first)
-		: service::ModifiedArgument<bool>::require<service::TypeModifier::Nullable>("includeDeprecated", defaultArguments.GetObject()));
+		: service::ModifiedArgument<bool>::require<service::TypeModifier::Nullable>(params.allocator, "includeDeprecated", defaultArguments.GetObject()));
 	auto result = getEnumValues(std::move(argIncludeDeprecated));
 
 	return service::ModifiedResult<__EnumValue>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Type::resolveInputFields(service::ResolverParams&& params)
+rapidjson::Value __Type::resolveInputFields(service::ResolverParams&& params)
 {
 	auto result = getInputFields();
 
 	return service::ModifiedResult<__InputValue>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Type::resolveOfType(service::ResolverParams&& params)
+rapidjson::Value __Type::resolveOfType(service::ResolverParams&& params)
 {
 	auto result = getOfType();
 
 	return service::ModifiedResult<__Type>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Type::resolve__typename(service::ResolverParams&&)
+rapidjson::Value __Type::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("__Type"));
 
@@ -328,51 +328,51 @@ __Field::__Field()
 {
 }
 
-rapidjson::Document __Field::resolveName(service::ResolverParams&& params)
+rapidjson::Value __Field::resolveName(service::ResolverParams&& params)
 {
 	auto result = getName();
 
 	return service::ModifiedResult<std::string>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Field::resolveDescription(service::ResolverParams&& params)
+rapidjson::Value __Field::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription();
 
 	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Field::resolveArgs(service::ResolverParams&& params)
+rapidjson::Value __Field::resolveArgs(service::ResolverParams&& params)
 {
 	auto result = getArgs();
 
 	return service::ModifiedResult<__InputValue>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Field::resolveType(service::ResolverParams&& params)
+rapidjson::Value __Field::resolveType(service::ResolverParams&& params)
 {
 	auto result = getType();
 
 	return service::ModifiedResult<__Type>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Field::resolveIsDeprecated(service::ResolverParams&& params)
+rapidjson::Value __Field::resolveIsDeprecated(service::ResolverParams&& params)
 {
 	auto result = getIsDeprecated();
 
 	return service::ModifiedResult<bool>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Field::resolveDeprecationReason(service::ResolverParams&& params)
+rapidjson::Value __Field::resolveDeprecationReason(service::ResolverParams&& params)
 {
 	auto result = getDeprecationReason();
 
 	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Field::resolve__typename(service::ResolverParams&&)
+rapidjson::Value __Field::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("__Field"));
 
@@ -392,37 +392,37 @@ __InputValue::__InputValue()
 {
 }
 
-rapidjson::Document __InputValue::resolveName(service::ResolverParams&& params)
+rapidjson::Value __InputValue::resolveName(service::ResolverParams&& params)
 {
 	auto result = getName();
 
 	return service::ModifiedResult<std::string>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document __InputValue::resolveDescription(service::ResolverParams&& params)
+rapidjson::Value __InputValue::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription();
 
 	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __InputValue::resolveType(service::ResolverParams&& params)
+rapidjson::Value __InputValue::resolveType(service::ResolverParams&& params)
 {
 	auto result = getType();
 
 	return service::ModifiedResult<__Type>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document __InputValue::resolveDefaultValue(service::ResolverParams&& params)
+rapidjson::Value __InputValue::resolveDefaultValue(service::ResolverParams&& params)
 {
 	auto result = getDefaultValue();
 
 	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __InputValue::resolve__typename(service::ResolverParams&&)
+rapidjson::Value __InputValue::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("__InputValue"));
 
@@ -442,37 +442,37 @@ __EnumValue::__EnumValue()
 {
 }
 
-rapidjson::Document __EnumValue::resolveName(service::ResolverParams&& params)
+rapidjson::Value __EnumValue::resolveName(service::ResolverParams&& params)
 {
 	auto result = getName();
 
 	return service::ModifiedResult<std::string>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document __EnumValue::resolveDescription(service::ResolverParams&& params)
+rapidjson::Value __EnumValue::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription();
 
 	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __EnumValue::resolveIsDeprecated(service::ResolverParams&& params)
+rapidjson::Value __EnumValue::resolveIsDeprecated(service::ResolverParams&& params)
 {
 	auto result = getIsDeprecated();
 
 	return service::ModifiedResult<bool>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document __EnumValue::resolveDeprecationReason(service::ResolverParams&& params)
+rapidjson::Value __EnumValue::resolveDeprecationReason(service::ResolverParams&& params)
 {
 	auto result = getDeprecationReason();
 
 	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __EnumValue::resolve__typename(service::ResolverParams&&)
+rapidjson::Value __EnumValue::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("__EnumValue"));
 
@@ -492,37 +492,37 @@ __Directive::__Directive()
 {
 }
 
-rapidjson::Document __Directive::resolveName(service::ResolverParams&& params)
+rapidjson::Value __Directive::resolveName(service::ResolverParams&& params)
 {
 	auto result = getName();
 
 	return service::ModifiedResult<std::string>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Directive::resolveDescription(service::ResolverParams&& params)
+rapidjson::Value __Directive::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription();
 
 	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Directive::resolveLocations(service::ResolverParams&& params)
+rapidjson::Value __Directive::resolveLocations(service::ResolverParams&& params)
 {
 	auto result = getLocations();
 
 	return service::ModifiedResult<__DirectiveLocation>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Directive::resolveArgs(service::ResolverParams&& params)
+rapidjson::Value __Directive::resolveArgs(service::ResolverParams&& params)
 {
 	auto result = getArgs();
 
 	return service::ModifiedResult<__InputValue>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-rapidjson::Document __Directive::resolve__typename(service::ResolverParams&&)
+rapidjson::Value __Directive::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("__Directive"));
 

--- a/samples/IntrospectionSchema.h
+++ b/samples/IntrospectionSchema.h
@@ -72,13 +72,13 @@ public:
 	virtual std::vector<std::shared_ptr<__Directive>> getDirectives() const = 0;
 
 private:
-	rapidjson::Document resolveTypes(service::ResolverParams&& params);
-	rapidjson::Document resolveQueryType(service::ResolverParams&& params);
-	rapidjson::Document resolveMutationType(service::ResolverParams&& params);
-	rapidjson::Document resolveSubscriptionType(service::ResolverParams&& params);
-	rapidjson::Document resolveDirectives(service::ResolverParams&& params);
+	rapidjson::Value resolveTypes(service::ResolverParams&& params);
+	rapidjson::Value resolveQueryType(service::ResolverParams&& params);
+	rapidjson::Value resolveMutationType(service::ResolverParams&& params);
+	rapidjson::Value resolveSubscriptionType(service::ResolverParams&& params);
+	rapidjson::Value resolveDirectives(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class __Type
@@ -99,17 +99,17 @@ public:
 	virtual std::shared_ptr<__Type> getOfType() const = 0;
 
 private:
-	rapidjson::Document resolveKind(service::ResolverParams&& params);
-	rapidjson::Document resolveName(service::ResolverParams&& params);
-	rapidjson::Document resolveDescription(service::ResolverParams&& params);
-	rapidjson::Document resolveFields(service::ResolverParams&& params);
-	rapidjson::Document resolveInterfaces(service::ResolverParams&& params);
-	rapidjson::Document resolvePossibleTypes(service::ResolverParams&& params);
-	rapidjson::Document resolveEnumValues(service::ResolverParams&& params);
-	rapidjson::Document resolveInputFields(service::ResolverParams&& params);
-	rapidjson::Document resolveOfType(service::ResolverParams&& params);
+	rapidjson::Value resolveKind(service::ResolverParams&& params);
+	rapidjson::Value resolveName(service::ResolverParams&& params);
+	rapidjson::Value resolveDescription(service::ResolverParams&& params);
+	rapidjson::Value resolveFields(service::ResolverParams&& params);
+	rapidjson::Value resolveInterfaces(service::ResolverParams&& params);
+	rapidjson::Value resolvePossibleTypes(service::ResolverParams&& params);
+	rapidjson::Value resolveEnumValues(service::ResolverParams&& params);
+	rapidjson::Value resolveInputFields(service::ResolverParams&& params);
+	rapidjson::Value resolveOfType(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class __Field
@@ -127,14 +127,14 @@ public:
 	virtual std::unique_ptr<std::string> getDeprecationReason() const = 0;
 
 private:
-	rapidjson::Document resolveName(service::ResolverParams&& params);
-	rapidjson::Document resolveDescription(service::ResolverParams&& params);
-	rapidjson::Document resolveArgs(service::ResolverParams&& params);
-	rapidjson::Document resolveType(service::ResolverParams&& params);
-	rapidjson::Document resolveIsDeprecated(service::ResolverParams&& params);
-	rapidjson::Document resolveDeprecationReason(service::ResolverParams&& params);
+	rapidjson::Value resolveName(service::ResolverParams&& params);
+	rapidjson::Value resolveDescription(service::ResolverParams&& params);
+	rapidjson::Value resolveArgs(service::ResolverParams&& params);
+	rapidjson::Value resolveType(service::ResolverParams&& params);
+	rapidjson::Value resolveIsDeprecated(service::ResolverParams&& params);
+	rapidjson::Value resolveDeprecationReason(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class __InputValue
@@ -150,12 +150,12 @@ public:
 	virtual std::unique_ptr<std::string> getDefaultValue() const = 0;
 
 private:
-	rapidjson::Document resolveName(service::ResolverParams&& params);
-	rapidjson::Document resolveDescription(service::ResolverParams&& params);
-	rapidjson::Document resolveType(service::ResolverParams&& params);
-	rapidjson::Document resolveDefaultValue(service::ResolverParams&& params);
+	rapidjson::Value resolveName(service::ResolverParams&& params);
+	rapidjson::Value resolveDescription(service::ResolverParams&& params);
+	rapidjson::Value resolveType(service::ResolverParams&& params);
+	rapidjson::Value resolveDefaultValue(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class __EnumValue
@@ -171,12 +171,12 @@ public:
 	virtual std::unique_ptr<std::string> getDeprecationReason() const = 0;
 
 private:
-	rapidjson::Document resolveName(service::ResolverParams&& params);
-	rapidjson::Document resolveDescription(service::ResolverParams&& params);
-	rapidjson::Document resolveIsDeprecated(service::ResolverParams&& params);
-	rapidjson::Document resolveDeprecationReason(service::ResolverParams&& params);
+	rapidjson::Value resolveName(service::ResolverParams&& params);
+	rapidjson::Value resolveDescription(service::ResolverParams&& params);
+	rapidjson::Value resolveIsDeprecated(service::ResolverParams&& params);
+	rapidjson::Value resolveDeprecationReason(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class __Directive
@@ -192,12 +192,12 @@ public:
 	virtual std::vector<std::shared_ptr<__InputValue>> getArgs() const = 0;
 
 private:
-	rapidjson::Document resolveName(service::ResolverParams&& params);
-	rapidjson::Document resolveDescription(service::ResolverParams&& params);
-	rapidjson::Document resolveLocations(service::ResolverParams&& params);
-	rapidjson::Document resolveArgs(service::ResolverParams&& params);
+	rapidjson::Value resolveName(service::ResolverParams&& params);
+	rapidjson::Value resolveDescription(service::ResolverParams&& params);
+	rapidjson::Value resolveLocations(service::ResolverParams&& params);
+	rapidjson::Value resolveArgs(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 } /* namespace object */

--- a/samples/TodaySchema.cpp
+++ b/samples/TodaySchema.cpp
@@ -15,7 +15,7 @@ namespace graphql {
 namespace service {
 
 template <>
-today::TaskState ModifiedArgument<today::TaskState>::convert(const rapidjson::Value& value)
+today::TaskState ModifiedArgument<today::TaskState>::convert(rapidjson::Document::AllocatorType&, const rapidjson::Value& value)
 {
 	static const std::unordered_map<std::string, today::TaskState> s_names = {
 		{ "New", today::TaskState::New },
@@ -35,7 +35,7 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const rapidjson::Va
 }
 
 template <>
-rapidjson::Document service::ModifiedResult<today::TaskState>::convert(today::TaskState&& value, ResolverParams&&)
+rapidjson::Value service::ModifiedResult<today::TaskState>::convert(today::TaskState&& value, ResolverParams&&)
 {
 	static const std::string s_names[] = {
 		"New",
@@ -44,7 +44,7 @@ rapidjson::Document service::ModifiedResult<today::TaskState>::convert(today::Ta
 		"Unassigned"
 	};
 
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef(s_names[static_cast<size_t>(value)].c_str()));
 
@@ -52,28 +52,28 @@ rapidjson::Document service::ModifiedResult<today::TaskState>::convert(today::Ta
 }
 
 template <>
-today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(const rapidjson::Value& value)
+today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(rapidjson::Document::AllocatorType& allocator, const rapidjson::Value& value)
 {
 	const auto defaultValue = []()
 	{
 		rapidjson::Document values(rapidjson::Type::kObjectType);
-		auto& allocator = values.GetAllocator();
+		auto& valuesAllocator = values.GetAllocator();
 		rapidjson::Document parsed;
 		rapidjson::Value entry;
 
 		parsed.Parse(R"js(true)js");
-		entry.CopyFrom(parsed, allocator);
-		values.AddMember(rapidjson::StringRef("isComplete"), entry, allocator);
+		entry.CopyFrom(parsed, valuesAllocator);
+		values.AddMember(rapidjson::StringRef("isComplete"), entry, valuesAllocator);
 
 		return values;
 	}();
 
-	auto valueId = service::ModifiedArgument<std::vector<uint8_t>>::require("id", value.GetObject());
-	auto pairIsComplete = service::ModifiedArgument<bool>::find<service::TypeModifier::Nullable>("isComplete", value.GetObject());
+	auto valueId = service::ModifiedArgument<std::vector<uint8_t>>::require(allocator, "id", value.GetObject());
+	auto pairIsComplete = service::ModifiedArgument<bool>::find<service::TypeModifier::Nullable>(allocator, "isComplete", value.GetObject());
 	auto valueIsComplete = (pairIsComplete.second
 		? std::move(pairIsComplete.first)
-		: service::ModifiedArgument<bool>::require<service::TypeModifier::Nullable>("isComplete", defaultValue.GetObject()));
-	auto valueClientMutationId = service::ModifiedArgument<std::string>::require<service::TypeModifier::Nullable>("clientMutationId", value.GetObject());
+		: service::ModifiedArgument<bool>::require<service::TypeModifier::Nullable>(allocator, "isComplete", defaultValue.GetObject()));
+	auto valueClientMutationId = service::ModifiedArgument<std::string>::require<service::TypeModifier::Nullable>(allocator, "clientMutationId", value.GetObject());
 
 	return {
 		std::move(valueId),
@@ -108,88 +108,88 @@ Query::Query()
 	today::AddTypesToSchema(_schema);
 }
 
-rapidjson::Document Query::resolveNode(service::ResolverParams&& params)
+rapidjson::Value Query::resolveNode(service::ResolverParams&& params)
 {
-	auto argId = service::ModifiedArgument<std::vector<uint8_t>>::require("id", params.arguments);
+	auto argId = service::ModifiedArgument<std::vector<uint8_t>>::require(params.allocator, "id", params.arguments);
 	auto result = getNode(std::move(argId));
 
 	return service::ModifiedResult<service::Object>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document Query::resolveAppointments(service::ResolverParams&& params)
+rapidjson::Value Query::resolveAppointments(service::ResolverParams&& params)
 {
-	auto argFirst = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>("first", params.arguments);
-	auto argAfter = service::ModifiedArgument<rapidjson::Document>::require<service::TypeModifier::Nullable>("after", params.arguments);
-	auto argLast = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>("last", params.arguments);
-	auto argBefore = service::ModifiedArgument<rapidjson::Document>::require<service::TypeModifier::Nullable>("before", params.arguments);
+	auto argFirst = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>(params.allocator, "first", params.arguments);
+	auto argAfter = service::ModifiedArgument<rapidjson::Value>::require<service::TypeModifier::Nullable>(params.allocator, "after", params.arguments);
+	auto argLast = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>(params.allocator, "last", params.arguments);
+	auto argBefore = service::ModifiedArgument<rapidjson::Value>::require<service::TypeModifier::Nullable>(params.allocator, "before", params.arguments);
 	auto result = getAppointments(std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 
 	return service::ModifiedResult<AppointmentConnection>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document Query::resolveTasks(service::ResolverParams&& params)
+rapidjson::Value Query::resolveTasks(service::ResolverParams&& params)
 {
-	auto argFirst = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>("first", params.arguments);
-	auto argAfter = service::ModifiedArgument<rapidjson::Document>::require<service::TypeModifier::Nullable>("after", params.arguments);
-	auto argLast = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>("last", params.arguments);
-	auto argBefore = service::ModifiedArgument<rapidjson::Document>::require<service::TypeModifier::Nullable>("before", params.arguments);
+	auto argFirst = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>(params.allocator, "first", params.arguments);
+	auto argAfter = service::ModifiedArgument<rapidjson::Value>::require<service::TypeModifier::Nullable>(params.allocator, "after", params.arguments);
+	auto argLast = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>(params.allocator, "last", params.arguments);
+	auto argBefore = service::ModifiedArgument<rapidjson::Value>::require<service::TypeModifier::Nullable>(params.allocator, "before", params.arguments);
 	auto result = getTasks(std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 
 	return service::ModifiedResult<TaskConnection>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document Query::resolveUnreadCounts(service::ResolverParams&& params)
+rapidjson::Value Query::resolveUnreadCounts(service::ResolverParams&& params)
 {
-	auto argFirst = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>("first", params.arguments);
-	auto argAfter = service::ModifiedArgument<rapidjson::Document>::require<service::TypeModifier::Nullable>("after", params.arguments);
-	auto argLast = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>("last", params.arguments);
-	auto argBefore = service::ModifiedArgument<rapidjson::Document>::require<service::TypeModifier::Nullable>("before", params.arguments);
+	auto argFirst = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>(params.allocator, "first", params.arguments);
+	auto argAfter = service::ModifiedArgument<rapidjson::Value>::require<service::TypeModifier::Nullable>(params.allocator, "after", params.arguments);
+	auto argLast = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>(params.allocator, "last", params.arguments);
+	auto argBefore = service::ModifiedArgument<rapidjson::Value>::require<service::TypeModifier::Nullable>(params.allocator, "before", params.arguments);
 	auto result = getUnreadCounts(std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 
 	return service::ModifiedResult<FolderConnection>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document Query::resolveAppointmentsById(service::ResolverParams&& params)
+rapidjson::Value Query::resolveAppointmentsById(service::ResolverParams&& params)
 {
-	auto argIds = service::ModifiedArgument<std::vector<uint8_t>>::require<service::TypeModifier::List>("ids", params.arguments);
+	auto argIds = service::ModifiedArgument<std::vector<uint8_t>>::require<service::TypeModifier::List>(params.allocator, "ids", params.arguments);
 	auto result = getAppointmentsById(std::move(argIds));
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document Query::resolveTasksById(service::ResolverParams&& params)
+rapidjson::Value Query::resolveTasksById(service::ResolverParams&& params)
 {
-	auto argIds = service::ModifiedArgument<std::vector<uint8_t>>::require<service::TypeModifier::List>("ids", params.arguments);
+	auto argIds = service::ModifiedArgument<std::vector<uint8_t>>::require<service::TypeModifier::List>(params.allocator, "ids", params.arguments);
 	auto result = getTasksById(std::move(argIds));
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document Query::resolveUnreadCountsById(service::ResolverParams&& params)
+rapidjson::Value Query::resolveUnreadCountsById(service::ResolverParams&& params)
 {
-	auto argIds = service::ModifiedArgument<std::vector<uint8_t>>::require<service::TypeModifier::List>("ids", params.arguments);
+	auto argIds = service::ModifiedArgument<std::vector<uint8_t>>::require<service::TypeModifier::List>(params.allocator, "ids", params.arguments);
 	auto result = getUnreadCountsById(std::move(argIds));
 
 	return service::ModifiedResult<Folder>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document Query::resolve__typename(service::ResolverParams&&)
+rapidjson::Value Query::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("Query"));
 
 	return result;
 }
 
-rapidjson::Document Query::resolve__schema(service::ResolverParams&& params)
+rapidjson::Value Query::resolve__schema(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<service::Object>::convert(std::static_pointer_cast<service::Object>(_schema), std::move(params));
 }
 
-rapidjson::Document Query::resolve__type(service::ResolverParams&& params)
+rapidjson::Value Query::resolve__type(service::ResolverParams&& params)
 {
-	auto argName = service::ModifiedArgument<std::string>::require("name", params.arguments);
+	auto argName = service::ModifiedArgument<std::string>::require(params.allocator, "name", params.arguments);
 	auto result = service::ModifiedResult<introspection::object::__Type>::convert<service::TypeModifier::Nullable>(_schema->LookupType(argName), std::move(params));
 
 	return result;
@@ -206,23 +206,23 @@ PageInfo::PageInfo()
 {
 }
 
-rapidjson::Document PageInfo::resolveHasNextPage(service::ResolverParams&& params)
+rapidjson::Value PageInfo::resolveHasNextPage(service::ResolverParams&& params)
 {
 	auto result = getHasNextPage();
 
 	return service::ModifiedResult<bool>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
+rapidjson::Value PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
 {
 	auto result = getHasPreviousPage();
 
 	return service::ModifiedResult<bool>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document PageInfo::resolve__typename(service::ResolverParams&&)
+rapidjson::Value PageInfo::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("PageInfo"));
 
@@ -240,23 +240,23 @@ AppointmentEdge::AppointmentEdge()
 {
 }
 
-rapidjson::Document AppointmentEdge::resolveNode(service::ResolverParams&& params)
+rapidjson::Value AppointmentEdge::resolveNode(service::ResolverParams&& params)
 {
 	auto result = getNode();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document AppointmentEdge::resolveCursor(service::ResolverParams&& params)
+rapidjson::Value AppointmentEdge::resolveCursor(service::ResolverParams&& params)
 {
-	auto result = getCursor();
+	auto result = getCursor(params.allocator);
 
-	return service::ModifiedResult<rapidjson::Document>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<rapidjson::Value>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document AppointmentEdge::resolve__typename(service::ResolverParams&&)
+rapidjson::Value AppointmentEdge::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("AppointmentEdge"));
 
@@ -274,23 +274,23 @@ AppointmentConnection::AppointmentConnection()
 {
 }
 
-rapidjson::Document AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
+rapidjson::Value AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	auto result = getPageInfo();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document AppointmentConnection::resolveEdges(service::ResolverParams&& params)
+rapidjson::Value AppointmentConnection::resolveEdges(service::ResolverParams&& params)
 {
 	auto result = getEdges();
 
 	return service::ModifiedResult<AppointmentEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document AppointmentConnection::resolve__typename(service::ResolverParams&&)
+rapidjson::Value AppointmentConnection::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("AppointmentConnection"));
 
@@ -308,23 +308,23 @@ TaskEdge::TaskEdge()
 {
 }
 
-rapidjson::Document TaskEdge::resolveNode(service::ResolverParams&& params)
+rapidjson::Value TaskEdge::resolveNode(service::ResolverParams&& params)
 {
 	auto result = getNode();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document TaskEdge::resolveCursor(service::ResolverParams&& params)
+rapidjson::Value TaskEdge::resolveCursor(service::ResolverParams&& params)
 {
-	auto result = getCursor();
+	auto result = getCursor(params.allocator);
 
-	return service::ModifiedResult<rapidjson::Document>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<rapidjson::Value>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document TaskEdge::resolve__typename(service::ResolverParams&&)
+rapidjson::Value TaskEdge::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("TaskEdge"));
 
@@ -342,23 +342,23 @@ TaskConnection::TaskConnection()
 {
 }
 
-rapidjson::Document TaskConnection::resolvePageInfo(service::ResolverParams&& params)
+rapidjson::Value TaskConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	auto result = getPageInfo();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document TaskConnection::resolveEdges(service::ResolverParams&& params)
+rapidjson::Value TaskConnection::resolveEdges(service::ResolverParams&& params)
 {
 	auto result = getEdges();
 
 	return service::ModifiedResult<TaskEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document TaskConnection::resolve__typename(service::ResolverParams&&)
+rapidjson::Value TaskConnection::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("TaskConnection"));
 
@@ -376,23 +376,23 @@ FolderEdge::FolderEdge()
 {
 }
 
-rapidjson::Document FolderEdge::resolveNode(service::ResolverParams&& params)
+rapidjson::Value FolderEdge::resolveNode(service::ResolverParams&& params)
 {
 	auto result = getNode();
 
 	return service::ModifiedResult<Folder>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document FolderEdge::resolveCursor(service::ResolverParams&& params)
+rapidjson::Value FolderEdge::resolveCursor(service::ResolverParams&& params)
 {
-	auto result = getCursor();
+	auto result = getCursor(params.allocator);
 
-	return service::ModifiedResult<rapidjson::Document>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<rapidjson::Value>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document FolderEdge::resolve__typename(service::ResolverParams&&)
+rapidjson::Value FolderEdge::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("FolderEdge"));
 
@@ -410,23 +410,23 @@ FolderConnection::FolderConnection()
 {
 }
 
-rapidjson::Document FolderConnection::resolvePageInfo(service::ResolverParams&& params)
+rapidjson::Value FolderConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	auto result = getPageInfo();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document FolderConnection::resolveEdges(service::ResolverParams&& params)
+rapidjson::Value FolderConnection::resolveEdges(service::ResolverParams&& params)
 {
 	auto result = getEdges();
 
 	return service::ModifiedResult<FolderEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document FolderConnection::resolve__typename(service::ResolverParams&&)
+rapidjson::Value FolderConnection::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("FolderConnection"));
 
@@ -444,23 +444,23 @@ CompleteTaskPayload::CompleteTaskPayload()
 {
 }
 
-rapidjson::Document CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
+rapidjson::Value CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
 {
 	auto result = getTask();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
+rapidjson::Value CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
 {
 	auto result = getClientMutationId();
 
 	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document CompleteTaskPayload::resolve__typename(service::ResolverParams&&)
+rapidjson::Value CompleteTaskPayload::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("CompleteTaskPayload"));
 
@@ -477,17 +477,17 @@ Mutation::Mutation()
 {
 }
 
-rapidjson::Document Mutation::resolveCompleteTask(service::ResolverParams&& params)
+rapidjson::Value Mutation::resolveCompleteTask(service::ResolverParams&& params)
 {
-	auto argInput = service::ModifiedArgument<CompleteTaskInput>::require("input", params.arguments);
+	auto argInput = service::ModifiedArgument<CompleteTaskInput>::require(params.allocator, "input", params.arguments);
 	auto result = getCompleteTask(std::move(argInput));
 
 	return service::ModifiedResult<CompleteTaskPayload>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document Mutation::resolve__typename(service::ResolverParams&&)
+rapidjson::Value Mutation::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("Mutation"));
 
@@ -504,16 +504,16 @@ Subscription::Subscription()
 {
 }
 
-rapidjson::Document Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
+rapidjson::Value Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
 {
 	auto result = getNextAppointmentChange();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document Subscription::resolve__typename(service::ResolverParams&&)
+rapidjson::Value Subscription::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("Subscription"));
 
@@ -534,37 +534,37 @@ Appointment::Appointment()
 {
 }
 
-rapidjson::Document Appointment::resolveId(service::ResolverParams&& params)
+rapidjson::Value Appointment::resolveId(service::ResolverParams&& params)
 {
 	auto result = getId();
 
 	return service::ModifiedResult<std::vector<uint8_t>>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document Appointment::resolveWhen(service::ResolverParams&& params)
+rapidjson::Value Appointment::resolveWhen(service::ResolverParams&& params)
 {
-	auto result = getWhen();
+	auto result = getWhen(params.allocator);
 
-	return service::ModifiedResult<rapidjson::Document>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<rapidjson::Value>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document Appointment::resolveSubject(service::ResolverParams&& params)
+rapidjson::Value Appointment::resolveSubject(service::ResolverParams&& params)
 {
 	auto result = getSubject();
 
 	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document Appointment::resolveIsNow(service::ResolverParams&& params)
+rapidjson::Value Appointment::resolveIsNow(service::ResolverParams&& params)
 {
 	auto result = getIsNow();
 
 	return service::ModifiedResult<bool>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document Appointment::resolve__typename(service::ResolverParams&&)
+rapidjson::Value Appointment::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("Appointment"));
 
@@ -584,30 +584,30 @@ Task::Task()
 {
 }
 
-rapidjson::Document Task::resolveId(service::ResolverParams&& params)
+rapidjson::Value Task::resolveId(service::ResolverParams&& params)
 {
 	auto result = getId();
 
 	return service::ModifiedResult<std::vector<uint8_t>>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document Task::resolveTitle(service::ResolverParams&& params)
+rapidjson::Value Task::resolveTitle(service::ResolverParams&& params)
 {
 	auto result = getTitle();
 
 	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document Task::resolveIsComplete(service::ResolverParams&& params)
+rapidjson::Value Task::resolveIsComplete(service::ResolverParams&& params)
 {
 	auto result = getIsComplete();
 
 	return service::ModifiedResult<bool>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document Task::resolve__typename(service::ResolverParams&&)
+rapidjson::Value Task::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("Task"));
 
@@ -627,30 +627,30 @@ Folder::Folder()
 {
 }
 
-rapidjson::Document Folder::resolveId(service::ResolverParams&& params)
+rapidjson::Value Folder::resolveId(service::ResolverParams&& params)
 {
 	auto result = getId();
 
 	return service::ModifiedResult<std::vector<uint8_t>>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document Folder::resolveName(service::ResolverParams&& params)
+rapidjson::Value Folder::resolveName(service::ResolverParams&& params)
 {
 	auto result = getName();
 
 	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-rapidjson::Document Folder::resolveUnreadCount(service::ResolverParams&& params)
+rapidjson::Value Folder::resolveUnreadCount(service::ResolverParams&& params)
 {
 	auto result = getUnreadCount();
 
 	return service::ModifiedResult<int>::convert(std::move(result), std::move(params));
 }
 
-rapidjson::Document Folder::resolve__typename(service::ResolverParams&&)
+rapidjson::Value Folder::resolve__typename(service::ResolverParams&&)
 {
-	rapidjson::Document result(rapidjson::Type::kStringType);
+	rapidjson::Value result(rapidjson::Type::kStringType);
 
 	result.SetString(rapidjson::StringRef("Folder"));
 

--- a/samples/TodaySchema.h
+++ b/samples/TodaySchema.h
@@ -64,25 +64,25 @@ protected:
 
 public:
 	virtual std::shared_ptr<service::Object> getNode(std::vector<uint8_t>&& id) const = 0;
-	virtual std::shared_ptr<AppointmentConnection> getAppointments(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Document>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Document>&& before) const = 0;
-	virtual std::shared_ptr<TaskConnection> getTasks(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Document>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Document>&& before) const = 0;
-	virtual std::shared_ptr<FolderConnection> getUnreadCounts(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Document>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Document>&& before) const = 0;
+	virtual std::shared_ptr<AppointmentConnection> getAppointments(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const = 0;
+	virtual std::shared_ptr<TaskConnection> getTasks(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const = 0;
+	virtual std::shared_ptr<FolderConnection> getUnreadCounts(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const = 0;
 	virtual std::vector<std::shared_ptr<Appointment>> getAppointmentsById(std::vector<std::vector<uint8_t>>&& ids) const = 0;
 	virtual std::vector<std::shared_ptr<Task>> getTasksById(std::vector<std::vector<uint8_t>>&& ids) const = 0;
 	virtual std::vector<std::shared_ptr<Folder>> getUnreadCountsById(std::vector<std::vector<uint8_t>>&& ids) const = 0;
 
 private:
-	rapidjson::Document resolveNode(service::ResolverParams&& params);
-	rapidjson::Document resolveAppointments(service::ResolverParams&& params);
-	rapidjson::Document resolveTasks(service::ResolverParams&& params);
-	rapidjson::Document resolveUnreadCounts(service::ResolverParams&& params);
-	rapidjson::Document resolveAppointmentsById(service::ResolverParams&& params);
-	rapidjson::Document resolveTasksById(service::ResolverParams&& params);
-	rapidjson::Document resolveUnreadCountsById(service::ResolverParams&& params);
+	rapidjson::Value resolveNode(service::ResolverParams&& params);
+	rapidjson::Value resolveAppointments(service::ResolverParams&& params);
+	rapidjson::Value resolveTasks(service::ResolverParams&& params);
+	rapidjson::Value resolveUnreadCounts(service::ResolverParams&& params);
+	rapidjson::Value resolveAppointmentsById(service::ResolverParams&& params);
+	rapidjson::Value resolveTasksById(service::ResolverParams&& params);
+	rapidjson::Value resolveUnreadCountsById(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
-	rapidjson::Document resolve__schema(service::ResolverParams&& params);
-	rapidjson::Document resolve__type(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__schema(service::ResolverParams&& params);
+	rapidjson::Value resolve__type(service::ResolverParams&& params);
 
 	std::shared_ptr<introspection::Schema> _schema;
 };
@@ -98,10 +98,10 @@ public:
 	virtual bool getHasPreviousPage() const = 0;
 
 private:
-	rapidjson::Document resolveHasNextPage(service::ResolverParams&& params);
-	rapidjson::Document resolveHasPreviousPage(service::ResolverParams&& params);
+	rapidjson::Value resolveHasNextPage(service::ResolverParams&& params);
+	rapidjson::Value resolveHasPreviousPage(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class AppointmentEdge
@@ -112,13 +112,13 @@ protected:
 
 public:
 	virtual std::shared_ptr<Appointment> getNode() const = 0;
-	virtual rapidjson::Document getCursor() const = 0;
+	virtual rapidjson::Value getCursor(rapidjson::Document::AllocatorType& allocator) const = 0;
 
 private:
-	rapidjson::Document resolveNode(service::ResolverParams&& params);
-	rapidjson::Document resolveCursor(service::ResolverParams&& params);
+	rapidjson::Value resolveNode(service::ResolverParams&& params);
+	rapidjson::Value resolveCursor(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class AppointmentConnection
@@ -132,10 +132,10 @@ public:
 	virtual std::unique_ptr<std::vector<std::shared_ptr<AppointmentEdge>>> getEdges() const = 0;
 
 private:
-	rapidjson::Document resolvePageInfo(service::ResolverParams&& params);
-	rapidjson::Document resolveEdges(service::ResolverParams&& params);
+	rapidjson::Value resolvePageInfo(service::ResolverParams&& params);
+	rapidjson::Value resolveEdges(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class TaskEdge
@@ -146,13 +146,13 @@ protected:
 
 public:
 	virtual std::shared_ptr<Task> getNode() const = 0;
-	virtual rapidjson::Document getCursor() const = 0;
+	virtual rapidjson::Value getCursor(rapidjson::Document::AllocatorType& allocator) const = 0;
 
 private:
-	rapidjson::Document resolveNode(service::ResolverParams&& params);
-	rapidjson::Document resolveCursor(service::ResolverParams&& params);
+	rapidjson::Value resolveNode(service::ResolverParams&& params);
+	rapidjson::Value resolveCursor(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class TaskConnection
@@ -166,10 +166,10 @@ public:
 	virtual std::unique_ptr<std::vector<std::shared_ptr<TaskEdge>>> getEdges() const = 0;
 
 private:
-	rapidjson::Document resolvePageInfo(service::ResolverParams&& params);
-	rapidjson::Document resolveEdges(service::ResolverParams&& params);
+	rapidjson::Value resolvePageInfo(service::ResolverParams&& params);
+	rapidjson::Value resolveEdges(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class FolderEdge
@@ -180,13 +180,13 @@ protected:
 
 public:
 	virtual std::shared_ptr<Folder> getNode() const = 0;
-	virtual rapidjson::Document getCursor() const = 0;
+	virtual rapidjson::Value getCursor(rapidjson::Document::AllocatorType& allocator) const = 0;
 
 private:
-	rapidjson::Document resolveNode(service::ResolverParams&& params);
-	rapidjson::Document resolveCursor(service::ResolverParams&& params);
+	rapidjson::Value resolveNode(service::ResolverParams&& params);
+	rapidjson::Value resolveCursor(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class FolderConnection
@@ -200,10 +200,10 @@ public:
 	virtual std::unique_ptr<std::vector<std::shared_ptr<FolderEdge>>> getEdges() const = 0;
 
 private:
-	rapidjson::Document resolvePageInfo(service::ResolverParams&& params);
-	rapidjson::Document resolveEdges(service::ResolverParams&& params);
+	rapidjson::Value resolvePageInfo(service::ResolverParams&& params);
+	rapidjson::Value resolveEdges(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class CompleteTaskPayload
@@ -217,10 +217,10 @@ public:
 	virtual std::unique_ptr<std::string> getClientMutationId() const = 0;
 
 private:
-	rapidjson::Document resolveTask(service::ResolverParams&& params);
-	rapidjson::Document resolveClientMutationId(service::ResolverParams&& params);
+	rapidjson::Value resolveTask(service::ResolverParams&& params);
+	rapidjson::Value resolveClientMutationId(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class Mutation
@@ -233,9 +233,9 @@ public:
 	virtual std::shared_ptr<CompleteTaskPayload> getCompleteTask(CompleteTaskInput&& input) const = 0;
 
 private:
-	rapidjson::Document resolveCompleteTask(service::ResolverParams&& params);
+	rapidjson::Value resolveCompleteTask(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class Subscription
@@ -248,9 +248,9 @@ public:
 	virtual std::shared_ptr<Appointment> getNextAppointmentChange() const = 0;
 
 private:
-	rapidjson::Document resolveNextAppointmentChange(service::ResolverParams&& params);
+	rapidjson::Value resolveNextAppointmentChange(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class Appointment
@@ -261,17 +261,17 @@ protected:
 	Appointment();
 
 public:
-	virtual std::unique_ptr<rapidjson::Document> getWhen() const = 0;
+	virtual std::unique_ptr<rapidjson::Value> getWhen(rapidjson::Document::AllocatorType& allocator) const = 0;
 	virtual std::unique_ptr<std::string> getSubject() const = 0;
 	virtual bool getIsNow() const = 0;
 
 private:
-	rapidjson::Document resolveId(service::ResolverParams&& params);
-	rapidjson::Document resolveWhen(service::ResolverParams&& params);
-	rapidjson::Document resolveSubject(service::ResolverParams&& params);
-	rapidjson::Document resolveIsNow(service::ResolverParams&& params);
+	rapidjson::Value resolveId(service::ResolverParams&& params);
+	rapidjson::Value resolveWhen(service::ResolverParams&& params);
+	rapidjson::Value resolveSubject(service::ResolverParams&& params);
+	rapidjson::Value resolveIsNow(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class Task
@@ -286,11 +286,11 @@ public:
 	virtual bool getIsComplete() const = 0;
 
 private:
-	rapidjson::Document resolveId(service::ResolverParams&& params);
-	rapidjson::Document resolveTitle(service::ResolverParams&& params);
-	rapidjson::Document resolveIsComplete(service::ResolverParams&& params);
+	rapidjson::Value resolveId(service::ResolverParams&& params);
+	rapidjson::Value resolveTitle(service::ResolverParams&& params);
+	rapidjson::Value resolveIsComplete(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 class Folder
@@ -305,11 +305,11 @@ public:
 	virtual int getUnreadCount() const = 0;
 
 private:
-	rapidjson::Document resolveId(service::ResolverParams&& params);
-	rapidjson::Document resolveName(service::ResolverParams&& params);
-	rapidjson::Document resolveUnreadCount(service::ResolverParams&& params);
+	rapidjson::Value resolveId(service::ResolverParams&& params);
+	rapidjson::Value resolveName(service::ResolverParams&& params);
+	rapidjson::Value resolveUnreadCount(service::ResolverParams&& params);
 
-	rapidjson::Document resolve__typename(service::ResolverParams&& params);
+	rapidjson::Value resolve__typename(service::ResolverParams&& params);
 };
 
 } /* namespace object */


### PR DESCRIPTION
RapidJSON use a separate memory pool for each document, and if you want the lifetime of the values in the document to match you need to allocate them with the document's allocator. Since I was using separate documents for the resolvers, that meant every value had to be deep-copied into the final results. This branch makes it so the resolvers pass the allocator from the original document down and perform all of the allocations there and then insert them into the document without an additional call to `rapidjson::Value::CopyFrom`.