### PR TITLE
CMake: fix TodaySchema sample install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,14 @@ if(BUILD_TESTS OR UPDATE_SAMPLES)
     COMMENT "Generating mock TodaySchema files"
   )
 
+  # force the generation of samples on the default build target
+  add_custom_target(update_samples ALL
+    DEPENDS ${CMAKE_BINARY_DIR}/TodaySchema.cpp
+  )
+
   if(BUILD_TESTS)
     add_library(todaygraphql
-      TodaySchema.cpp
+       ${CMAKE_BINARY_DIR}/TodaySchema.cpp
       Today.cpp)
     target_link_libraries(todaygraphql
       graphqlservice)


### PR DESCRIPTION
When UPDATE_SAMPLES=ON and BUILD_TESTS=OFF,
the install target produced the following error:

    -- Install configuration: ""
    -- Installing: .../samples/IntrospectionSchema.h
    -- Installing: .../samples/IntrospectionSchema.cpp
    CMake Error at cmake_install.cmake:49 (file):
      file INSTALL cannot find
      ".../TodaySchema.h".

The reason was that by default `add_custom_command()`
is not added to the default build target.
`add_custom_target(<tgt> ALL ...)` on the other hand has this capability,
so use that.