### PR TITLE
Use std::future<> to allow concurrency and batching in queries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,11 +54,16 @@ if(BUILD_TESTS OR UPDATE_SAMPLES)
   )
 
   if(BUILD_TESTS)
+    if(UNIX)
+      find_package(Threads CONFIG REQUIRED)
+    endif()
+
     add_library(todaygraphql
        ${CMAKE_BINARY_DIR}/TodaySchema.cpp
       Today.cpp)
     target_link_libraries(todaygraphql
-      graphqlservice)
+      graphqlservice
+      ${CMAKE_THREAD_LIBS_INIT})
     target_include_directories(todaygraphql SYSTEM PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
     target_include_directories(todaygraphql PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
     set_property(TARGET todaygraphql PROPERTY CXX_STANDARD 11)
@@ -67,7 +72,8 @@ if(BUILD_TESTS OR UPDATE_SAMPLES)
       test_today.cpp)
     target_link_libraries(test_today
       graphqlservice
-      todaygraphql)
+      todaygraphql
+      ${CMAKE_THREAD_LIBS_INIT})
     target_include_directories(test_today SYSTEM PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
     target_include_directories(test_today PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
     set_property(TARGET test_today PROPERTY CXX_STANDARD 11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ if(WIN32)
   SET(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 endif()
 
+find_package(Threads MODULE REQUIRED)
+
 find_package(pegtl CONFIG REQUIRED)
 
 add_executable(schemagen GraphQLTree.cpp SchemaGenerator.cpp)
@@ -32,6 +34,7 @@ add_library(graphqlservice
   Introspection.cpp
   IntrospectionSchema.cpp)
 target_link_libraries(graphqlservice PRIVATE taocpp::pegtl)
+target_link_libraries(graphqlservice PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(graphqlservice SYSTEM PUBLIC ${RAPIDJSON_INCLUDE_DIRS})
 target_include_directories(graphqlservice SYSTEM INTERFACE $<INSTALL_INTERFACE:include>)
 target_include_directories(graphqlservice PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
@@ -54,16 +57,11 @@ if(BUILD_TESTS OR UPDATE_SAMPLES)
   )
 
   if(BUILD_TESTS)
-    if(UNIX)
-      find_package(Threads CONFIG REQUIRED)
-    endif()
-
     add_library(todaygraphql
        ${CMAKE_BINARY_DIR}/TodaySchema.cpp
       Today.cpp)
     target_link_libraries(todaygraphql
-      graphqlservice
-      ${CMAKE_THREAD_LIBS_INIT})
+      graphqlservice)
     target_include_directories(todaygraphql SYSTEM PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
     target_include_directories(todaygraphql PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
     set_property(TARGET todaygraphql PROPERTY CXX_STANDARD 11)
@@ -72,13 +70,13 @@ if(BUILD_TESTS OR UPDATE_SAMPLES)
       test_today.cpp)
     target_link_libraries(test_today
       graphqlservice
-      todaygraphql
-      ${CMAKE_THREAD_LIBS_INIT})
+      todaygraphql)
     target_include_directories(test_today SYSTEM PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
     target_include_directories(test_today PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
     set_property(TARGET test_today PROPERTY CXX_STANDARD 11)
 
-    find_package(GTest REQUIRED)
+    enable_testing()
+    find_package(GTest MODULE REQUIRED)
 
     add_executable(tests
       tests.cpp)
@@ -91,7 +89,6 @@ if(BUILD_TESTS OR UPDATE_SAMPLES)
     target_include_directories(tests PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
     set_property(TARGET tests PROPERTY CXX_STANDARD 11)
 
-    enable_testing()
     add_test(NAME TodayServiceCase
       COMMAND tests --gtest_filter=TodayServiceCase.*
       WORKING_DIRECTORY $<TARGET_FILE_DIR:tests>)

--- a/GraphQLService.cpp
+++ b/GraphQLService.cpp
@@ -1039,7 +1039,9 @@ void OperationDefinitionVisitor::visit(const peg::ast_node& operationDefinition)
 			throw schema_exception({ error.str() });
 		}
 
-		_result = std::async(std::launch::deferred, [this, &operationDefinition, operationObject = itr->second]()
+		auto operationObject = itr->second;
+
+		_result = std::async(std::launch::deferred, [this, &operationDefinition, operationObject]()
 		{
 			rapidjson::Document operationVariables(rapidjson::Type::kObjectType);
 

--- a/GraphQLService.cpp
+++ b/GraphQLService.cpp
@@ -387,7 +387,8 @@ std::future<rapidjson::Value> Object::resolve(RequestId requestId, rapidjson::Do
 
 	endSelectionSet(requestId);
 
-	return std::async(std::launch::deferred, [&allocator](std::queue<std::future<rapidjson::Value>>&& promises)
+	return std::async(std::launch::deferred,
+		[&allocator](std::queue<std::future<rapidjson::Value>>&& promises)
 	{
 		rapidjson::Value result(rapidjson::Type::kObjectType);
 
@@ -1041,7 +1042,8 @@ void OperationDefinitionVisitor::visit(const peg::ast_node& operationDefinition)
 
 		auto operationObject = itr->second;
 
-		_result = std::async(std::launch::deferred, [this, &operationDefinition, operationObject]()
+		_result = std::async(std::launch::deferred,
+			[this, &operationDefinition, operationObject]()
 		{
 			rapidjson::Document operationVariables(rapidjson::Type::kObjectType);
 

--- a/GraphQLService.cpp
+++ b/GraphQLService.cpp
@@ -272,71 +272,96 @@ std::vector<uint8_t> ModifiedArgument<std::vector<uint8_t>>::convert(rapidjson::
 }
 
 template <>
-rapidjson::Value ModifiedResult<int>::convert(int&& result, ResolverParams&&)
+std::future<rapidjson::Value> ModifiedResult<int>::convert(std::future<int>&& result, ResolverParams&&)
 {
-	rapidjson::Value value(rapidjson::Type::kNumberType);
-
-	value.SetInt(result);
-
-	return value;
-}
-
-template <>
-rapidjson::Value ModifiedResult<double>::convert(double&& result, ResolverParams&&)
-{
-	rapidjson::Value value(rapidjson::Type::kNumberType);
-
-	value.SetDouble(result);
-
-	return value;
-}
-
-template <>
-rapidjson::Value ModifiedResult<std::string>::convert(std::string&& result, ResolverParams&& params)
-{
-	rapidjson::Value value(rapidjson::Type::kStringType);
-
-	value.SetString(result.c_str(), params.allocator);
-	
-	return value;
-}
-
-template <>
-rapidjson::Value ModifiedResult<bool>::convert(bool&& result, ResolverParams&&)
-{
-	return rapidjson::Value(result ? rapidjson::Type::kTrueType : rapidjson::Type::kFalseType);
-}
-
-template <>
-rapidjson::Value ModifiedResult<rapidjson::Value>::convert(rapidjson::Value&& result, ResolverParams&&)
-{
-	return rapidjson::Value(std::move(result));
-}
-
-template <>
-rapidjson::Value ModifiedResult<std::vector<uint8_t>>::convert(std::vector<uint8_t>&& result, ResolverParams&& params)
-{
-	rapidjson::Value value(rapidjson::Type::kStringType);
-
-	value.SetString(Base64::toBase64(result).c_str(), params.allocator);
-
-	return value;
-}
-
-template <>
-rapidjson::Value ModifiedResult<Object>::convert(std::shared_ptr<Object> result, ResolverParams&& params)
-{
-	if (!result)
+	return std::async(std::launch::deferred,
+		[](std::future<int>&& resultFuture)
 	{
-		return rapidjson::Value(rapidjson::Type::kNullType);
-	}
+		rapidjson::Value value(rapidjson::Type::kNumberType);
 
-	if (!params.selection)
+		value.SetInt(resultFuture.get());
+
+		return value;
+	}, std::move(result));
+}
+
+template <>
+std::future<rapidjson::Value> ModifiedResult<double>::convert(std::future<double>&& result, ResolverParams&&)
+{
+	return std::async(std::launch::deferred,
+		[](std::future<double>&& resultFuture)
 	{
-		return rapidjson::Value(rapidjson::Type::kObjectType);
-	}
+		rapidjson::Value value(rapidjson::Type::kNumberType);
 
-	return result->resolve(params.allocator, *params.selection, params.fragments, params.variables);
+		value.SetDouble(resultFuture.get());
+
+		return value;
+	}, std::move(result));
+}
+
+template <>
+std::future<rapidjson::Value> ModifiedResult<std::string>::convert(std::future<std::string>&& result, ResolverParams&& params)
+{
+	return std::async(std::launch::deferred,
+		[&](std::future<std::string>&& resultFuture, ResolverParams&& paramsFuture)
+	{
+		rapidjson::Value value(rapidjson::Type::kStringType);
+
+		value.SetString(resultFuture.get().c_str(), paramsFuture.allocator);
+
+		return value;
+	}, std::move(result), std::move(params));
+}
+
+template <>
+std::future<rapidjson::Value> ModifiedResult<bool>::convert(std::future<bool>&& result, ResolverParams&&)
+{
+	return std::async(std::launch::deferred,
+		[](std::future<bool>&& resultFuture)
+	{
+		return rapidjson::Value(resultFuture.get()
+			? rapidjson::Type::kTrueType
+			: rapidjson::Type::kFalseType);
+	}, std::move(result));
+}
+
+template <>
+std::future<rapidjson::Value> ModifiedResult<rapidjson::Value>::convert(std::future<rapidjson::Value>&& result, ResolverParams&&)
+{
+	return std::move(result);
+}
+
+template <>
+std::future<rapidjson::Value> ModifiedResult<std::vector<uint8_t>>::convert(std::future<std::vector<uint8_t>>&& result, ResolverParams&& params)
+{
+	return std::async(std::launch::deferred,
+		[](std::future<std::vector<uint8_t>>&& resultFuture, ResolverParams&& paramsFuture)
+	{
+		rapidjson::Value value(rapidjson::Type::kStringType);
+
+		value.SetString(Base64::toBase64(resultFuture.get()).c_str(), paramsFuture.allocator);
+
+		return value;
+	}, std::move(result), std::move(params));
+}
+
+template <>
+std::future<rapidjson::Value> ModifiedResult<Object>::convert(std::future<std::shared_ptr<Object>> result, ResolverParams&& params)
+{
+	return std::async(std::launch::deferred,
+		[](std::future<std::shared_ptr<Object>>&& resultFuture, ResolverParams&& paramsFuture)
+	{
+		auto wrappedResult = resultFuture.get();
+
+		if (!wrappedResult || !paramsFuture.selection)
+		{
+			return rapidjson::Value(!wrappedResult
+				? rapidjson::Type::kNullType
+				: rapidjson::Type::kObjectType);
+		}
+
+		return wrappedResult->resolve(paramsFuture.requestId, paramsFuture.allocator, *paramsFuture.selection, paramsFuture.fragments, paramsFuture.variables).get();
+	}, std::move(result), std::move(params));
 }
 
 Object::Object(TypeNames&& typeNames, ResolverMap&& resolvers)
@@ -345,28 +370,52 @@ Object::Object(TypeNames&& typeNames, ResolverMap&& resolvers)
 {
 }
 
-rapidjson::Value Object::resolve(rapidjson::Document::AllocatorType& allocator, const peg::ast_node& selection, const FragmentMap& fragments, const rapidjson::Value::ConstObject& variables) const
+std::future<rapidjson::Value> Object::resolve(RequestId requestId, rapidjson::Document::AllocatorType& allocator,
+	const peg::ast_node& selection, const FragmentMap& fragments, const rapidjson::Value::ConstObject& variables) const
 {
-	rapidjson::Value result(rapidjson::Type::kObjectType);
+	std::queue<std::future<rapidjson::Value>> selections;
+
+	beginSelectionSet(requestId);
 
 	for (const auto& child : selection.children)
 	{
-		SelectionVisitor visitor(allocator, fragments, variables, _typeNames, _resolvers);
+		SelectionVisitor visitor(requestId, allocator, fragments, variables, _typeNames, _resolvers);
 
 		visitor.visit(*child);
-
-		auto values = visitor.getValues();
-
-		if (values.IsObject())
-		{
-			for (auto& entry : values.GetObject())
-			{
-				result.AddMember(entry.name, entry.value, allocator);
-			}
-		}
+		selections.push(visitor.getValues());
 	}
 
-	return result;
+	endSelectionSet(requestId);
+
+	return std::async(std::launch::deferred, [&allocator](std::queue<std::future<rapidjson::Value>>&& promises)
+	{
+		rapidjson::Value result(rapidjson::Type::kObjectType);
+
+		while (!promises.empty())
+		{
+			auto values = promises.front().get();
+
+			promises.pop();
+
+			if (values.IsObject())
+			{
+				for (auto& entry : values.GetObject())
+				{
+					result.AddMember(entry.name, entry.value, allocator);
+				}
+			}
+		}
+
+		return result;
+	}, std::move(selections));
+}
+
+void Object::beginSelectionSet(RequestId) const
+{
+}
+
+void Object::endSelectionSet(RequestId) const
+{
 }
 
 Request::Request(TypeMap&& operationTypes)
@@ -374,7 +423,7 @@ Request::Request(TypeMap&& operationTypes)
 {
 }
 
-rapidjson::Document Request::resolve(const peg::ast_node& root, const std::string& operationName, const rapidjson::Document::ConstObject& variables) const
+std::future<rapidjson::Document> Request::resolve(RequestId requestId, const peg::ast_node& root, const std::string& operationName, const rapidjson::Document::ConstObject& variables) const
 {
 	FragmentDefinitionVisitor fragmentVisitor;
 
@@ -385,7 +434,7 @@ rapidjson::Document Request::resolve(const peg::ast_node& root, const std::strin
 	});
 
 	auto fragments = fragmentVisitor.getFragments();
-	OperationDefinitionVisitor operationVisitor(_operations, operationName, variables, fragments);
+	OperationDefinitionVisitor operationVisitor(requestId, _operations, operationName, variables, fragments);
 
 	peg::for_each_child<peg::operation_definition>(root,
 		[&operationVisitor](const peg::ast_node& child)
@@ -396,21 +445,38 @@ rapidjson::Document Request::resolve(const peg::ast_node& root, const std::strin
 	return operationVisitor.getValue();
 }
 
-SelectionVisitor::SelectionVisitor(rapidjson::Document::AllocatorType& allocator, const FragmentMap& fragments, const rapidjson::Document::ConstObject& variables, const TypeNames& typeNames, const ResolverMap& resolvers)
-	: _allocator(allocator)
+SelectionVisitor::SelectionVisitor(RequestId requestId, rapidjson::Document::AllocatorType& allocator,
+	const FragmentMap& fragments, const rapidjson::Document::ConstObject& variables, const TypeNames& typeNames, const ResolverMap& resolvers)
+	: _requestId(requestId)
+	, _allocator(allocator)
 	, _fragments(fragments)
 	, _variables(variables)
 	, _typeNames(typeNames)
 	, _resolvers(resolvers)
-	, _values(rapidjson::Type::kObjectType)
 {
 }
 
-rapidjson::Value SelectionVisitor::getValues()
+std::future<rapidjson::Value> SelectionVisitor::getValues()
 {
-	auto result = std::move(_values);
+	auto& allocator = _allocator;
 
-	return result;;
+	return std::async(std::launch::deferred,
+		[&allocator](std::queue<std::pair<rapidjson::Value, std::future<rapidjson::Value>>>&& values)
+	{
+		rapidjson::Value result(rapidjson::Type::kObjectType);
+
+		while (!values.empty())
+		{
+			auto& entry = values.front();
+			auto selectionName = std::move(entry.first);
+			auto selectionValue = entry.second.get();
+
+			result.AddMember(selectionName, selectionValue, allocator);
+			values.pop();
+		}
+
+		return result;
+	}, std::move(_values));
 }
 
 void SelectionVisitor::visit(const peg::ast_node& selection)
@@ -505,10 +571,10 @@ void SelectionVisitor::visitField(const peg::ast_node& field)
 		selection = &child;
 	});
 
-	rapidjson::Value selectionName(alias.c_str(), _allocator);
-	auto selectionValue = itr->second({ _allocator, const_cast<const rapidjson::Value&>(arguments).GetObject(), selection, _fragments, _variables });
-
-	_values.AddMember(selectionName, selectionValue, _allocator);
+	_values.push({
+		rapidjson::Value(alias.c_str(), _allocator),
+		itr->second({ _requestId, _allocator, const_cast<const rapidjson::Value&>(arguments).GetObject(), selection, _fragments, _variables })
+		});
 }
 
 void SelectionVisitor::visitFragmentSpread(const peg::ast_node& fragmentSpread)
@@ -850,21 +916,22 @@ void FragmentDefinitionVisitor::visit(const peg::ast_node& fragmentDefinition)
 	_fragments.insert({ fragmentDefinition.children.front()->content(), Fragment(fragmentDefinition) });
 }
 
-OperationDefinitionVisitor::OperationDefinitionVisitor(const TypeMap& operations, const std::string& operationName, const rapidjson::Document::ConstObject& variables, const FragmentMap& fragments)
-	: _operations(operations)
+OperationDefinitionVisitor::OperationDefinitionVisitor(RequestId requestId, const TypeMap& operations, const std::string& operationName, const rapidjson::Document::ConstObject& variables, const FragmentMap& fragments)
+	: _requestId(requestId)
+	, _operations(operations)
 	, _operationName(operationName)
 	, _variables(variables)
 	, _fragments(fragments)
 {
 }
 
-rapidjson::Document OperationDefinitionVisitor::getValue()
+std::future<rapidjson::Document> OperationDefinitionVisitor::getValue()
 {
-	rapidjson::Document result(std::move(_result));
+	auto result = std::move(_result);
 
 	try
 	{
-		if (result.IsNull())
+		if (!result.valid())
 		{
 			std::ostringstream error;
 
@@ -880,14 +947,17 @@ rapidjson::Document OperationDefinitionVisitor::getValue()
 	}
 	catch (const schema_exception& ex)
 	{
-		result = rapidjson::Document(rapidjson::Type::kObjectType);
-
-		auto& allocator = result.GetAllocator();
+		std::promise<rapidjson::Document> promise;
+		rapidjson::Document document(rapidjson::Type::kObjectType);
+		auto& allocator = document.GetAllocator();
 		rapidjson::Value errors;
 
 		errors.CopyFrom(ex.getErrors(), allocator);
-		result.AddMember(rapidjson::StringRef("data"), rapidjson::Value(rapidjson::Type::kNullType), allocator);
-		result.AddMember(rapidjson::StringRef("errors"), errors, allocator);
+		document.AddMember(rapidjson::StringRef("data"), rapidjson::Value(rapidjson::Type::kNullType), allocator);
+		document.AddMember(rapidjson::StringRef("errors"), errors, allocator);
+		promise.set_value(std::move(document));
+
+		result = promise.get_future();
 	}
 
 	return result;
@@ -926,7 +996,7 @@ void OperationDefinitionVisitor::visit(const peg::ast_node& operationDefinition)
 
 	try
 	{
-		if (!_result.IsNull())
+		if (_result.valid())
 		{
 			std::ostringstream error;
 
@@ -950,8 +1020,6 @@ void OperationDefinitionVisitor::visit(const peg::ast_node& operationDefinition)
 			throw schema_exception({ error.str() });
 		}
 
-		_result = rapidjson::Document(rapidjson::Type::kObjectType);
-
 		auto itr = _operations.find(operation);
 
 		if (itr == _operations.cend())
@@ -971,62 +1039,73 @@ void OperationDefinitionVisitor::visit(const peg::ast_node& operationDefinition)
 			throw schema_exception({ error.str() });
 		}
 
-		rapidjson::Document operationVariables(rapidjson::Type::kObjectType);
-
-		peg::on_first_child<peg::variable_definitions>(operationDefinition,
-			[this, &operationVariables](const peg::ast_node& child)
+		_result = std::async(std::launch::deferred, [this, &operationDefinition, operationObject = itr->second]()
 		{
-			peg::for_each_child<peg::variable>(child,
-				[this, &operationVariables](const peg::ast_node& variable)
+			rapidjson::Document operationVariables(rapidjson::Type::kObjectType);
+
+			peg::on_first_child<peg::variable_definitions>(operationDefinition,
+				[this, &operationVariables](const peg::ast_node& child)
 			{
-				std::string variableName;
-
-				peg::on_first_child<peg::variable_name>(variable,
-					[&variableName](const peg::ast_node& name)
+				peg::for_each_child<peg::variable>(child,
+					[this, &operationVariables](const peg::ast_node& variable)
 				{
-					// Skip the $ prefix
-					variableName = name.content().c_str() + 1;
-				});
+					std::string variableName;
 
-				auto& variableAllocator = operationVariables.GetAllocator();
-				rapidjson::Value nameVar(rapidjson::StringRef(variableName.c_str()));
-				auto itrVar = _variables.FindMember(nameVar);
-				rapidjson::Value valueVar;
-
-				if (itrVar != _variables.MemberEnd())
-				{
-					valueVar.CopyFrom(itrVar->value, variableAllocator);
-				}
-				else
-				{
-					peg::on_first_child<peg::default_value>(variable,
-						[this, &variableAllocator, &valueVar](const peg::ast_node& defaultValue)
+					peg::on_first_child<peg::variable_name>(variable,
+						[&variableName](const peg::ast_node& name)
 					{
-						ValueVisitor visitor(variableAllocator, _variables);
-
-						visitor.visit(*defaultValue.children.front());
-						valueVar = visitor.getValue();
+						// Skip the $ prefix
+						variableName = name.content().c_str() + 1;
 					});
-				}
 
-				operationVariables.AddMember(nameVar, valueVar, variableAllocator);
+					auto& variableAllocator = operationVariables.GetAllocator();
+					rapidjson::Value nameVar(rapidjson::StringRef(variableName.c_str()));
+					auto itrVar = _variables.FindMember(nameVar);
+					rapidjson::Value valueVar;
+
+					if (itrVar != _variables.MemberEnd())
+					{
+						valueVar.CopyFrom(itrVar->value, variableAllocator);
+					}
+					else
+					{
+						peg::on_first_child<peg::default_value>(variable,
+							[this, &variableAllocator, &valueVar](const peg::ast_node& defaultValue)
+						{
+							ValueVisitor visitor(variableAllocator, _variables);
+
+							visitor.visit(*defaultValue.children.front());
+							valueVar = visitor.getValue();
+						});
+					}
+
+					operationVariables.AddMember(nameVar, valueVar, variableAllocator);
+				});
 			});
+
+			rapidjson::Document document(rapidjson::Type::kObjectType);
+			auto& allocator = document.GetAllocator();
+			auto data = operationObject->resolve(_requestId, allocator, *operationDefinition.children.back(),
+				_fragments, const_cast<const rapidjson::Document&>(operationVariables).GetObject());
+
+			document.AddMember(rapidjson::StringRef("data"), data.get(), allocator);
+
+			return document;
 		});
-
-		auto data = itr->second->resolve(_result.GetAllocator(), *operationDefinition.children.back(), _fragments, const_cast<const rapidjson::Document&>(operationVariables).GetObject());
-
-		_result.AddMember(rapidjson::StringRef("data"), data, _result.GetAllocator());
 	}
 	catch (const schema_exception& ex)
 	{
-		_result = rapidjson::Document(rapidjson::Type::kObjectType);
-
-		auto& allocator = _result.GetAllocator();
+		std::promise<rapidjson::Document> promise;
+		rapidjson::Document document(rapidjson::Type::kObjectType);
+		auto& allocator = document.GetAllocator();
 		rapidjson::Value errors;
 
 		errors.CopyFrom(ex.getErrors(), allocator);
-		_result.AddMember(rapidjson::StringRef("data"), rapidjson::Value(rapidjson::Type::kNullType), allocator);
-		_result.AddMember(rapidjson::StringRef("errors"), errors, allocator);
+		document.AddMember(rapidjson::StringRef("data"), rapidjson::Value(rapidjson::Type::kNullType), allocator);
+		document.AddMember(rapidjson::StringRef("errors"), errors, allocator);
+		promise.set_value(std::move(document));
+
+		_result = promise.get_future();
 	}
 }
 

--- a/Introspection.cpp
+++ b/Introspection.cpp
@@ -52,37 +52,58 @@ std::shared_ptr<object::__Type> Schema::LookupType(const std::string& name) cons
 	return _types[itr->second].second;
 }
 
-std::vector<std::shared_ptr<object::__Type>> Schema::getTypes() const
+std::future<std::vector<std::shared_ptr<object::__Type>>> Schema::getTypes(service::RequestId) const
 {
-	std::vector<std::shared_ptr<object::__Type>> result(_types.size());
-
-	std::transform(_types.cbegin(), _types.cend(), result.begin(),
-		[](const std::pair<std::string, std::shared_ptr<object::__Type>>& namedType)
+	return std::async(std::launch::deferred,
+		[this]()
 	{
-		return namedType.second;
+		std::vector<std::shared_ptr<object::__Type>> result(_types.size());
+
+		std::transform(_types.cbegin(), _types.cend(), result.begin(),
+			[](const std::pair<std::string, std::shared_ptr<object::__Type>>& namedType)
+		{
+			return namedType.second;
+		});
+
+		return result;
 	});
-
-	return result;
 }
 
-std::shared_ptr<object::__Type> Schema::getQueryType() const
+std::future<std::shared_ptr<object::__Type>> Schema::getQueryType(service::RequestId) const
 {
-	return _query;
+	std::promise<std::shared_ptr<object::__Type>> promise;
+
+	promise.set_value(_query);
+
+	return promise.get_future();
 }
 
-std::shared_ptr<object::__Type> Schema::getMutationType() const
+std::future<std::shared_ptr<object::__Type>> Schema::getMutationType(service::RequestId) const
 {
-	return _mutation;
+	std::promise<std::shared_ptr<object::__Type>> promise;
+
+	promise.set_value(_mutation);
+
+	return promise.get_future();
 }
 
-std::shared_ptr<object::__Type> Schema::getSubscriptionType() const
+std::future<std::shared_ptr<object::__Type>> Schema::getSubscriptionType(service::RequestId) const
 {
-	return _subscription;
+	std::promise<std::shared_ptr<object::__Type>> promise;
+
+	promise.set_value(_subscription);
+
+	return promise.get_future();
 }
 
-std::vector<std::shared_ptr<object::__Directive>> Schema::getDirectives() const
+std::future<std::vector<std::shared_ptr<object::__Directive>>> Schema::getDirectives(service::RequestId) const
 {
-	return {};
+	std::promise<std::vector<std::shared_ptr<object::__Directive>>> promise;
+
+	// TODO: preserve directives
+	promise.set_value({});
+
+	return promise.get_future();
 }
 
 BaseType::BaseType(std::string description)
@@ -90,46 +111,78 @@ BaseType::BaseType(std::string description)
 {
 }
 
-std::unique_ptr<std::string> BaseType::getName() const
+std::future<std::unique_ptr<std::string>> BaseType::getName(service::RequestId) const
 {
-	return nullptr;
+	std::promise<std::unique_ptr<std::string>> promise;
+
+	promise.set_value(nullptr);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::string> BaseType::getDescription() const
+std::future<std::unique_ptr<std::string>> BaseType::getDescription(service::RequestId) const
 {
-	std::unique_ptr<std::string> result(_description.empty() ? nullptr : new std::string(_description));
+	std::promise<std::unique_ptr<std::string>> promise;
 
-	return result;
+	promise.set_value(std::unique_ptr<std::string>(_description.empty()
+		? nullptr
+		: new std::string(_description)));
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>> BaseType::getFields(std::unique_ptr<bool>&& /*includeDeprecated*/) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> BaseType::getFields(service::RequestId, std::unique_ptr<bool>&& /*includeDeprecated*/) const
 {
-	return nullptr;
+	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> promise;
+
+	promise.set_value(nullptr);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>> BaseType::getInterfaces() const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> BaseType::getInterfaces(service::RequestId) const
 {
-	return nullptr;
+	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> promise;
+
+	promise.set_value(nullptr);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>> BaseType::getPossibleTypes() const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> BaseType::getPossibleTypes(service::RequestId) const
 {
-	return nullptr;
+	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> promise;
+
+	promise.set_value(nullptr);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>> BaseType::getEnumValues(std::unique_ptr<bool>&& /*includeDeprecated*/) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> BaseType::getEnumValues(service::RequestId, std::unique_ptr<bool>&& /*includeDeprecated*/) const
 {
-	return nullptr;
+	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> promise;
+
+	promise.set_value(nullptr);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>> BaseType::getInputFields() const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> BaseType::getInputFields(service::RequestId) const
 {
-	return nullptr;
+	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> promise;
+
+	promise.set_value(nullptr);
+
+	return promise.get_future();
 }
 
-std::shared_ptr<object::__Type> BaseType::getOfType() const
+std::future<std::shared_ptr<object::__Type>> BaseType::getOfType(service::RequestId) const
 {
-	return nullptr;
+	std::promise<std::shared_ptr<object::__Type>> promise;
+
+	promise.set_value(nullptr);
+
+	return promise.get_future();
 }
 
 ScalarType::ScalarType(std::string name, std::string description)
@@ -138,16 +191,22 @@ ScalarType::ScalarType(std::string name, std::string description)
 {
 }
 
-__TypeKind ScalarType::getKind() const
+std::future<__TypeKind> ScalarType::getKind(service::RequestId) const
 {
-	return __TypeKind::SCALAR;
+	std::promise<__TypeKind> promise;
+
+	promise.set_value(__TypeKind::SCALAR);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::string> ScalarType::getName() const
+std::future<std::unique_ptr<std::string>> ScalarType::getName(service::RequestId) const
 {
-	std::unique_ptr<std::string> result(new std::string(_name));
+	std::promise<std::unique_ptr<std::string>> promise;
 
-	return result;
+	promise.set_value(std::unique_ptr<std::string>(new std::string(_name)));
+
+	return promise.get_future();
 }
 
 ObjectType::ObjectType(std::string name, std::string description)
@@ -166,41 +225,51 @@ void ObjectType::AddFields(std::vector<std::shared_ptr<Field>> fields)
 	_fields = std::move(fields);
 }
 
-__TypeKind ObjectType::getKind() const
+std::future<__TypeKind> ObjectType::getKind(service::RequestId) const
 {
-	return __TypeKind::OBJECT;
+	std::promise<__TypeKind> promise;
+
+	promise.set_value(__TypeKind::OBJECT);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::string> ObjectType::getName() const
+std::future<std::unique_ptr<std::string>> ObjectType::getName(service::RequestId) const
 {
-	std::unique_ptr<std::string> result(new std::string(_name));
+	std::promise<std::unique_ptr<std::string>> promise;
 
-	return result;
+	promise.set_value(std::unique_ptr<std::string>(new std::string(_name)));
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>> ObjectType::getFields(std::unique_ptr<bool>&& includeDeprecated) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> ObjectType::getFields(service::RequestId requestId, std::unique_ptr<bool>&& includeDeprecated) const
 {
 	const bool deprecated = includeDeprecated && *includeDeprecated;
+	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> promise;
 	std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>> result(new std::vector<std::shared_ptr<object::__Field>>());
 
 	result->reserve(_fields.size());
 	std::copy_if(_fields.cbegin(), _fields.cend(), std::back_inserter(*result),
-		[deprecated](const std::shared_ptr<Field>& field)
+		[requestId, deprecated](const std::shared_ptr<Field>& field)
 	{
 		return deprecated
-			|| !field->getIsDeprecated();
+			|| !field->getIsDeprecated(requestId).get();
 	});
+	promise.set_value(std::move(result));
 
-	return result;
+	return promise.get_future();
 }
 
-std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>> ObjectType::getInterfaces() const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> ObjectType::getInterfaces(service::RequestId) const
 {
+	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> promise;
 	std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>> result(new std::vector<std::shared_ptr<object::__Type>>(_interfaces.size()));
 
 	std::copy(_interfaces.cbegin(), _interfaces.cend(), result->begin());
+	promise.set_value(std::move(result));
 
-	return result;
+	return promise.get_future();
 }
 
 InterfaceType::InterfaceType(std::string name, std::string description)
@@ -214,32 +283,40 @@ void InterfaceType::AddFields(std::vector<std::shared_ptr<Field>> fields)
 	_fields = std::move(fields);
 }
 
-__TypeKind InterfaceType::getKind() const
+std::future<__TypeKind> InterfaceType::getKind(service::RequestId) const
 {
-	return __TypeKind::INTERFACE;
+	std::promise<__TypeKind> promise;
+
+	promise.set_value(__TypeKind::INTERFACE);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::string> InterfaceType::getName() const
+std::future<std::unique_ptr<std::string>> InterfaceType::getName(service::RequestId) const
 {
-	std::unique_ptr<std::string> result(new std::string(_name));
+	std::promise<std::unique_ptr<std::string>> promise;
 
-	return result;
+	promise.set_value(std::unique_ptr<std::string>(new std::string(_name)));
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>> InterfaceType::getFields(std::unique_ptr<bool>&& includeDeprecated) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> InterfaceType::getFields(service::RequestId requestId, std::unique_ptr<bool>&& includeDeprecated) const
 {
 	const bool deprecated = includeDeprecated && *includeDeprecated;
+	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> promise;
 	std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>> result(new std::vector<std::shared_ptr<object::__Field>>());
 
 	result->reserve(_fields.size());
 	std::copy_if(_fields.cbegin(), _fields.cend(), std::back_inserter(*result),
-		[deprecated](const std::shared_ptr<Field>& field)
+		[requestId, deprecated](const std::shared_ptr<Field>& field)
 	{
 		return deprecated
-			|| !field->getIsDeprecated();
+			|| !field->getIsDeprecated(requestId).get();
 	});
+	promise.set_value(std::move(result));
 
-	return result;
+	return promise.get_future();
 }
 
 UnionType::UnionType(std::string name, std::string description)
@@ -258,20 +335,27 @@ void UnionType::AddPossibleTypes(std::vector<std::shared_ptr<object::__Type>> po
 	});
 }
 
-__TypeKind UnionType::getKind() const
+std::future<__TypeKind> UnionType::getKind(service::RequestId) const
 {
-	return __TypeKind::UNION;
+	std::promise<__TypeKind> promise;
+
+	promise.set_value(__TypeKind::UNION);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::string> UnionType::getName() const
+std::future<std::unique_ptr<std::string>> UnionType::getName(service::RequestId) const
 {
-	std::unique_ptr<std::string> result(new std::string(_name));
+	std::promise<std::unique_ptr<std::string>> promise;
 
-	return result;
+	promise.set_value(std::unique_ptr<std::string>(new std::string(_name)));
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>> UnionType::getPossibleTypes() const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> UnionType::getPossibleTypes(service::RequestId) const
 {
+	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> promise;
 	std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>> result(new std::vector<std::shared_ptr<object::__Type>>(_possibleTypes.size()));
 
 	std::transform(_possibleTypes.cbegin(), _possibleTypes.cend(), result->begin(),
@@ -279,8 +363,9 @@ std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>> UnionType::getPoss
 	{
 		return weak.lock();
 	});
+	promise.set_value(std::move(result));
 
-	return result;
+	return promise.get_future();
 }
 
 EnumType::EnumType(std::string name, std::string description)
@@ -303,32 +388,40 @@ void EnumType::AddEnumValues(std::vector<EnumValueType> enumValues)
 	}
 }
 
-__TypeKind EnumType::getKind() const
+std::future<__TypeKind> EnumType::getKind(service::RequestId) const
 {
-	return __TypeKind::ENUM;
+	std::promise<__TypeKind> promise;
+
+	promise.set_value(__TypeKind::ENUM);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::string> EnumType::getName() const
+std::future<std::unique_ptr<std::string>> EnumType::getName(service::RequestId) const
 {
-	std::unique_ptr<std::string> result(new std::string(_name));
+	std::promise<std::unique_ptr<std::string>> promise;
 
-	return result;
+	promise.set_value(std::unique_ptr<std::string>(new std::string(_name)));
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>> EnumType::getEnumValues(std::unique_ptr<bool>&& includeDeprecated) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> EnumType::getEnumValues(service::RequestId requestId, std::unique_ptr<bool>&& includeDeprecated) const
 {
 	const bool deprecated = includeDeprecated && *includeDeprecated;
+	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> promise;
 	std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>> result(new std::vector<std::shared_ptr<object::__EnumValue>>());
 
 	result->reserve(_enumValues.size());
 	std::copy_if(_enumValues.cbegin(), _enumValues.cend(), std::back_inserter(*result),
-		[deprecated](const std::shared_ptr<object::__EnumValue>& value)
+		[requestId, deprecated](const std::shared_ptr<object::__EnumValue>& value)
 	{
 		return deprecated
-			|| !value->getIsDeprecated();
+			|| !value->getIsDeprecated(requestId).get();
 	});
+	promise.set_value(std::move(result));
 
-	return result;
+	return promise.get_future();
 }
 
 InputObjectType::InputObjectType(std::string name, std::string description)
@@ -342,25 +435,33 @@ void InputObjectType::AddInputValues(std::vector<std::shared_ptr<InputValue>> in
 	_inputValues = std::move(inputValues);
 }
 
-__TypeKind InputObjectType::getKind() const
+std::future<__TypeKind> InputObjectType::getKind(service::RequestId) const
 {
-	return __TypeKind::INPUT_OBJECT;
+	std::promise<__TypeKind> promise;
+
+	promise.set_value(__TypeKind::INPUT_OBJECT);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::string> InputObjectType::getName() const
+std::future<std::unique_ptr<std::string>> InputObjectType::getName(service::RequestId) const
 {
-	std::unique_ptr<std::string> result(new std::string(_name));
+	std::promise<std::unique_ptr<std::string>> promise;
 
-	return result;
+	promise.set_value(std::unique_ptr<std::string>(new std::string(_name)));
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>> InputObjectType::getInputFields() const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> InputObjectType::getInputFields(service::RequestId) const
 {
+	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> promise;
 	std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>> result(new std::vector<std::shared_ptr<object::__InputValue>>(_inputValues.size()));
 
 	std::copy(_inputValues.cbegin(), _inputValues.cend(), result->begin());
+	promise.set_value(std::move(result));
 
-	return result;
+	return promise.get_future();
 }
 
 WrapperType::WrapperType(__TypeKind kind, std::shared_ptr<object::__Type> ofType)
@@ -370,14 +471,22 @@ WrapperType::WrapperType(__TypeKind kind, std::shared_ptr<object::__Type> ofType
 {
 }
 
-__TypeKind WrapperType::getKind() const
+std::future<__TypeKind> WrapperType::getKind(service::RequestId) const
 {
-	return _kind;
+	std::promise<__TypeKind> promise;
+
+	promise.set_value(_kind);
+
+	return promise.get_future();
 }
 
-std::shared_ptr<object::__Type> WrapperType::getOfType() const
+std::future<std::shared_ptr<object::__Type>> WrapperType::getOfType(service::RequestId) const
 {
-	return _ofType.lock();
+	std::promise<std::shared_ptr<object::__Type>> promise;
+
+	promise.set_value(_ofType.lock());
+
+	return promise.get_future();
 }
 
 Field::Field(std::string name, std::string description, std::unique_ptr<std::string>&& deprecationReason, std::vector<std::shared_ptr<InputValue>> args, std::shared_ptr<object::__Type> type)
@@ -389,42 +498,64 @@ Field::Field(std::string name, std::string description, std::unique_ptr<std::str
 {
 }
 
-std::string Field::getName() const
+std::future<std::string> Field::getName(service::RequestId) const
 {
-	return _name;
+	std::promise<std::string> promise;
+
+	promise.set_value(_name);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::string> Field::getDescription() const
+std::future<std::unique_ptr<std::string>> Field::getDescription(service::RequestId) const
 {
-	std::unique_ptr<std::string> result(_description.empty() ? nullptr : new std::string(_description));
+	std::promise<std::unique_ptr<std::string>> promise;
 
-	return result;
+	promise.set_value(std::unique_ptr<std::string>(_description.empty()
+		? nullptr
+		: new std::string(_description)));
+
+	return promise.get_future();
 }
 
-std::vector<std::shared_ptr<object::__InputValue>> Field::getArgs() const
+std::future<std::vector<std::shared_ptr<object::__InputValue>>> Field::getArgs(service::RequestId) const
 {
+	std::promise<std::vector<std::shared_ptr<object::__InputValue>>> promise;
 	std::vector<std::shared_ptr<object::__InputValue>> result(_args.size());
 
 	std::copy(_args.cbegin(), _args.cend(), result.begin());
+	promise.set_value(std::move(result));
 
-	return result;
+	return promise.get_future();
 }
 
-std::shared_ptr<object::__Type> Field::getType() const
+std::future<std::shared_ptr<object::__Type>> Field::getType(service::RequestId) const
 {
-	return _type.lock();
+	std::promise<std::shared_ptr<object::__Type>> promise;
+
+	promise.set_value(_type.lock());
+
+	return promise.get_future();
 }
 
-bool Field::getIsDeprecated() const
+std::future<bool> Field::getIsDeprecated(service::RequestId) const
 {
-	return _deprecationReason != nullptr;
+	std::promise<bool> promise;
+
+	promise.set_value(_deprecationReason != nullptr);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::string> Field::getDeprecationReason() const
+std::future<std::unique_ptr<std::string>> Field::getDeprecationReason(service::RequestId) const
 {
-	return _deprecationReason
+	std::promise<std::unique_ptr<std::string>> promise;
+
+	promise.set_value(_deprecationReason
 		? std::unique_ptr<std::string>(new std::string(*_deprecationReason))
-		: nullptr;
+		: nullptr);
+
+	return promise.get_future();
 }
 
 InputValue::InputValue(std::string name, std::string description, std::shared_ptr<object::__Type> type, const rapidjson::Value& defaultValue)
@@ -435,28 +566,42 @@ InputValue::InputValue(std::string name, std::string description, std::shared_pt
 {
 }
 
-std::string InputValue::getName() const
+std::future<std::string> InputValue::getName(service::RequestId) const
 {
-	return _name;
+	std::promise<std::string> promise;
+
+	promise.set_value(_name);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::string> InputValue::getDescription() const
+std::future<std::unique_ptr<std::string>> InputValue::getDescription(service::RequestId) const
 {
-	std::unique_ptr<std::string> result(_description.empty() ? nullptr : new std::string(_description));
+	std::promise<std::unique_ptr<std::string>> promise;
 
-	return result;
+	promise.set_value(std::unique_ptr<std::string>(_description.empty()
+		? nullptr
+		: new std::string(_description)));
+
+	return promise.get_future();
 }
 
-std::shared_ptr<object::__Type> InputValue::getType() const
+std::future<std::shared_ptr<object::__Type>> InputValue::getType(service::RequestId) const
 {
-	return _type.lock();
+	std::promise<std::shared_ptr<object::__Type>> promise;
+
+	promise.set_value(_type.lock());
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::string> InputValue::getDefaultValue() const
+std::future<std::unique_ptr<std::string>> InputValue::getDefaultValue(service::RequestId) const
 {
-	std::unique_ptr<std::string> result(new std::string(_defaultValue));
+	std::promise<std::unique_ptr<std::string>> promise;
 
-	return result;
+	promise.set_value(std::unique_ptr<std::string>(new std::string(_defaultValue)));
+
+	return promise.get_future();
 }
 
 std::string InputValue::formatDefaultValue(const rapidjson::Value& defaultValue) noexcept
@@ -521,28 +666,44 @@ EnumValue::EnumValue(std::string name, std::string description, std::unique_ptr<
 {
 }
 
-std::string EnumValue::getName() const
+std::future<std::string> EnumValue::getName(service::RequestId) const
 {
-	return _name;
+	std::promise<std::string> promise;
+
+	promise.set_value(_name);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::string> EnumValue::getDescription() const
+std::future<std::unique_ptr<std::string>> EnumValue::getDescription(service::RequestId) const
 {
-	std::unique_ptr<std::string> result(_description.empty() ? nullptr : new std::string(_description));
+	std::promise<std::unique_ptr<std::string>> promise;
 
-	return result;
+	promise.set_value(std::unique_ptr<std::string>(_description.empty()
+		? nullptr
+		: new std::string(_description)));
+
+	return promise.get_future();
 }
 
-bool EnumValue::getIsDeprecated() const
+std::future<bool> EnumValue::getIsDeprecated(service::RequestId) const
 {
-	return _deprecationReason != nullptr;
+	std::promise<bool> promise;
+
+	promise.set_value(_deprecationReason != nullptr);
+
+	return promise.get_future();
 }
 
-std::unique_ptr<std::string> EnumValue::getDeprecationReason() const
+std::future<std::unique_ptr<std::string>> EnumValue::getDeprecationReason(service::RequestId) const
 {
-	return _deprecationReason
+	std::promise<std::unique_ptr<std::string>> promise;
+
+	promise.set_value(_deprecationReason
 		? std::unique_ptr<std::string>(new std::string(*_deprecationReason))
-		: nullptr;
+		: nullptr);
+
+	return promise.get_future();
 }
 
 } /* namespace facebook */

--- a/Introspection.h
+++ b/Introspection.h
@@ -34,11 +34,11 @@ public:
 	std::shared_ptr<object::__Type> LookupType(const std::string& name) const;
 
 	// Accessors
-	std::vector<std::shared_ptr<object::__Type>> getTypes() const override;
-	std::shared_ptr<object::__Type> getQueryType() const override;
-	std::shared_ptr<object::__Type> getMutationType() const override;
-	std::shared_ptr<object::__Type> getSubscriptionType() const override;
-	std::vector<std::shared_ptr<object::__Directive>> getDirectives() const override;
+	std::future<std::vector<std::shared_ptr<object::__Type>>> getTypes(service::RequestId requestId) const override;
+	std::future<std::shared_ptr<object::__Type>> getQueryType(service::RequestId requestId) const override;
+	std::future<std::shared_ptr<object::__Type>> getMutationType(service::RequestId requestId) const override;
+	std::future<std::shared_ptr<object::__Type>> getSubscriptionType(service::RequestId requestId) const override;
+	std::future<std::vector<std::shared_ptr<object::__Directive>>> getDirectives(service::RequestId requestId) const override;
 
 private:
 	std::shared_ptr<ObjectType> _query;
@@ -52,14 +52,14 @@ class BaseType : public object::__Type
 {
 public:
 	// Accessors
-	std::unique_ptr<std::string> getName() const override;
-	std::unique_ptr<std::string> getDescription() const override;
-	std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>> getFields(std::unique_ptr<bool>&& includeDeprecated) const override;
-	std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>> getInterfaces() const override;
-	std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>> getPossibleTypes() const override;
-	std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>> getEnumValues(std::unique_ptr<bool>&& includeDeprecated) const override;
-	std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>> getInputFields() const override;
-	std::shared_ptr<object::__Type> getOfType() const override;
+	std::future<std::unique_ptr<std::string>> getName(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> getFields(service::RequestId requestId, std::unique_ptr<bool>&& includeDeprecated) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> getInterfaces(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> getPossibleTypes(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> getEnumValues(service::RequestId requestId, std::unique_ptr<bool>&& includeDeprecated) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> getInputFields(service::RequestId requestId) const override;
+	std::future<std::shared_ptr<object::__Type>> getOfType(service::RequestId requestId) const override;
 
 protected:
 	BaseType(std::string description);
@@ -74,8 +74,8 @@ public:
 	explicit ScalarType(std::string name, std::string description);
 
 	// Accessors
-	__TypeKind getKind() const override;
-	std::unique_ptr<std::string> getName() const override;
+	std::future<__TypeKind> getKind(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::string>> getName(service::RequestId requestId) const override;
 
 private:
 	const std::string _name;
@@ -90,10 +90,10 @@ public:
 	void AddFields(std::vector<std::shared_ptr<Field>> fields);
 
 	// Accessors
-	__TypeKind getKind() const override;
-	std::unique_ptr<std::string> getName() const override;
-	std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>> getFields(std::unique_ptr<bool>&& includeDeprecated) const override;
-	std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>> getInterfaces() const override;
+	std::future<__TypeKind> getKind(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::string>> getName(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> getFields(service::RequestId requestId, std::unique_ptr<bool>&& includeDeprecated) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> getInterfaces(service::RequestId requestId) const override;
 
 private:
 	const std::string _name;
@@ -110,9 +110,9 @@ public:
 	void AddFields(std::vector<std::shared_ptr<Field>> fields);
 
 	// Accessors
-	__TypeKind getKind() const override;
-	std::unique_ptr<std::string> getName() const override;
-	std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>> getFields(std::unique_ptr<bool>&& includeDeprecated) const override;
+	std::future<__TypeKind> getKind(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::string>> getName(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> getFields(service::RequestId requestId, std::unique_ptr<bool>&& includeDeprecated) const override;
 
 private:
 	const std::string _name;
@@ -128,9 +128,9 @@ public:
 	void AddPossibleTypes(std::vector<std::shared_ptr<object::__Type>> possibleTypes);
 
 	// Accessors
-	__TypeKind getKind() const override;
-	std::unique_ptr<std::string> getName() const override;
-	std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>> getPossibleTypes() const override;
+	std::future<__TypeKind> getKind(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::string>> getName(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> getPossibleTypes(service::RequestId requestId) const override;
 
 private:
 	const std::string _name;
@@ -153,9 +153,9 @@ public:
 	void AddEnumValues(std::vector<EnumValueType> enumValues);
 
 	// Accessors
-	__TypeKind getKind() const override;
-	std::unique_ptr<std::string> getName() const override;
-	std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>> getEnumValues(std::unique_ptr<bool>&& includeDeprecated) const override;
+	std::future<__TypeKind> getKind(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::string>> getName(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> getEnumValues(service::RequestId requestId, std::unique_ptr<bool>&& includeDeprecated) const override;
 
 private:
 	const std::string _name;
@@ -171,9 +171,9 @@ public:
 	void AddInputValues(std::vector<std::shared_ptr<InputValue>> inputValues);
 
 	// Accessors
-	__TypeKind getKind() const override;
-	std::unique_ptr<std::string> getName() const override;
-	std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>> getInputFields() const override;
+	std::future<__TypeKind> getKind(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::string>> getName(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> getInputFields(service::RequestId requestId) const override;
 
 private:
 	const std::string _name;
@@ -187,8 +187,8 @@ public:
 	explicit WrapperType(__TypeKind kind, std::shared_ptr<object::__Type> ofType);
 
 	// Accessors
-	__TypeKind getKind() const override;
-	std::shared_ptr<object::__Type> getOfType() const override;
+	std::future<__TypeKind> getKind(service::RequestId requestId) const override;
+	std::future<std::shared_ptr<object::__Type>> getOfType(service::RequestId requestId) const override;
 
 private:
 	const __TypeKind _kind;
@@ -201,12 +201,12 @@ public:
 	explicit Field(std::string name, std::string description, std::unique_ptr<std::string>&& deprecationReason, std::vector<std::shared_ptr<InputValue>> args, std::shared_ptr<object::__Type> type);
 
 	// Accessors
-	std::string getName() const override;
-	std::unique_ptr<std::string> getDescription() const override;
-	std::vector<std::shared_ptr<object::__InputValue>> getArgs() const override;
-	std::shared_ptr<object::__Type> getType() const override;
-	bool getIsDeprecated() const override;
-	std::unique_ptr<std::string> getDeprecationReason() const override;
+	std::future<std::string> getName(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const override;
+	std::future<std::vector<std::shared_ptr<object::__InputValue>>> getArgs(service::RequestId requestId) const override;
+	std::future<std::shared_ptr<object::__Type>> getType(service::RequestId requestId) const override;
+	std::future<bool> getIsDeprecated(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::string>> getDeprecationReason(service::RequestId requestId) const override;
 
 private:
 	const std::string _name;
@@ -222,10 +222,10 @@ public:
 	explicit InputValue(std::string name, std::string description, std::shared_ptr<object::__Type> type, const rapidjson::Value& defaultValue);
 
 	// Accessors
-	std::string getName() const override;
-	std::unique_ptr<std::string> getDescription() const override;
-	std::shared_ptr<object::__Type> getType() const override;
-	std::unique_ptr<std::string> getDefaultValue() const override;
+	std::future<std::string> getName(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const override;
+	std::future<std::shared_ptr<object::__Type>> getType(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::string>> getDefaultValue(service::RequestId requestId) const override;
 
 private:
 	static std::string formatDefaultValue(const rapidjson::Value& defaultValue) noexcept;
@@ -242,10 +242,10 @@ public:
 	explicit EnumValue(std::string name, std::string description, std::unique_ptr<std::string>&& deprecationReason);
 
 	// Accessors
-	std::string getName() const override;
-	std::unique_ptr<std::string> getDescription() const override;
-	bool getIsDeprecated() const override;
-	std::unique_ptr<std::string> getDeprecationReason() const override;
+	std::future<std::string> getName(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const override;
+	std::future<bool> getIsDeprecated(service::RequestId requestId) const override;
+	std::future<std::unique_ptr<std::string>> getDeprecationReason(service::RequestId requestId) const override;
 
 private:
 	const std::string _name;

--- a/Today.cpp
+++ b/Today.cpp
@@ -48,13 +48,13 @@ void Query::loadAppointments() const
 	}
 }
 
-std::shared_ptr<Appointment> Query::findAppointment(const std::vector<uint8_t>& id) const
+std::shared_ptr<Appointment> Query::findAppointment(service::RequestId requestId, const std::vector<uint8_t>& id) const
 {
 	loadAppointments();
 
 	for (const auto& appointment : _appointments)
 	{
-		auto appointmentId = appointment->getId();
+		auto appointmentId = appointment->getId(requestId).get();
 
 		if (appointmentId == id)
 		{
@@ -74,13 +74,13 @@ void Query::loadTasks() const
 	}
 }
 
-std::shared_ptr<Task> Query::findTask(const std::vector<uint8_t>& id) const
+std::shared_ptr<Task> Query::findTask(service::RequestId requestId, const std::vector<uint8_t>& id) const
 {
 	loadTasks();
 
 	for (const auto& task : _tasks)
 	{
-		auto taskId = task->getId();
+		auto taskId = task->getId(requestId).get();
 
 		if (taskId == id)
 		{
@@ -100,13 +100,13 @@ void Query::loadUnreadCounts() const
 	}
 }
 
-std::shared_ptr<Folder> Query::findUnreadCount(const std::vector<uint8_t>& id) const
+std::shared_ptr<Folder> Query::findUnreadCount(service::RequestId requestId, const std::vector<uint8_t>& id) const
 {
 	loadUnreadCounts();
 
 	for (const auto& folder : _unreadCounts)
 	{
-		auto folderId = folder->getId();
+		auto folderId = folder->getId(requestId).get();
 
 		if (folderId == id)
 		{
@@ -117,30 +117,35 @@ std::shared_ptr<Folder> Query::findUnreadCount(const std::vector<uint8_t>& id) c
 	return nullptr;
 }
 
-std::shared_ptr<service::Object> Query::getNode(std::vector<uint8_t>&& id) const
+std::future<std::shared_ptr<service::Object>> Query::getNode(service::RequestId requestId, std::vector<uint8_t>&& id) const
 {
-	auto appointment = findAppointment(id);
+	std::promise<std::shared_ptr<service::Object>> promise;
+	auto appointment = findAppointment(requestId, id);
 
 	if (appointment)
 	{
-		return appointment;
+		promise.set_value(appointment);
+		return promise.get_future();
 	}
 
-	auto task = findTask(id);
+	auto task = findTask(requestId, id);
 
 	if (task)
 	{
-		return task;
+		promise.set_value(task);
+		return promise.get_future();
 	}
 
-	auto folder = findUnreadCount(id);
+	auto folder = findUnreadCount(requestId, id);
 
 	if (folder)
 	{
-		return folder;
+		promise.set_value(folder);
+		return promise.get_future();
 	}
 
-	return nullptr;
+	promise.set_value(nullptr);
+	return promise.get_future();
 }
 
 template <class _Object, class _Connection>
@@ -149,8 +154,9 @@ struct EdgeConstraints
 	using vec_type = std::vector<std::shared_ptr<_Object>>;
 	using itr_type = typename vec_type::const_iterator;
 
-	EdgeConstraints(const vec_type& objects)
-		: _objects(objects)
+	EdgeConstraints(service::RequestId requestId, const vec_type& objects)
+		: _requestId(requestId)
+		, _objects(objects)
 	{
 	}
 
@@ -163,9 +169,9 @@ struct EdgeConstraints
 		{
 			auto afterId = service::Base64::fromBase64(after->GetString(), after->GetStringLength());
 			auto itrAfter = std::find_if(itrFirst, itrLast,
-				[&afterId](const std::shared_ptr<_Object>& entry)
+				[this, &afterId](const std::shared_ptr<_Object>& entry)
 			{
-				return entry->getId() == afterId;
+				return entry->getId(_requestId).get() == afterId;
 			});
 
 			if (itrAfter != itrLast)
@@ -178,9 +184,9 @@ struct EdgeConstraints
 		{
 			auto beforeId = service::Base64::fromBase64(before->GetString(), before->GetStringLength());
 			auto itrBefore = std::find_if(itrFirst, itrLast,
-				[&beforeId](const std::shared_ptr<_Object>& entry)
+				[this, &beforeId](const std::shared_ptr<_Object>& entry)
 			{
-				return entry->getId() == beforeId;
+				return entry->getId(_requestId).get() == beforeId;
 			});
 
 			if (itrBefore != itrLast)
@@ -230,76 +236,92 @@ struct EdgeConstraints
 	}
 
 private:
+	const service::RequestId _requestId;
 	const vec_type& _objects;
 };
 
-std::shared_ptr<object::AppointmentConnection> Query::getAppointments(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
+std::future<std::shared_ptr<object::AppointmentConnection>> Query::getAppointments(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
 {
 	loadAppointments();
 
-	EdgeConstraints<Appointment, AppointmentConnection> constraints(_appointments);
+	std::promise<std::shared_ptr<object::AppointmentConnection>> promise;
+	EdgeConstraints<Appointment, AppointmentConnection> constraints(requestId, _appointments);
 	auto connection = constraints(first.get(), after.get(), last.get(), before.get());
 
-	return std::static_pointer_cast<object::AppointmentConnection>(connection);
+	promise.set_value(std::static_pointer_cast<object::AppointmentConnection>(connection));
+
+	return promise.get_future();
 }
 
-std::shared_ptr<object::TaskConnection> Query::getTasks(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
+std::future<std::shared_ptr<object::TaskConnection>> Query::getTasks(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
 {
 	loadTasks();
 
-	EdgeConstraints<Task, TaskConnection> constraints(_tasks);
+	std::promise<std::shared_ptr<object::TaskConnection>> promise;
+	EdgeConstraints<Task, TaskConnection> constraints(requestId, _tasks);
 	auto connection = constraints(first.get(), after.get(), last.get(), before.get());
 
-	return std::static_pointer_cast<object::TaskConnection>(connection);
+	promise.set_value(std::static_pointer_cast<object::TaskConnection>(connection));
+
+	return promise.get_future();
 }
 
-std::shared_ptr<object::FolderConnection> Query::getUnreadCounts(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
+std::future<std::shared_ptr<object::FolderConnection>> Query::getUnreadCounts(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
 {
 	loadUnreadCounts();
 
-	EdgeConstraints<Folder, FolderConnection> constraints(_unreadCounts);
+	std::promise<std::shared_ptr<object::FolderConnection>> promise;
+	EdgeConstraints<Folder, FolderConnection> constraints(requestId, _unreadCounts);
 	auto connection = constraints(first.get(), after.get(), last.get(), before.get());
 
-	return std::static_pointer_cast<object::FolderConnection>(connection);
+	promise.set_value(std::static_pointer_cast<object::FolderConnection>(connection));
+
+	return promise.get_future();
 }
 
-std::vector<std::shared_ptr<object::Appointment>> Query::getAppointmentsById(std::vector<std::vector<uint8_t>>&& ids) const
+std::future<std::vector<std::shared_ptr<object::Appointment>>> Query::getAppointmentsById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const
 {
+	std::promise<std::vector<std::shared_ptr<object::Appointment>>> promise;
 	std::vector<std::shared_ptr<object::Appointment>> result(ids.size());
 
 	std::transform(ids.cbegin(), ids.cend(), result.begin(),
-		[this](const std::vector<uint8_t>& id)
+		[this, requestId](const std::vector<uint8_t>& id)
 	{
-		return std::static_pointer_cast<object::Appointment>(findAppointment(id));
+		return std::static_pointer_cast<object::Appointment>(findAppointment(requestId, id));
 	});
+	promise.set_value(std::move(result));
 
-	return result;
+	return promise.get_future();
 }
 
-std::vector<std::shared_ptr<object::Task>> Query::getTasksById(std::vector<std::vector<uint8_t>>&& ids) const
+std::future<std::vector<std::shared_ptr<object::Task>>> Query::getTasksById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const
 {
+	std::promise<std::vector<std::shared_ptr<object::Task>>> promise;
 	std::vector<std::shared_ptr<object::Task>> result(ids.size());
 
 	std::transform(ids.cbegin(), ids.cend(), result.begin(),
-		[this](const std::vector<uint8_t>& id)
+		[this, requestId](const std::vector<uint8_t>& id)
 	{
-		return std::static_pointer_cast<object::Task>(findTask(id));
+		return std::static_pointer_cast<object::Task>(findTask(requestId, id));
 	});
+	promise.set_value(std::move(result));
 
-	return result;
+	return promise.get_future();
 }
 
-std::vector<std::shared_ptr<object::Folder>> Query::getUnreadCountsById(std::vector<std::vector<uint8_t>>&& ids) const
+std::future<std::vector<std::shared_ptr<object::Folder>>> Query::getUnreadCountsById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const
 {
+	std::promise<std::vector<std::shared_ptr<object::Folder>>> promise;
 	std::vector<std::shared_ptr<object::Folder>> result(ids.size());
 
 	std::transform(ids.cbegin(), ids.cend(), result.begin(),
-		[this](const std::vector<uint8_t>& id)
+		[this, requestId](const std::vector<uint8_t>& id)
 	{
-		return std::static_pointer_cast<object::Folder>(findUnreadCount(id));
+		return std::static_pointer_cast<object::Folder>(findUnreadCount(requestId, id));
 	});
+	promise.set_value(std::move(result));
 
-	return result;
+	return promise.get_future();
 }
 
 Mutation::Mutation(completeTaskMutation&& mutateCompleteTask)
@@ -307,9 +329,13 @@ Mutation::Mutation(completeTaskMutation&& mutateCompleteTask)
 {
 }
 
-std::shared_ptr<object::CompleteTaskPayload> Mutation::getCompleteTask(CompleteTaskInput&& input) const
+std::future<std::shared_ptr<object::CompleteTaskPayload>> Mutation::getCompleteTask(service::RequestId requestId, CompleteTaskInput&& input) const
 {
-	return _mutateCompleteTask(std::move(input));
+	std::promise<std::shared_ptr<object::CompleteTaskPayload>> promise;
+
+	promise.set_value(_mutateCompleteTask(std::move(input)));
+
+	return promise.get_future();
 }
 
 } /* namespace today */

--- a/Today.cpp
+++ b/Today.cpp
@@ -242,41 +242,47 @@ private:
 
 std::future<std::shared_ptr<object::AppointmentConnection>> Query::getAppointments(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
 {
-	loadAppointments();
+	auto spThis = shared_from_this();
+	return std::async(std::launch::async,
+		[this, spThis](service::RequestId requestIdWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<rapidjson::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<rapidjson::Value>&& beforeWrapped)
+	{
+		loadAppointments();
 
-	std::promise<std::shared_ptr<object::AppointmentConnection>> promise;
-	EdgeConstraints<Appointment, AppointmentConnection> constraints(requestId, _appointments);
-	auto connection = constraints(first.get(), after.get(), last.get(), before.get());
+		EdgeConstraints<Appointment, AppointmentConnection> constraints(requestIdWrapped, _appointments);
+		auto connection = constraints(firstWrapped.get(), afterWrapped.get(), lastWrapped.get(), beforeWrapped.get());
 
-	promise.set_value(std::static_pointer_cast<object::AppointmentConnection>(connection));
-
-	return promise.get_future();
+		return std::static_pointer_cast<object::AppointmentConnection>(connection);
+	}, requestId, std::move(first), std::move(after), std::move(last), std::move(before));
 }
 
 std::future<std::shared_ptr<object::TaskConnection>> Query::getTasks(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
 {
-	loadTasks();
+	auto spThis = shared_from_this();
+	return std::async(std::launch::async,
+		[this, spThis](service::RequestId requestIdWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<rapidjson::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<rapidjson::Value>&& beforeWrapped)
+	{
+		loadTasks();
 
-	std::promise<std::shared_ptr<object::TaskConnection>> promise;
-	EdgeConstraints<Task, TaskConnection> constraints(requestId, _tasks);
-	auto connection = constraints(first.get(), after.get(), last.get(), before.get());
+		EdgeConstraints<Task, TaskConnection> constraints(requestIdWrapped, _tasks);
+		auto connection = constraints(firstWrapped.get(), afterWrapped.get(), lastWrapped.get(), beforeWrapped.get());
 
-	promise.set_value(std::static_pointer_cast<object::TaskConnection>(connection));
-
-	return promise.get_future();
+		return std::static_pointer_cast<object::TaskConnection>(connection);
+	}, requestId, std::move(first), std::move(after), std::move(last), std::move(before));
 }
 
 std::future<std::shared_ptr<object::FolderConnection>> Query::getUnreadCounts(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
 {
-	loadUnreadCounts();
+	auto spThis = shared_from_this();
+	return std::async(std::launch::async,
+		[this, spThis](service::RequestId requestIdWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<rapidjson::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<rapidjson::Value>&& beforeWrapped)
+	{
+		loadUnreadCounts();
 
-	std::promise<std::shared_ptr<object::FolderConnection>> promise;
-	EdgeConstraints<Folder, FolderConnection> constraints(requestId, _unreadCounts);
-	auto connection = constraints(first.get(), after.get(), last.get(), before.get());
+		EdgeConstraints<Folder, FolderConnection> constraints(requestIdWrapped, _unreadCounts);
+		auto connection = constraints(firstWrapped.get(), afterWrapped.get(), lastWrapped.get(), beforeWrapped.get());
 
-	promise.set_value(std::static_pointer_cast<object::FolderConnection>(connection));
-
-	return promise.get_future();
+		return std::static_pointer_cast<object::FolderConnection>(connection);
+	}, requestId, std::move(first), std::move(after), std::move(last), std::move(before));
 }
 
 std::future<std::vector<std::shared_ptr<object::Appointment>>> Query::getAppointmentsById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const

--- a/samples/IntrospectionSchema.h
+++ b/samples/IntrospectionSchema.h
@@ -65,20 +65,20 @@ protected:
 	__Schema();
 
 public:
-	virtual std::vector<std::shared_ptr<__Type>> getTypes() const = 0;
-	virtual std::shared_ptr<__Type> getQueryType() const = 0;
-	virtual std::shared_ptr<__Type> getMutationType() const = 0;
-	virtual std::shared_ptr<__Type> getSubscriptionType() const = 0;
-	virtual std::vector<std::shared_ptr<__Directive>> getDirectives() const = 0;
+	virtual std::future<std::vector<std::shared_ptr<__Type>>> getTypes(service::RequestId requestId) const = 0;
+	virtual std::future<std::shared_ptr<__Type>> getQueryType(service::RequestId requestId) const = 0;
+	virtual std::future<std::shared_ptr<__Type>> getMutationType(service::RequestId requestId) const = 0;
+	virtual std::future<std::shared_ptr<__Type>> getSubscriptionType(service::RequestId requestId) const = 0;
+	virtual std::future<std::vector<std::shared_ptr<__Directive>>> getDirectives(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolveTypes(service::ResolverParams&& params);
-	rapidjson::Value resolveQueryType(service::ResolverParams&& params);
-	rapidjson::Value resolveMutationType(service::ResolverParams&& params);
-	rapidjson::Value resolveSubscriptionType(service::ResolverParams&& params);
-	rapidjson::Value resolveDirectives(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveTypes(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveQueryType(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveMutationType(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveSubscriptionType(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveDirectives(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class __Type
@@ -88,28 +88,28 @@ protected:
 	__Type();
 
 public:
-	virtual __TypeKind getKind() const = 0;
-	virtual std::unique_ptr<std::string> getName() const = 0;
-	virtual std::unique_ptr<std::string> getDescription() const = 0;
-	virtual std::unique_ptr<std::vector<std::shared_ptr<__Field>>> getFields(std::unique_ptr<bool>&& includeDeprecated) const = 0;
-	virtual std::unique_ptr<std::vector<std::shared_ptr<__Type>>> getInterfaces() const = 0;
-	virtual std::unique_ptr<std::vector<std::shared_ptr<__Type>>> getPossibleTypes() const = 0;
-	virtual std::unique_ptr<std::vector<std::shared_ptr<__EnumValue>>> getEnumValues(std::unique_ptr<bool>&& includeDeprecated) const = 0;
-	virtual std::unique_ptr<std::vector<std::shared_ptr<__InputValue>>> getInputFields() const = 0;
-	virtual std::shared_ptr<__Type> getOfType() const = 0;
+	virtual std::future<__TypeKind> getKind(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::string>> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Field>>>> getFields(service::RequestId requestId, std::unique_ptr<bool>&& includeDeprecated) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Type>>>> getInterfaces(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Type>>>> getPossibleTypes(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__EnumValue>>>> getEnumValues(service::RequestId requestId, std::unique_ptr<bool>&& includeDeprecated) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__InputValue>>>> getInputFields(service::RequestId requestId) const = 0;
+	virtual std::future<std::shared_ptr<__Type>> getOfType(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolveKind(service::ResolverParams&& params);
-	rapidjson::Value resolveName(service::ResolverParams&& params);
-	rapidjson::Value resolveDescription(service::ResolverParams&& params);
-	rapidjson::Value resolveFields(service::ResolverParams&& params);
-	rapidjson::Value resolveInterfaces(service::ResolverParams&& params);
-	rapidjson::Value resolvePossibleTypes(service::ResolverParams&& params);
-	rapidjson::Value resolveEnumValues(service::ResolverParams&& params);
-	rapidjson::Value resolveInputFields(service::ResolverParams&& params);
-	rapidjson::Value resolveOfType(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveKind(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveName(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveDescription(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveFields(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveInterfaces(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolvePossibleTypes(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveEnumValues(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveInputFields(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveOfType(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class __Field
@@ -119,22 +119,22 @@ protected:
 	__Field();
 
 public:
-	virtual std::string getName() const = 0;
-	virtual std::unique_ptr<std::string> getDescription() const = 0;
-	virtual std::vector<std::shared_ptr<__InputValue>> getArgs() const = 0;
-	virtual std::shared_ptr<__Type> getType() const = 0;
-	virtual bool getIsDeprecated() const = 0;
-	virtual std::unique_ptr<std::string> getDeprecationReason() const = 0;
+	virtual std::future<std::string> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<std::vector<std::shared_ptr<__InputValue>>> getArgs(service::RequestId requestId) const = 0;
+	virtual std::future<std::shared_ptr<__Type>> getType(service::RequestId requestId) const = 0;
+	virtual std::future<bool> getIsDeprecated(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::string>> getDeprecationReason(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolveName(service::ResolverParams&& params);
-	rapidjson::Value resolveDescription(service::ResolverParams&& params);
-	rapidjson::Value resolveArgs(service::ResolverParams&& params);
-	rapidjson::Value resolveType(service::ResolverParams&& params);
-	rapidjson::Value resolveIsDeprecated(service::ResolverParams&& params);
-	rapidjson::Value resolveDeprecationReason(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveName(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveDescription(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveArgs(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveType(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveIsDeprecated(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveDeprecationReason(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class __InputValue
@@ -144,18 +144,18 @@ protected:
 	__InputValue();
 
 public:
-	virtual std::string getName() const = 0;
-	virtual std::unique_ptr<std::string> getDescription() const = 0;
-	virtual std::shared_ptr<__Type> getType() const = 0;
-	virtual std::unique_ptr<std::string> getDefaultValue() const = 0;
+	virtual std::future<std::string> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<std::shared_ptr<__Type>> getType(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::string>> getDefaultValue(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolveName(service::ResolverParams&& params);
-	rapidjson::Value resolveDescription(service::ResolverParams&& params);
-	rapidjson::Value resolveType(service::ResolverParams&& params);
-	rapidjson::Value resolveDefaultValue(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveName(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveDescription(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveType(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveDefaultValue(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class __EnumValue
@@ -165,18 +165,18 @@ protected:
 	__EnumValue();
 
 public:
-	virtual std::string getName() const = 0;
-	virtual std::unique_ptr<std::string> getDescription() const = 0;
-	virtual bool getIsDeprecated() const = 0;
-	virtual std::unique_ptr<std::string> getDeprecationReason() const = 0;
+	virtual std::future<std::string> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<bool> getIsDeprecated(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::string>> getDeprecationReason(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolveName(service::ResolverParams&& params);
-	rapidjson::Value resolveDescription(service::ResolverParams&& params);
-	rapidjson::Value resolveIsDeprecated(service::ResolverParams&& params);
-	rapidjson::Value resolveDeprecationReason(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveName(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveDescription(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveIsDeprecated(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveDeprecationReason(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class __Directive
@@ -186,18 +186,18 @@ protected:
 	__Directive();
 
 public:
-	virtual std::string getName() const = 0;
-	virtual std::unique_ptr<std::string> getDescription() const = 0;
-	virtual std::vector<__DirectiveLocation> getLocations() const = 0;
-	virtual std::vector<std::shared_ptr<__InputValue>> getArgs() const = 0;
+	virtual std::future<std::string> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<std::vector<__DirectiveLocation>> getLocations(service::RequestId requestId) const = 0;
+	virtual std::future<std::vector<std::shared_ptr<__InputValue>>> getArgs(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolveName(service::ResolverParams&& params);
-	rapidjson::Value resolveDescription(service::ResolverParams&& params);
-	rapidjson::Value resolveLocations(service::ResolverParams&& params);
-	rapidjson::Value resolveArgs(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveName(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveDescription(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveLocations(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveArgs(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 } /* namespace object */

--- a/samples/TodaySchema.h
+++ b/samples/TodaySchema.h
@@ -36,7 +36,7 @@ struct CompleteTaskInput
 
 struct Node
 {
-	virtual std::vector<uint8_t> getId() const = 0;
+	virtual std::future<std::vector<uint8_t>> getId(service::RequestId requestId) const = 0;
 };
 
 namespace object {
@@ -63,26 +63,26 @@ protected:
 	Query();
 
 public:
-	virtual std::shared_ptr<service::Object> getNode(std::vector<uint8_t>&& id) const = 0;
-	virtual std::shared_ptr<AppointmentConnection> getAppointments(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const = 0;
-	virtual std::shared_ptr<TaskConnection> getTasks(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const = 0;
-	virtual std::shared_ptr<FolderConnection> getUnreadCounts(std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const = 0;
-	virtual std::vector<std::shared_ptr<Appointment>> getAppointmentsById(std::vector<std::vector<uint8_t>>&& ids) const = 0;
-	virtual std::vector<std::shared_ptr<Task>> getTasksById(std::vector<std::vector<uint8_t>>&& ids) const = 0;
-	virtual std::vector<std::shared_ptr<Folder>> getUnreadCountsById(std::vector<std::vector<uint8_t>>&& ids) const = 0;
+	virtual std::future<std::shared_ptr<service::Object>> getNode(service::RequestId requestId, std::vector<uint8_t>&& id) const = 0;
+	virtual std::future<std::shared_ptr<AppointmentConnection>> getAppointments(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const = 0;
+	virtual std::future<std::shared_ptr<TaskConnection>> getTasks(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const = 0;
+	virtual std::future<std::shared_ptr<FolderConnection>> getUnreadCounts(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const = 0;
+	virtual std::future<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const = 0;
+	virtual std::future<std::vector<std::shared_ptr<Task>>> getTasksById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const = 0;
+	virtual std::future<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const = 0;
 
 private:
-	rapidjson::Value resolveNode(service::ResolverParams&& params);
-	rapidjson::Value resolveAppointments(service::ResolverParams&& params);
-	rapidjson::Value resolveTasks(service::ResolverParams&& params);
-	rapidjson::Value resolveUnreadCounts(service::ResolverParams&& params);
-	rapidjson::Value resolveAppointmentsById(service::ResolverParams&& params);
-	rapidjson::Value resolveTasksById(service::ResolverParams&& params);
-	rapidjson::Value resolveUnreadCountsById(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveNode(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveAppointments(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveTasks(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveUnreadCounts(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveAppointmentsById(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveTasksById(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveUnreadCountsById(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
-	rapidjson::Value resolve__schema(service::ResolverParams&& params);
-	rapidjson::Value resolve__type(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__schema(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__type(service::ResolverParams&& params);
 
 	std::shared_ptr<introspection::Schema> _schema;
 };
@@ -94,14 +94,14 @@ protected:
 	PageInfo();
 
 public:
-	virtual bool getHasNextPage() const = 0;
-	virtual bool getHasPreviousPage() const = 0;
+	virtual std::future<bool> getHasNextPage(service::RequestId requestId) const = 0;
+	virtual std::future<bool> getHasPreviousPage(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolveHasNextPage(service::ResolverParams&& params);
-	rapidjson::Value resolveHasPreviousPage(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveHasNextPage(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveHasPreviousPage(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class AppointmentEdge
@@ -111,14 +111,14 @@ protected:
 	AppointmentEdge();
 
 public:
-	virtual std::shared_ptr<Appointment> getNode() const = 0;
-	virtual rapidjson::Value getCursor(rapidjson::Document::AllocatorType& allocator) const = 0;
+	virtual std::future<std::shared_ptr<Appointment>> getNode(service::RequestId requestId) const = 0;
+	virtual std::future<rapidjson::Value> getCursor(service::RequestId requestId, rapidjson::Document::AllocatorType& allocator) const = 0;
 
 private:
-	rapidjson::Value resolveNode(service::ResolverParams&& params);
-	rapidjson::Value resolveCursor(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveNode(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveCursor(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class AppointmentConnection
@@ -128,14 +128,14 @@ protected:
 	AppointmentConnection();
 
 public:
-	virtual std::shared_ptr<PageInfo> getPageInfo() const = 0;
-	virtual std::unique_ptr<std::vector<std::shared_ptr<AppointmentEdge>>> getEdges() const = 0;
+	virtual std::future<std::shared_ptr<PageInfo>> getPageInfo(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolvePageInfo(service::ResolverParams&& params);
-	rapidjson::Value resolveEdges(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolvePageInfo(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveEdges(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class TaskEdge
@@ -145,14 +145,14 @@ protected:
 	TaskEdge();
 
 public:
-	virtual std::shared_ptr<Task> getNode() const = 0;
-	virtual rapidjson::Value getCursor(rapidjson::Document::AllocatorType& allocator) const = 0;
+	virtual std::future<std::shared_ptr<Task>> getNode(service::RequestId requestId) const = 0;
+	virtual std::future<rapidjson::Value> getCursor(service::RequestId requestId, rapidjson::Document::AllocatorType& allocator) const = 0;
 
 private:
-	rapidjson::Value resolveNode(service::ResolverParams&& params);
-	rapidjson::Value resolveCursor(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveNode(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveCursor(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class TaskConnection
@@ -162,14 +162,14 @@ protected:
 	TaskConnection();
 
 public:
-	virtual std::shared_ptr<PageInfo> getPageInfo() const = 0;
-	virtual std::unique_ptr<std::vector<std::shared_ptr<TaskEdge>>> getEdges() const = 0;
+	virtual std::future<std::shared_ptr<PageInfo>> getPageInfo(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolvePageInfo(service::ResolverParams&& params);
-	rapidjson::Value resolveEdges(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolvePageInfo(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveEdges(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class FolderEdge
@@ -179,14 +179,14 @@ protected:
 	FolderEdge();
 
 public:
-	virtual std::shared_ptr<Folder> getNode() const = 0;
-	virtual rapidjson::Value getCursor(rapidjson::Document::AllocatorType& allocator) const = 0;
+	virtual std::future<std::shared_ptr<Folder>> getNode(service::RequestId requestId) const = 0;
+	virtual std::future<rapidjson::Value> getCursor(service::RequestId requestId, rapidjson::Document::AllocatorType& allocator) const = 0;
 
 private:
-	rapidjson::Value resolveNode(service::ResolverParams&& params);
-	rapidjson::Value resolveCursor(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveNode(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveCursor(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class FolderConnection
@@ -196,14 +196,14 @@ protected:
 	FolderConnection();
 
 public:
-	virtual std::shared_ptr<PageInfo> getPageInfo() const = 0;
-	virtual std::unique_ptr<std::vector<std::shared_ptr<FolderEdge>>> getEdges() const = 0;
+	virtual std::future<std::shared_ptr<PageInfo>> getPageInfo(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolvePageInfo(service::ResolverParams&& params);
-	rapidjson::Value resolveEdges(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolvePageInfo(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveEdges(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class CompleteTaskPayload
@@ -213,14 +213,14 @@ protected:
 	CompleteTaskPayload();
 
 public:
-	virtual std::shared_ptr<Task> getTask() const = 0;
-	virtual std::unique_ptr<std::string> getClientMutationId() const = 0;
+	virtual std::future<std::shared_ptr<Task>> getTask(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::string>> getClientMutationId(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolveTask(service::ResolverParams&& params);
-	rapidjson::Value resolveClientMutationId(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveTask(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveClientMutationId(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class Mutation
@@ -230,12 +230,12 @@ protected:
 	Mutation();
 
 public:
-	virtual std::shared_ptr<CompleteTaskPayload> getCompleteTask(CompleteTaskInput&& input) const = 0;
+	virtual std::future<std::shared_ptr<CompleteTaskPayload>> getCompleteTask(service::RequestId requestId, CompleteTaskInput&& input) const = 0;
 
 private:
-	rapidjson::Value resolveCompleteTask(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveCompleteTask(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class Subscription
@@ -245,12 +245,12 @@ protected:
 	Subscription();
 
 public:
-	virtual std::shared_ptr<Appointment> getNextAppointmentChange() const = 0;
+	virtual std::future<std::shared_ptr<Appointment>> getNextAppointmentChange(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolveNextAppointmentChange(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveNextAppointmentChange(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class Appointment
@@ -261,17 +261,17 @@ protected:
 	Appointment();
 
 public:
-	virtual std::unique_ptr<rapidjson::Value> getWhen(rapidjson::Document::AllocatorType& allocator) const = 0;
-	virtual std::unique_ptr<std::string> getSubject() const = 0;
-	virtual bool getIsNow() const = 0;
+	virtual std::future<std::unique_ptr<rapidjson::Value>> getWhen(service::RequestId requestId, rapidjson::Document::AllocatorType& allocator) const = 0;
+	virtual std::future<std::unique_ptr<std::string>> getSubject(service::RequestId requestId) const = 0;
+	virtual std::future<bool> getIsNow(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolveId(service::ResolverParams&& params);
-	rapidjson::Value resolveWhen(service::ResolverParams&& params);
-	rapidjson::Value resolveSubject(service::ResolverParams&& params);
-	rapidjson::Value resolveIsNow(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveId(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveWhen(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveSubject(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveIsNow(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class Task
@@ -282,15 +282,15 @@ protected:
 	Task();
 
 public:
-	virtual std::unique_ptr<std::string> getTitle() const = 0;
-	virtual bool getIsComplete() const = 0;
+	virtual std::future<std::unique_ptr<std::string>> getTitle(service::RequestId requestId) const = 0;
+	virtual std::future<bool> getIsComplete(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolveId(service::ResolverParams&& params);
-	rapidjson::Value resolveTitle(service::ResolverParams&& params);
-	rapidjson::Value resolveIsComplete(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveId(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveTitle(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveIsComplete(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class Folder
@@ -301,15 +301,15 @@ protected:
 	Folder();
 
 public:
-	virtual std::unique_ptr<std::string> getName() const = 0;
-	virtual int getUnreadCount() const = 0;
+	virtual std::future<std::unique_ptr<std::string>> getName(service::RequestId requestId) const = 0;
+	virtual std::future<int> getUnreadCount(service::RequestId requestId) const = 0;
 
 private:
-	rapidjson::Value resolveId(service::ResolverParams&& params);
-	rapidjson::Value resolveName(service::ResolverParams&& params);
-	rapidjson::Value resolveUnreadCount(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveId(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveName(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolveUnreadCount(service::ResolverParams&& params);
 
-	rapidjson::Value resolve__typename(service::ResolverParams&& params);
+	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 } /* namespace object */

--- a/test_today.cpp
+++ b/test_today.cpp
@@ -96,7 +96,7 @@ int main(int argc, char** argv)
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 		const rapidjson::Document variables(rapidjson::Type::kObjectType);
 		
-		service->resolve(*ast, ((argc > 2) ? argv[2] : ""), variables.GetObject()).Accept(writer);
+		service->resolve(0, *ast, ((argc > 2) ? argv[2] : ""), variables.GetObject()).get().Accept(writer);
 		std::cout << buffer.GetString() << std::endl;
 	}
 	catch (const std::runtime_error& ex)

--- a/tests.cpp
+++ b/tests.cpp
@@ -123,7 +123,7 @@ TEST_F(TodayServiceCase, QueryEverything)
 			}
 		})"_graphql;
 	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	auto result = _service->resolve(*ast->root, "Everything", variables.GetObject());
+	auto result = _service->resolve(0, *ast->root, "Everything", variables.GetObject()).get();
 	auto& allocator = result.GetAllocator();
 	EXPECT_EQ(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_EQ(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
@@ -198,7 +198,7 @@ TEST_F(TodayServiceCase, QueryAppointments)
 			}
 		})"_graphql;
 	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	auto result = _service->resolve(*ast->root, "", variables.GetObject());
+	auto result = _service->resolve(1, *ast->root, "", variables.GetObject()).get();
 	auto& allocator = result.GetAllocator();
 	EXPECT_EQ(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_GE(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
@@ -254,7 +254,7 @@ TEST_F(TodayServiceCase, QueryTasks)
 			}
 		})gql"_graphql;
 	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	auto result = _service->resolve(*ast->root, "", variables.GetObject());
+	auto result = _service->resolve(2, *ast->root, "", variables.GetObject()).get();
 	auto& allocator = result.GetAllocator();
 	EXPECT_GE(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_EQ(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
@@ -309,7 +309,7 @@ TEST_F(TodayServiceCase, QueryUnreadCounts)
 			}
 		})"_graphql;
 	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	auto result = _service->resolve(*ast->root, "", variables.GetObject());
+	auto result = _service->resolve(3, *ast->root, "", variables.GetObject()).get();
 	auto& allocator = result.GetAllocator();
 	EXPECT_GE(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_GE(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
@@ -363,7 +363,7 @@ TEST_F(TodayServiceCase, MutateCompleteTask)
 			}
 		})"_graphql;
 	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	auto result = _service->resolve(*ast->root, "", variables.GetObject());
+	auto result = _service->resolve(4, *ast->root, "", variables.GetObject()).get();
 	auto& allocator = result.GetAllocator();
 
 	try
@@ -439,7 +439,7 @@ TEST_F(TodayServiceCase, Introspection)
 			}
 		})"_graphql;
 	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	auto result = _service->resolve(*ast->root, "", variables.GetObject());
+	auto result = _service->resolve(5, *ast->root, "", variables.GetObject()).get();
 	auto& allocator = result.GetAllocator();
 
 	try


### PR DESCRIPTION
Between using `std::future<>` and adding the `requestId` parameter for correlation, this should address the asynch and optimization suggestions from #11. The suggestion to abstract the results away from JSON is still pending.