### PR TITLE
Refactor responses into a non-JSON type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,11 @@ find_package(Threads MODULE REQUIRED)
 
 find_package(pegtl CONFIG REQUIRED)
 
-add_executable(schemagen GraphQLTree.cpp SchemaGenerator.cpp)
+add_executable(schemagen
+  GraphQLTree.cpp
+  GraphQLResponse.cpp
+  SchemaGenerator.cpp)
 target_link_libraries(schemagen PRIVATE taocpp::pegtl)
-target_include_directories(schemagen SYSTEM PUBLIC ${RAPIDJSON_INCLUDE_DIRS})
 target_include_directories(schemagen PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 set_property(TARGET schemagen PROPERTY CXX_STANDARD 11)
 
@@ -26,16 +28,14 @@ add_custom_command(
   COMMENT "Generating IntrospectionSchema files"
 )
 
-find_package(RapidJSON CONFIG REQUIRED)
-
 add_library(graphqlservice
   GraphQLTree.cpp
+  GraphQLResponse.cpp
   GraphQLService.cpp
   Introspection.cpp
   IntrospectionSchema.cpp)
 target_link_libraries(graphqlservice PRIVATE taocpp::pegtl)
 target_link_libraries(graphqlservice PUBLIC ${CMAKE_THREAD_LIBS_INIT})
-target_include_directories(graphqlservice SYSTEM PUBLIC ${RAPIDJSON_INCLUDE_DIRS})
 target_include_directories(graphqlservice SYSTEM INTERFACE $<INSTALL_INTERFACE:include>)
 target_include_directories(graphqlservice PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 set_property(TARGET graphqlservice PROPERTY CXX_STANDARD 11)
@@ -57,21 +57,22 @@ if(BUILD_TESTS OR UPDATE_SAMPLES)
   )
 
   if(BUILD_TESTS)
+    find_package(RapidJSON CONFIG REQUIRED)
+
     add_library(todaygraphql
        ${CMAKE_BINARY_DIR}/TodaySchema.cpp
-      Today.cpp)
-    target_link_libraries(todaygraphql
+      Today.cpp
+	  JSONResponse.cpp)
+    target_link_libraries(todaygraphql PUBLIC
       graphqlservice)
-    target_include_directories(todaygraphql SYSTEM PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
+    target_include_directories(todaygraphql SYSTEM PUBLIC ${RAPIDJSON_INCLUDE_DIRS})
     target_include_directories(todaygraphql PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
     set_property(TARGET todaygraphql PROPERTY CXX_STANDARD 11)
 
     add_executable(test_today
       test_today.cpp)
-    target_link_libraries(test_today
-      graphqlservice
+    target_link_libraries(test_today PRIVATE
       todaygraphql)
-    target_include_directories(test_today SYSTEM PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
     target_include_directories(test_today PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
     set_property(TARGET test_today PROPERTY CXX_STANDARD 11)
 
@@ -80,12 +81,10 @@ if(BUILD_TESTS OR UPDATE_SAMPLES)
 
     add_executable(tests
       tests.cpp)
-    target_link_libraries(tests
-      graphqlservice
+    target_link_libraries(tests PRIVATE
       todaygraphql
       GTest::GTest
       GTest::Main)
-    target_include_directories(tests SYSTEM PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
     target_include_directories(tests PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
     set_property(TARGET tests PROPERTY CXX_STANDARD 11)
 
@@ -122,9 +121,11 @@ install(TARGETS schemagen
 
 install(FILES
   GraphQLTree.h
+  GraphQLResponse.h
   GraphQLService.h
   Introspection.h
   ${CMAKE_BINARY_DIR}/IntrospectionSchema.h
+  JSONResponse.h
   DESTINATION include/graphqlservice
   CONFIGURATIONS Release)
 

--- a/GraphQLResponse.cpp
+++ b/GraphQLResponse.cpp
@@ -1,0 +1,280 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "GraphQLResponse.h"
+
+#include <stdexcept>
+
+namespace facebook {
+namespace graphql {
+namespace response {
+
+Value::Value(Type type /*= Type::Null*/)
+	: _type(type)
+{
+	switch (type)
+	{
+		case Type::Map:
+			_members.reset(new std::unordered_map<std::string, size_t>());
+			_map.reset(new MapType());
+			break;
+
+		case Type::List:
+			_list.reset(new ListType());
+			break;
+
+		case Type::String:
+		case Type::EnumValue:
+			_string.reset(new StringType());
+			break;
+
+		case Type::Boolean:
+			_boolean = false;
+			break;
+
+		case Type::Int:
+			_int = 0;
+			break;
+
+		case Type::Float:
+			_float = 0;
+			break;
+
+		case Type::Scalar:
+			_scalar.reset(new Value());
+			break;
+
+		default:
+			break;
+	}
+}
+
+Value::Value(StringType&& value)
+	: _type(Type::String)
+	, _string(new StringType(std::move(value)))
+{
+}
+
+Value::Value(BooleanType value)
+	: _type(Type::Boolean)
+	, _boolean(value)
+{
+}
+
+Value::Value(IntType value)
+	: _type(Type::Int)
+	, _int(value)
+{
+}
+
+Value::Value(FloatType value)
+	: _type(Type::Float)
+	, _float(value)
+{
+}
+
+Value::Value(Value&& other)
+	: _type(other._type)
+	, _members(std::move(other._members))
+	, _map(std::move(other._map))
+	, _list(std::move(other._list))
+	, _string(std::move(other._string))
+	, _scalar(std::move(other._scalar))
+{
+	switch (_type)
+	{
+		case Type::Boolean:
+			_boolean = other._boolean;
+			break;
+
+		case Type::Int:
+			_int = other._int;
+			break;
+
+		case Type::Float:
+			_float = other._float;
+			break;
+
+		default:
+			break;
+	}
+}
+
+Value::Value(const Value& other)
+	: _type(other._type)
+{
+	switch (_type)
+	{
+		case Type::Map:
+			_members.reset(new std::unordered_map<std::string, size_t>(*other._members));
+			_map.reset(new MapType(*other._map));
+			break;
+
+		case Type::List:
+			_list.reset(new ListType(*other._list));
+			break;
+
+		case Type::String:
+		case Type::EnumValue:
+			_string.reset(new StringType(*other._string));
+			break;
+
+		case Type::Boolean:
+			_boolean = other._boolean;
+			break;
+
+		case Type::Int:
+			_int = other._int;
+			break;
+
+		case Type::Float:
+			_float = other._float;
+			break;
+
+		case Type::Scalar:
+			_scalar.reset(new Value(*other._scalar));
+			break;
+
+		default:
+			break;
+	}
+}
+
+Value& Value::operator=(Value&& rhs)
+{
+	const_cast<Type&>(_type) = rhs._type;
+	const_cast<Type&>(rhs._type) = Type::Null;
+
+	_members = std::move(rhs._members);
+	_map = std::move(rhs._map);
+	_list = std::move(rhs._list);
+	_string = std::move(rhs._string);
+	_scalar = std::move(rhs._scalar);
+
+	switch (_type)
+	{
+		case Type::Boolean:
+			_boolean = rhs._boolean;
+			break;
+
+		case Type::Int:
+			_int = rhs._int;
+			break;
+
+		case Type::Float:
+			_float = rhs._float;
+			break;
+
+		default:
+			break;
+	}
+
+	return *this;
+}
+
+Value::Type Value::type() const
+{
+	return _type;
+}
+
+void Value::reserve(size_t count)
+{
+	switch (_type)
+	{
+		case Type::Map:
+			_members->reserve(count);
+			_map->reserve(count);
+			break;
+
+		case Type::List:
+			_list->reserve(count);
+			break;
+
+		default:
+			throw std::logic_error("Invalid call to Value::reserve");
+	}
+}
+
+size_t Value::size() const
+{
+	switch (_type)
+	{
+		case Type::Map:
+			return _map->size();
+
+		case Type::List:
+			return _list->size();
+
+		default:
+			throw std::logic_error("Invalid call to Value::size");
+	}
+}
+
+void Value::emplace_back(std::string&& name, Value&& value)
+{
+	if (_type != Type::Map)
+	{
+		throw std::logic_error("Invalid call to Value::emplace_back for MapType");
+	}
+
+	if (_members->find(name) != _members->cend())
+	{
+		throw std::runtime_error("Duplicate Map member");
+	}
+
+	_members->insert({ name, _map->size() });
+	_map->emplace_back(std::make_pair(std::move(name), std::move(value)));
+}
+
+Value::MapType::const_iterator Value::find(const std::string& name) const
+{
+	if (_type != Type::Map)
+	{
+		throw std::logic_error("Invalid call to Value::find for MapType");
+	}
+
+	const auto itr = _members->find(name);
+
+	if (itr == _members->cend())
+	{
+		return _map->cend();
+	}
+
+	return _map->cbegin() + itr->second;
+}
+
+const Value& Value::operator[](const std::string& name) const
+{
+	const auto itr = find(name);
+
+	if (itr == _map->cend())
+	{
+		throw std::runtime_error("Missing Map member");
+	}
+
+	return itr->second;
+}
+
+void Value::emplace_back(Value&& value)
+{
+	if (_type != Type::List)
+	{
+		throw std::logic_error("Invalid call to Value::emplace_back for ListType");
+	}
+
+	_list->emplace_back(std::move(value));
+}
+
+const Value& Value::operator[](size_t index) const
+{
+	if (_type != Type::List)
+	{
+		throw std::logic_error("Invalid call to Value::emplace_back for ListType");
+	}
+
+	return _list->at(index);
+}
+
+} /* namespace response */
+} /* namespace graphql */
+} /* namespace facebook */

--- a/GraphQLResponse.cpp
+++ b/GraphQLResponse.cpp
@@ -172,7 +172,7 @@ Value& Value::operator=(Value&& rhs)
 	return *this;
 }
 
-Value::Type Value::type() const
+Type Value::type() const
 {
 	return _type;
 }
@@ -226,7 +226,7 @@ void Value::emplace_back(std::string&& name, Value&& value)
 	_map->emplace_back(std::make_pair(std::move(name), std::move(value)));
 }
 
-Value::MapType::const_iterator Value::find(const std::string& name) const
+MapType::const_iterator Value::find(const std::string& name) const
 {
 	if (_type != Type::Map)
 	{
@@ -276,7 +276,7 @@ const Value& Value::operator[](size_t index) const
 }
 
 template <>
-void Value::set<Value::StringType>(StringType&& value)
+void Value::set<StringType>(StringType&& value)
 {
 	if (_type != Type::String
 		&& _type != Type::EnumValue)
@@ -288,7 +288,7 @@ void Value::set<Value::StringType>(StringType&& value)
 }
 
 template <>
-void Value::set<Value::BooleanType>(BooleanType&& value)
+void Value::set<BooleanType>(BooleanType&& value)
 {
 	if (_type != Type::Boolean)
 	{
@@ -299,7 +299,7 @@ void Value::set<Value::BooleanType>(BooleanType&& value)
 }
 
 template <>
-void Value::set<Value::IntType>(IntType&& value)
+void Value::set<IntType>(IntType&& value)
 {
 	if (_type != Type::Int)
 	{
@@ -310,7 +310,7 @@ void Value::set<Value::IntType>(IntType&& value)
 }
 
 template <>
-void Value::set<Value::FloatType>(FloatType&& value)
+void Value::set<FloatType>(FloatType&& value)
 {
 	if (_type != Type::Float)
 	{
@@ -321,7 +321,7 @@ void Value::set<Value::FloatType>(FloatType&& value)
 }
 
 template <>
-void Value::set<Value::ScalarType>(ScalarType&& value)
+void Value::set<ScalarType>(ScalarType&& value)
 {
 	if (_type != Type::Scalar)
 	{
@@ -332,7 +332,7 @@ void Value::set<Value::ScalarType>(ScalarType&& value)
 }
 
 template <>
-const Value::MapType& Value::get<const Value::MapType&>() const
+const MapType& Value::get<const MapType&>() const
 {
 	if (_type != Type::Map)
 	{
@@ -343,7 +343,7 @@ const Value::MapType& Value::get<const Value::MapType&>() const
 }
 
 template <>
-const Value::ListType& Value::get<const Value::ListType&>() const
+const ListType& Value::get<const ListType&>() const
 {
 	if (_type != Type::List)
 	{
@@ -354,7 +354,7 @@ const Value::ListType& Value::get<const Value::ListType&>() const
 }
 
 template <>
-const Value::StringType& Value::get<const Value::StringType&>() const
+const StringType& Value::get<const StringType&>() const
 {
 	if (_type != Type::String
 		&& _type != Type::EnumValue)
@@ -366,7 +366,7 @@ const Value::StringType& Value::get<const Value::StringType&>() const
 }
 
 template <>
-Value::BooleanType Value::get<Value::BooleanType>() const
+BooleanType Value::get<BooleanType>() const
 {
 	if (_type != Type::Boolean)
 	{
@@ -377,7 +377,7 @@ Value::BooleanType Value::get<Value::BooleanType>() const
 }
 
 template <>
-Value::IntType Value::get<Value::IntType>() const
+IntType Value::get<IntType>() const
 {
 	if (_type != Type::Int)
 	{
@@ -388,7 +388,7 @@ Value::IntType Value::get<Value::IntType>() const
 }
 
 template <>
-Value::FloatType Value::get<Value::FloatType>() const
+FloatType Value::get<FloatType>() const
 {
 	if (_type != Type::Float)
 	{
@@ -399,7 +399,7 @@ Value::FloatType Value::get<Value::FloatType>() const
 }
 
 template <>
-const Value::ScalarType& Value::get<const Value::ScalarType&>() const
+const ScalarType& Value::get<const ScalarType&>() const
 {
 	if (_type != Type::Scalar)
 	{
@@ -410,7 +410,7 @@ const Value::ScalarType& Value::get<const Value::ScalarType&>() const
 }
 
 template <>
-Value::MapType Value::release<Value::MapType>()
+MapType Value::release<MapType>()
 {
 	if (_type != Type::Map)
 	{
@@ -425,7 +425,7 @@ Value::MapType Value::release<Value::MapType>()
 }
 
 template <>
-Value::ListType Value::release<Value::ListType>()
+ListType Value::release<ListType>()
 {
 	if (_type != Type::List)
 	{
@@ -438,7 +438,7 @@ Value::ListType Value::release<Value::ListType>()
 }
 
 template <>
-Value::StringType Value::release<Value::StringType>()
+StringType Value::release<StringType>()
 {
 	if (_type != Type::String
 		&& _type != Type::EnumValue)
@@ -452,7 +452,7 @@ Value::StringType Value::release<Value::StringType>()
 }
 
 template <>
-Value::ScalarType Value::release<Value::ScalarType>()
+ScalarType Value::release<ScalarType>()
 {
 	if (_type != Type::Scalar)
 	{

--- a/GraphQLResponse.cpp
+++ b/GraphQLResponse.cpp
@@ -275,6 +275,195 @@ const Value& Value::operator[](size_t index) const
 	return _list->at(index);
 }
 
+template <>
+void Value::set<Value::StringType>(StringType&& value)
+{
+	if (_type != Type::String
+		&& _type != Type::EnumValue)
+	{
+		throw std::logic_error("Invalid call to Value::set for StringType");
+	}
+
+	*_string = std::move(value);
+}
+
+template <>
+void Value::set<Value::BooleanType>(BooleanType&& value)
+{
+	if (_type != Type::Boolean)
+	{
+		throw std::logic_error("Invalid call to Value::set for BooleanType");
+	}
+
+	_boolean = value;
+}
+
+template <>
+void Value::set<Value::IntType>(IntType&& value)
+{
+	if (_type != Type::Int)
+	{
+		throw std::logic_error("Invalid call to Value::set for IntType");
+	}
+
+	_int = value;
+}
+
+template <>
+void Value::set<Value::FloatType>(FloatType&& value)
+{
+	if (_type != Type::Float)
+	{
+		throw std::logic_error("Invalid call to Value::set for FloatType");
+	}
+
+	_float = value;
+}
+
+template <>
+void Value::set<Value::ScalarType>(ScalarType&& value)
+{
+	if (_type != Type::Scalar)
+	{
+		throw std::logic_error("Invalid call to Value::set for ScalarType");
+	}
+
+	*_scalar = std::move(value);
+}
+
+template <>
+const Value::MapType& Value::get<const Value::MapType&>() const
+{
+	if (_type != Type::Map)
+	{
+		throw std::logic_error("Invalid call to Value::get for MapType");
+	}
+
+	return *_map;
+}
+
+template <>
+const Value::ListType& Value::get<const Value::ListType&>() const
+{
+	if (_type != Type::List)
+	{
+		throw std::logic_error("Invalid call to Value::get for ListType");
+	}
+
+	return *_list;
+}
+
+template <>
+const Value::StringType& Value::get<const Value::StringType&>() const
+{
+	if (_type != Type::String
+		&& _type != Type::EnumValue)
+	{
+		throw std::logic_error("Invalid call to Value::get for StringType");
+	}
+
+	return *_string;
+}
+
+template <>
+Value::BooleanType Value::get<Value::BooleanType>() const
+{
+	if (_type != Type::Boolean)
+	{
+		throw std::logic_error("Invalid call to Value::get for BooleanType");
+	}
+
+	return _boolean;
+}
+
+template <>
+Value::IntType Value::get<Value::IntType>() const
+{
+	if (_type != Type::Int)
+	{
+		throw std::logic_error("Invalid call to Value::get for IntType");
+	}
+
+	return _int;
+}
+
+template <>
+Value::FloatType Value::get<Value::FloatType>() const
+{
+	if (_type != Type::Float)
+	{
+		throw std::logic_error("Invalid call to Value::get for FloatType");
+	}
+
+	return _float;
+}
+
+template <>
+const Value::ScalarType& Value::get<const Value::ScalarType&>() const
+{
+	if (_type != Type::Scalar)
+	{
+		throw std::logic_error("Invalid call to Value::get for ScalarType");
+	}
+
+	return *_scalar;
+}
+
+template <>
+Value::MapType Value::release<Value::MapType>()
+{
+	if (_type != Type::Map)
+	{
+		throw std::logic_error("Invalid call to Value::release for MapType");
+	}
+
+	MapType result = std::move(*_map);
+
+	_members->clear();
+
+	return result;
+}
+
+template <>
+Value::ListType Value::release<Value::ListType>()
+{
+	if (_type != Type::List)
+	{
+		throw std::logic_error("Invalid call to Value::release for ListType");
+	}
+
+	ListType result = std::move(*_list);
+
+	return result;
+}
+
+template <>
+Value::StringType Value::release<Value::StringType>()
+{
+	if (_type != Type::String
+		&& _type != Type::EnumValue)
+	{
+		throw std::logic_error("Invalid call to Value::release for StringType");
+	}
+
+	StringType result = std::move(*_string);
+
+	return result;
+}
+
+template <>
+Value::ScalarType Value::release<Value::ScalarType>()
+{
+	if (_type != Type::Scalar)
+	{
+		throw std::logic_error("Invalid call to Value::release for ScalarType");
+	}
+
+	ScalarType result = std::move(*_scalar);
+
+	return result;
+}
+
 } /* namespace response */
 } /* namespace graphql */
 } /* namespace facebook */

--- a/GraphQLResponse.h
+++ b/GraphQLResponse.h
@@ -68,45 +68,17 @@ struct Value
 	void emplace_back(Value&& value);
 	const Value& operator[](size_t index) const;
 
+	// Specialized for all single-value Types.
 	template <typename _Value>
-	void set(_Value&& value)
-	{
-		// Specialized for all single-value Types.
-		static_assert(false, "Use emplace_back to add elements to a collection.");
-	}
+	void set(_Value&& value);
 
-	template <> void set<StringType>(StringType&& value);
-	template <> void set<BooleanType>(BooleanType&& value);
-	template <> void set<IntType>(IntType&& value);
-	template <> void set<FloatType>(FloatType&& value);
-	template <> void set<ScalarType>(ScalarType&& value);
-
+	// Specialized for all Types.
 	template <typename _Value>
-	_Value get() const
-	{
-		// Specialized for all Types.
-		static_assert(false, "Invalid type.");
-	}
+	_Value get() const;
 
-	template <> const MapType& get<const MapType&>() const;
-	template <> const ListType& get<const ListType&>() const;
-	template <> const StringType& get<const StringType&>() const;
-	template <> BooleanType get<BooleanType>() const;
-	template <> IntType get<IntType>() const;
-	template <> FloatType get<FloatType>() const;
-	template <> const ScalarType& get<const ScalarType&>() const;
-
+	// Specialized for all Types which allocate extra memory.
 	template <typename _Value>
-	_Value release()
-	{
-		// Specialized for all Types which allocate extra memory.
-		static_assert(false, "Use get<> to access this type.");
-	}
-
-	template <> MapType release<MapType>();
-	template <> ListType release<ListType>();
-	template <> StringType release<StringType>();
-	template <> ScalarType release<ScalarType>();
+	_Value release();
 
 private:
 	const Type _type;
@@ -136,195 +108,6 @@ private:
 	// Type::Scalar
 	std::unique_ptr<ScalarType> _scalar;
 };
-
-template <>
-void Value::set<Value::StringType>(StringType&& value)
-{
-	if (_type != Type::String
-		&& _type != Type::EnumValue)
-	{
-		throw std::logic_error("Invalid call to Value::set<StringType>");
-	}
-
-	*_string = std::move(value);
-}
-
-template <>
-void Value::set<Value::BooleanType>(BooleanType&& value)
-{
-	if (_type != Type::Boolean)
-	{
-		throw std::logic_error("Invalid call to Value::set<BooleanType>");
-	}
-
-	_boolean = value;
-}
-
-template <>
-void Value::set<Value::IntType>(IntType&& value)
-{
-	if (_type != Type::Int)
-	{
-		throw std::logic_error("Invalid call to Value::set<IntType>");
-	}
-
-	_int = value;
-}
-
-template <>
-void Value::set<Value::FloatType>(FloatType&& value)
-{
-	if (_type != Type::Float)
-	{
-		throw std::logic_error("Invalid call to Value::set<FloatType>");
-	}
-
-	_float = value;
-}
-
-template <>
-void Value::set<Value::ScalarType>(ScalarType&& value)
-{
-	if (_type != Type::Scalar)
-	{
-		throw std::logic_error("Invalid call to Value::set<ScalarType>");
-	}
-
-	*_scalar = std::move(value);
-}
-
-template <>
-const Value::MapType& Value::get<const Value::MapType&>() const
-{
-	if (_type != Type::Map)
-	{
-		throw std::logic_error("Invalid call to Value::get<MapType>");
-	}
-
-	return *_map;
-}
-
-template <>
-const Value::ListType& Value::get<const Value::ListType&>() const
-{
-	if (_type != Type::List)
-	{
-		throw std::logic_error("Invalid call to Value::get<ListType>");
-	}
-
-	return *_list;
-}
-
-template <>
-const Value::StringType& Value::get<const Value::StringType&>() const
-{
-	if (_type != Type::String
-		&& _type != Type::EnumValue)
-	{
-		throw std::logic_error("Invalid call to Value::get<StringType>");
-	}
-
-	return *_string;
-}
-
-template <>
-Value::BooleanType Value::get<Value::BooleanType>() const
-{
-	if (_type != Type::Boolean)
-	{
-		throw std::logic_error("Invalid call to Value::get<BooleanType>");
-	}
-
-	return _boolean;
-
-}
-template <>
-Value::IntType Value::get<Value::IntType>() const
-{
-	if (_type != Type::Int)
-	{
-		throw std::logic_error("Invalid call to Value::get<IntType>");
-	}
-
-	return _int;
-}
-
-template <>
-Value::FloatType Value::get<Value::FloatType>() const
-{
-	if (_type != Type::Float)
-	{
-		throw std::logic_error("Invalid call to Value::get<FloatType>");
-	}
-
-	return _float;
-}
-
-template <>
-const Value::ScalarType& Value::get<const Value::ScalarType&>() const
-{
-	if (_type != Type::Scalar)
-	{
-		throw std::logic_error("Invalid call to Value::get<ScalarType>");
-	}
-
-	return *_scalar;
-}
-
-template <>
-Value::MapType Value::release<Value::MapType>()
-{
-	if (_type != Type::Map)
-	{
-		throw std::logic_error("Invalid call to Value::release<MapType>");
-	}
-
-	MapType result = std::move(*_map);
-
-	_members->clear();
-
-	return result;
-}
-
-template <>
-Value::ListType Value::release<Value::ListType>()
-{
-	if (_type != Type::List)
-	{
-		throw std::logic_error("Invalid call to Value::release<ListType>");
-	}
-
-	ListType result = std::move(*_list);
-
-	return result;
-}
-
-template <>
-Value::StringType Value::release<Value::StringType>()
-{
-	if (_type != Type::String
-		&& _type != Type::EnumValue)
-	{
-		throw std::logic_error("Invalid call to Value::release<StringType>");
-	}
-
-	StringType result = std::move(*_string);
-
-	return result;
-}
-
-template <>
-Value::ScalarType Value::release<Value::ScalarType>()
-{
-	if (_type != Type::Scalar)
-	{
-		throw std::logic_error("Invalid call to Value::release<ScalarType>");
-	}
-
-	ScalarType result = std::move(*_scalar);
-
-	return result;
-}
 
 } /* namespace response */
 } /* namespace graphql */

--- a/GraphQLResponse.h
+++ b/GraphQLResponse.h
@@ -12,33 +12,35 @@ namespace facebook {
 namespace graphql {
 namespace response {
 
+// GraphQL responses are not technically JSON-specific, although that is probably the most common
+// way of representing them. These are the primitive types that may be represented in GraphQL, as
+// of the [June 2018 spec](https://facebook.github.io/graphql/June2018/#sec-Serialization-Format).
+enum class Type : uint8_t
+{
+	Map,		// JSON Object
+	List,		// JSON Array
+	String,		// JSON String
+	Null,		// JSON null
+	Boolean,	// JSON true or false
+	Int,		// JSON Number
+	Float,		// JSON Number
+	EnumValue,	// JSON String
+	Scalar,		// JSON any type
+};
+
+struct Value;
+
+using MapType = std::vector<std::pair<std::string, Value>>;
+using ListType = std::vector<Value>;
+using StringType = std::string;
+using BooleanType = bool;
+using IntType = int;
+using FloatType = double;
+using ScalarType = Value;
+
 // Represent a discriminated union of GraphQL response value types.
 struct Value
 {
-	// GraphQL responses are not technically JSON-specific, although that is probably the most common
-	// way of representing them. These are the primitive types that may be represented in GraphQL, as
-	// of the [June 2018 spec](https://facebook.github.io/graphql/June2018/#sec-Serialization-Format).
-	enum class Type : uint8_t
-	{
-		Map,		// JSON Object
-		List,		// JSON Array
-		String,		// JSON String
-		Null,		// JSON null
-		Boolean,	// JSON true or false
-		Int,		// JSON Number
-		Float,		// JSON Number
-		EnumValue,	// JSON String
-		Scalar,		// JSON any type
-	};
-
-	using MapType = std::vector<std::pair<std::string, Value>>;
-	using ListType = std::vector<Value>;
-	using StringType = std::string;
-	using BooleanType = bool;
-	using IntType = int;
-	using FloatType = double;
-	using ScalarType = Value;
-
 	Value(Type type = Type::Null);
 
 	explicit Value(StringType&& value);

--- a/GraphQLResponse.h
+++ b/GraphQLResponse.h
@@ -1,0 +1,331 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+namespace facebook {
+namespace graphql {
+namespace response {
+
+// Represent a discriminated union of GraphQL response value types.
+struct Value
+{
+	// GraphQL responses are not technically JSON-specific, although that is probably the most common
+	// way of representing them. These are the primitive types that may be represented in GraphQL, as
+	// of the [June 2018 spec](https://facebook.github.io/graphql/June2018/#sec-Serialization-Format).
+	enum class Type : uint8_t
+	{
+		Map,		// JSON Object
+		List,		// JSON Array
+		String,		// JSON String
+		Null,		// JSON null
+		Boolean,	// JSON true or false
+		Int,		// JSON Number
+		Float,		// JSON Number
+		EnumValue,	// JSON String
+		Scalar,		// JSON any type
+	};
+
+	using MapType = std::vector<std::pair<std::string, Value>>;
+	using ListType = std::vector<Value>;
+	using StringType = std::string;
+	using BooleanType = bool;
+	using IntType = int;
+	using FloatType = double;
+	using ScalarType = Value;
+
+	Value(Type type = Type::Null);
+
+	explicit Value(StringType&& value);
+	explicit Value(BooleanType value);
+	explicit Value(IntType value);
+	explicit Value(FloatType value);
+
+	Value(Value&& other);
+	explicit Value(const Value& other);
+
+	Value& operator=(Value&& rhs);
+	Value& operator=(const Value& rhs) = delete;
+
+	// Check the Type
+	Type type() const;
+
+	// Valid for Type::Map or Type::List
+	void reserve(size_t count);
+	size_t size() const;
+
+	// Valid for Type::Map
+	void emplace_back(std::string&& name, Value&& value);
+	MapType::const_iterator find(const std::string& name) const;
+	const Value& operator[](const std::string& name) const;
+
+	// Valid for Type::List
+	void emplace_back(Value&& value);
+	const Value& operator[](size_t index) const;
+
+	template <typename _Value>
+	void set(_Value&& value)
+	{
+		// Specialized for all single-value Types.
+		static_assert(false, "Use emplace_back to add elements to a collection.");
+	}
+
+	template <> void set<StringType>(StringType&& value);
+	template <> void set<BooleanType>(BooleanType&& value);
+	template <> void set<IntType>(IntType&& value);
+	template <> void set<FloatType>(FloatType&& value);
+	template <> void set<ScalarType>(ScalarType&& value);
+
+	template <typename _Value>
+	_Value get() const
+	{
+		// Specialized for all Types.
+		static_assert(false, "Invalid type.");
+	}
+
+	template <> const MapType& get<const MapType&>() const;
+	template <> const ListType& get<const ListType&>() const;
+	template <> const StringType& get<const StringType&>() const;
+	template <> BooleanType get<BooleanType>() const;
+	template <> IntType get<IntType>() const;
+	template <> FloatType get<FloatType>() const;
+	template <> const ScalarType& get<const ScalarType&>() const;
+
+	template <typename _Value>
+	_Value release()
+	{
+		// Specialized for all Types which allocate extra memory.
+		static_assert(false, "Use get<> to access this type.");
+	}
+
+	template <> MapType release<MapType>();
+	template <> ListType release<ListType>();
+	template <> StringType release<StringType>();
+	template <> ScalarType release<ScalarType>();
+
+private:
+	const Type _type;
+
+	// Type::Map
+	std::unique_ptr<std::unordered_map<std::string, size_t>> _members;
+	std::unique_ptr<MapType> _map;
+
+	// Type::List
+	std::unique_ptr<ListType> _list;
+
+	// Type::String or Type::EnumValue
+	std::unique_ptr<StringType> _string;
+
+	union
+	{
+		// Type::Boolean
+		BooleanType _boolean;
+
+		// Type::Int
+		IntType _int;
+
+		// Type::Float
+		FloatType _float;
+	};
+
+	// Type::Scalar
+	std::unique_ptr<ScalarType> _scalar;
+};
+
+template <>
+void Value::set<Value::StringType>(StringType&& value)
+{
+	if (_type != Type::String
+		&& _type != Type::EnumValue)
+	{
+		throw std::logic_error("Invalid call to Value::set<StringType>");
+	}
+
+	*_string = std::move(value);
+}
+
+template <>
+void Value::set<Value::BooleanType>(BooleanType&& value)
+{
+	if (_type != Type::Boolean)
+	{
+		throw std::logic_error("Invalid call to Value::set<BooleanType>");
+	}
+
+	_boolean = value;
+}
+
+template <>
+void Value::set<Value::IntType>(IntType&& value)
+{
+	if (_type != Type::Int)
+	{
+		throw std::logic_error("Invalid call to Value::set<IntType>");
+	}
+
+	_int = value;
+}
+
+template <>
+void Value::set<Value::FloatType>(FloatType&& value)
+{
+	if (_type != Type::Float)
+	{
+		throw std::logic_error("Invalid call to Value::set<FloatType>");
+	}
+
+	_float = value;
+}
+
+template <>
+void Value::set<Value::ScalarType>(ScalarType&& value)
+{
+	if (_type != Type::Scalar)
+	{
+		throw std::logic_error("Invalid call to Value::set<ScalarType>");
+	}
+
+	*_scalar = std::move(value);
+}
+
+template <>
+const Value::MapType& Value::get<const Value::MapType&>() const
+{
+	if (_type != Type::Map)
+	{
+		throw std::logic_error("Invalid call to Value::get<MapType>");
+	}
+
+	return *_map;
+}
+
+template <>
+const Value::ListType& Value::get<const Value::ListType&>() const
+{
+	if (_type != Type::List)
+	{
+		throw std::logic_error("Invalid call to Value::get<ListType>");
+	}
+
+	return *_list;
+}
+
+template <>
+const Value::StringType& Value::get<const Value::StringType&>() const
+{
+	if (_type != Type::String
+		&& _type != Type::EnumValue)
+	{
+		throw std::logic_error("Invalid call to Value::get<StringType>");
+	}
+
+	return *_string;
+}
+
+template <>
+Value::BooleanType Value::get<Value::BooleanType>() const
+{
+	if (_type != Type::Boolean)
+	{
+		throw std::logic_error("Invalid call to Value::get<BooleanType>");
+	}
+
+	return _boolean;
+
+}
+template <>
+Value::IntType Value::get<Value::IntType>() const
+{
+	if (_type != Type::Int)
+	{
+		throw std::logic_error("Invalid call to Value::get<IntType>");
+	}
+
+	return _int;
+}
+
+template <>
+Value::FloatType Value::get<Value::FloatType>() const
+{
+	if (_type != Type::Float)
+	{
+		throw std::logic_error("Invalid call to Value::get<FloatType>");
+	}
+
+	return _float;
+}
+
+template <>
+const Value::ScalarType& Value::get<const Value::ScalarType&>() const
+{
+	if (_type != Type::Scalar)
+	{
+		throw std::logic_error("Invalid call to Value::get<ScalarType>");
+	}
+
+	return *_scalar;
+}
+
+template <>
+Value::MapType Value::release<Value::MapType>()
+{
+	if (_type != Type::Map)
+	{
+		throw std::logic_error("Invalid call to Value::release<MapType>");
+	}
+
+	MapType result = std::move(*_map);
+
+	_members->clear();
+
+	return result;
+}
+
+template <>
+Value::ListType Value::release<Value::ListType>()
+{
+	if (_type != Type::List)
+	{
+		throw std::logic_error("Invalid call to Value::release<ListType>");
+	}
+
+	ListType result = std::move(*_list);
+
+	return result;
+}
+
+template <>
+Value::StringType Value::release<Value::StringType>()
+{
+	if (_type != Type::String
+		&& _type != Type::EnumValue)
+	{
+		throw std::logic_error("Invalid call to Value::release<StringType>");
+	}
+
+	StringType result = std::move(*_string);
+
+	return result;
+}
+
+template <>
+Value::ScalarType Value::release<Value::ScalarType>()
+{
+	if (_type != Type::Scalar)
+	{
+		throw std::logic_error("Invalid call to Value::release<ScalarType>");
+	}
+
+	ScalarType result = std::move(*_scalar);
+
+	return result;
+}
+
+} /* namespace response */
+} /* namespace graphql */
+} /* namespace facebook */

--- a/GraphQLService.cpp
+++ b/GraphQLService.cpp
@@ -13,11 +13,11 @@ namespace graphql {
 namespace service {
 
 schema_exception::schema_exception(std::vector<std::string>&& messages)
-	: _errors(response::Value::Type::List)
+	: _errors(response::Type::List)
 {
 	for (auto& message : messages)
 	{
-		response::Value error(response::Value::Type::Map);
+		response::Value error(response::Type::Map);
 
 		error.emplace_back("message", response::Value(std::move(message)));
 		_errors.emplace_back(std::move(error));
@@ -198,53 +198,53 @@ std::string Base64::toBase64(const std::vector<uint8_t>& bytes)
 }
 
 template <>
-response::Value::IntType ModifiedArgument<response::Value::IntType>::convert(const response::Value& value)
+response::IntType ModifiedArgument<response::IntType>::convert(const response::Value& value)
 {
-	if (value.type() != response::Value::Type::Int)
+	if (value.type() != response::Type::Int)
 	{
 		throw schema_exception({ "not an integer" });
 	}
 
-	return value.get<response::Value::IntType>();
+	return value.get<response::IntType>();
 }
 
 template <>
-response::Value::FloatType ModifiedArgument<response::Value::FloatType>::convert(const response::Value& value)
+response::FloatType ModifiedArgument<response::FloatType>::convert(const response::Value& value)
 {
-	if (value.type() != response::Value::Type::Float)
+	if (value.type() != response::Type::Float)
 	{
 		throw schema_exception({ "not a float" });
 	}
 
-	return value.get<response::Value::FloatType>();
+	return value.get<response::FloatType>();
 }
 
 template <>
-response::Value::StringType ModifiedArgument<response::Value::StringType>::convert(const response::Value& value)
+response::StringType ModifiedArgument<response::StringType>::convert(const response::Value& value)
 {
-	if (value.type() != response::Value::Type::String)
+	if (value.type() != response::Type::String)
 	{
 		throw schema_exception({ "not a string" });
 	}
 
-	return value.get<const response::Value::StringType&>();
+	return value.get<const response::StringType&>();
 }
 
 template <>
-response::Value::BooleanType ModifiedArgument<response::Value::BooleanType>::convert(const response::Value& value)
+response::BooleanType ModifiedArgument<response::BooleanType>::convert(const response::Value& value)
 {
-	if (value.type() != response::Value::Type::Boolean)
+	if (value.type() != response::Type::Boolean)
 	{
 		throw schema_exception({ "not a boolean" });
 	}
 
-	return value.get<response::Value::BooleanType>();
+	return value.get<response::BooleanType>();
 }
 
 template <>
 response::Value ModifiedArgument<response::Value>::convert(const response::Value& value)
 {
-	if (value.type() != response::Value::Type::Map)
+	if (value.type() != response::Type::Map)
 	{
 		throw schema_exception({ "not an object" });
 	}
@@ -255,51 +255,51 @@ response::Value ModifiedArgument<response::Value>::convert(const response::Value
 template <>
 std::vector<uint8_t> ModifiedArgument<std::vector<uint8_t>>::convert(const response::Value& value)
 {
-	if (value.type() != response::Value::Type::String)
+	if (value.type() != response::Type::String)
 	{
 		throw schema_exception({ "not a string" });
 	}
 
-	const auto& encoded = value.get<const response::Value::StringType&>();
+	const auto& encoded = value.get<const response::StringType&>();
 
 	return Base64::fromBase64(encoded.c_str(), encoded.size());
 }
 
 template <>
-std::future<response::Value> ModifiedResult<response::Value::IntType>::convert(std::future<response::Value::IntType>&& result, ResolverParams&&)
+std::future<response::Value> ModifiedResult<response::IntType>::convert(std::future<response::IntType>&& result, ResolverParams&&)
 {
 	return std::async(std::launch::deferred,
-		[](std::future<response::Value::IntType>&& resultFuture)
+		[](std::future<response::IntType>&& resultFuture)
 	{
 		return response::Value(resultFuture.get());
 	}, std::move(result));
 }
 
 template <>
-std::future<response::Value> ModifiedResult<response::Value::FloatType>::convert(std::future<response::Value::FloatType>&& result, ResolverParams&&)
+std::future<response::Value> ModifiedResult<response::FloatType>::convert(std::future<response::FloatType>&& result, ResolverParams&&)
 {
 	return std::async(std::launch::deferred,
-		[](std::future<response::Value::FloatType>&& resultFuture)
+		[](std::future<response::FloatType>&& resultFuture)
 	{
 		return response::Value(resultFuture.get());
 	}, std::move(result));
 }
 
 template <>
-std::future<response::Value> ModifiedResult<response::Value::StringType>::convert(std::future<response::Value::StringType>&& result, ResolverParams&& params)
+std::future<response::Value> ModifiedResult<response::StringType>::convert(std::future<response::StringType>&& result, ResolverParams&& params)
 {
 	return std::async(std::launch::deferred,
-		[&](std::future<response::Value::StringType>&& resultFuture, ResolverParams&& paramsFuture)
+		[&](std::future<response::StringType>&& resultFuture, ResolverParams&& paramsFuture)
 	{
 		return response::Value(resultFuture.get());
 	}, std::move(result), std::move(params));
 }
 
 template <>
-std::future<response::Value> ModifiedResult<response::Value::BooleanType>::convert(std::future<response::Value::BooleanType>&& result, ResolverParams&&)
+std::future<response::Value> ModifiedResult<response::BooleanType>::convert(std::future<response::BooleanType>&& result, ResolverParams&&)
 {
 	return std::async(std::launch::deferred,
-		[](std::future<response::Value::BooleanType>&& resultFuture)
+		[](std::future<response::BooleanType>&& resultFuture)
 	{
 		return response::Value(resultFuture.get());
 	}, std::move(result));
@@ -332,8 +332,8 @@ std::future<response::Value> ModifiedResult<Object>::convert(std::future<std::sh
 		if (!wrappedResult || !paramsFuture.selection)
 		{
 			return response::Value(!wrappedResult
-				? response::Value::Type::Null
-				: response::Value::Type::Map);
+				? response::Type::Null
+				: response::Type::Map);
 		}
 
 		return wrappedResult->resolve(paramsFuture.requestId, *paramsFuture.selection, paramsFuture.fragments, paramsFuture.variables).get();
@@ -365,7 +365,7 @@ std::future<response::Value> Object::resolve(RequestId requestId, const peg::ast
 	return std::async(std::launch::deferred,
 		[](std::queue<std::future<response::Value>>&& promises)
 	{
-		response::Value result(response::Value::Type::Map);
+		response::Value result(response::Type::Map);
 
 		while (!promises.empty())
 		{
@@ -373,9 +373,9 @@ std::future<response::Value> Object::resolve(RequestId requestId, const peg::ast
 
 			promises.pop();
 
-			if (values.type() == response::Value::Type::Map)
+			if (values.type() == response::Type::Map)
 			{
-				auto members = values.release<response::Value::MapType>();
+				auto members = values.release<response::MapType>();
 
 				for (auto& entry : members)
 				{
@@ -437,7 +437,7 @@ std::future<response::Value> SelectionVisitor::getValues()
 	return std::async(std::launch::deferred,
 		[](std::queue<std::pair<std::string, std::future<response::Value>>>&& values)
 	{
-		response::Value result(response::Value::Type::Map);
+		response::Value result(response::Type::Map);
 
 		while (!values.empty())
 		{
@@ -517,7 +517,7 @@ void SelectionVisitor::visitField(const peg::ast_node& field)
 		return;
 	}
 
-	response::Value arguments(response::Value::Type::Map);
+	response::Value arguments(response::Type::Map);
 
 	peg::on_first_child<peg::arguments>(field,
 		[this, &arguments](const peg::ast_node& child)
@@ -790,7 +790,7 @@ void ValueVisitor::visitVariable(const peg::ast_node& variable)
 	const std::string name(variable.content().c_str() + 1);
 	auto itr = _variables.find(name);
 
-	if (itr == _variables.get<const response::Value::MapType&>().cend())
+	if (itr == _variables.get<const response::MapType&>().cend())
 	{
 		auto position = variable.begin();
 		std::ostringstream error;
@@ -837,7 +837,7 @@ void ValueVisitor::visitEnumValue(const peg::ast_node& enumValue)
 
 void ValueVisitor::visitListValue(const peg::ast_node& listValue)
 {
-	_value = response::Value(response::Value::Type::List);
+	_value = response::Value(response::Type::List);
 	_value.reserve(listValue.children.size());
 
 	ValueVisitor visitor(_variables);
@@ -851,7 +851,7 @@ void ValueVisitor::visitListValue(const peg::ast_node& listValue)
 
 void ValueVisitor::visitObjectValue(const peg::ast_node& objectValue)
 {
-	_value = response::Value(response::Value::Type::Map);
+	_value = response::Value(response::Type::Map);
 	_value.reserve(objectValue.children.size());
 
 	ValueVisitor visitor(_variables);
@@ -910,7 +910,7 @@ std::future<response::Value> OperationDefinitionVisitor::getValue()
 	catch (const schema_exception& ex)
 	{
 		std::promise<response::Value> promise;
-		response::Value document(response::Value::Type::Map);
+		response::Value document(response::Type::Map);
 
 		document.emplace_back("data", response::Value());
 		document.emplace_back("errors", response::Value(ex.getErrors()));
@@ -1003,7 +1003,7 @@ void OperationDefinitionVisitor::visit(const peg::ast_node& operationDefinition)
 		_result = std::async(std::launch::deferred,
 			[this, &operationDefinition, operationObject]()
 		{
-			response::Value operationVariables(response::Value::Type::Map);
+			response::Value operationVariables(response::Type::Map);
 
 			peg::on_first_child<peg::variable_definitions>(operationDefinition,
 				[this, &operationVariables](const peg::ast_node& child)
@@ -1023,7 +1023,7 @@ void OperationDefinitionVisitor::visit(const peg::ast_node& operationDefinition)
 					auto itrVar = _variables.find(variableName);
 					response::Value valueVar;
 
-					if (itrVar != _variables.get<const response::Value::MapType&>().cend())
+					if (itrVar != _variables.get<const response::MapType&>().cend())
 					{
 						valueVar = response::Value(itrVar->second);
 					}
@@ -1043,7 +1043,7 @@ void OperationDefinitionVisitor::visit(const peg::ast_node& operationDefinition)
 				});
 			});
 
-			response::Value document(response::Value::Type::Map);
+			response::Value document(response::Type::Map);
 			auto data = operationObject->resolve(_requestId, *operationDefinition.children.back(), _fragments, operationVariables);
 
 			document.emplace_back("data", data.get());
@@ -1054,7 +1054,7 @@ void OperationDefinitionVisitor::visit(const peg::ast_node& operationDefinition)
 	catch (const schema_exception& ex)
 	{
 		std::promise<response::Value> promise;
-		response::Value document(response::Value::Type::Map);
+		response::Value document(response::Type::Map);
 
 		document.emplace_back("data", response::Value());
 		document.emplace_back("errors", response::Value(ex.getErrors()));

--- a/GraphQLService.h
+++ b/GraphQLService.h
@@ -166,7 +166,7 @@ struct ModifiedArgument
 			std::ostringstream error;
 
 			error << "Invalid argument: " << name
-				<< " message: " << ex.getErrors()[0]["message"].get<const response::Value::StringType&>();
+				<< " message: " << ex.getErrors()[0]["message"].get<const response::StringType&>();
 			throw schema_exception({ error.str() });
 		}
 	}
@@ -200,8 +200,8 @@ struct ModifiedArgument
 	{
 		const auto& valueItr = arguments.find(name);
 
-		if (valueItr == arguments.get<const response::Value::MapType&>().cend()
-			|| valueItr->second.type() == response::Value::Type::Null)
+		if (valueItr == arguments.get<const response::MapType&>().cend()
+			|| valueItr->second.type() == response::Type::Null)
 		{
 			return nullptr;
 		}
@@ -218,12 +218,12 @@ struct ModifiedArgument
 	{
 		const auto& values = arguments[name];
 		typename ArgumentTraits<_Type, _Modifier, _Other...>::type result(values.size());
-		const auto& elements = values.get<const response::Value::ListType&>();
+		const auto& elements = values.get<const response::ListType&>();
 
 		std::transform(elements.cbegin(), elements.cend(), result.begin(),
 			[&name](const response::Value& element)
 		{
-			response::Value single(response::Value::Type::Map);
+			response::Value single(response::Type::Map);
 
 			single.emplace_back(std::string(name), response::Value(element));
 
@@ -252,10 +252,10 @@ struct ModifiedArgument
 // Convenient type aliases for testing, generated code won't actually use these. These are also
 // the specializations which are implemented in the GraphQLService library, other specializations
 // for input types should be generated in schemagen.
-using IntArgument = ModifiedArgument<response::Value::IntType>;
-using FloatArgument = ModifiedArgument<response::Value::FloatType>;
-using StringArgument = ModifiedArgument<response::Value::StringType>;
-using BooleanArgument = ModifiedArgument<response::Value::BooleanType>;
+using IntArgument = ModifiedArgument<response::IntType>;
+using FloatArgument = ModifiedArgument<response::FloatType>;
+using StringArgument = ModifiedArgument<response::StringType>;
+using BooleanArgument = ModifiedArgument<response::BooleanType>;
 using IdArgument = ModifiedArgument<std::vector<uint8_t>>;
 using ScalarArgument = ModifiedArgument<response::Value>;
 
@@ -421,7 +421,7 @@ struct ModifiedResult
 				children.push(convert<_Other...>(promise.get_future(), ResolverParams(wrappedParams)));
 			}
 
-			auto value = response::Value(response::Value::Type::List);
+			auto value = response::Value(response::Type::List);
 
 			value.reserve(wrappedResult.size());
 
@@ -439,10 +439,10 @@ struct ModifiedResult
 // Convenient type aliases for testing, generated code won't actually use these. These are also
 // the specializations which are implemented in the GraphQLService library, other specializations
 // for output types should be generated in schemagen.
-using IntResult = ModifiedResult<response::Value::IntType>;
-using FloatResult = ModifiedResult<response::Value::FloatType>;
-using StringResult = ModifiedResult<response::Value::StringType>;
-using BooleanResult = ModifiedResult<response::Value::BooleanType>;
+using IntResult = ModifiedResult<response::IntType>;
+using FloatResult = ModifiedResult<response::FloatType>;
+using StringResult = ModifiedResult<response::StringType>;
+using BooleanResult = ModifiedResult<response::BooleanType>;
 using IdResult = ModifiedResult<std::vector<uint8_t>>;
 using ScalarResult = ModifiedResult<response::Value>;
 using ObjectResult = ModifiedResult<Object>;

--- a/GraphQLService.h
+++ b/GraphQLService.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "GraphQLTree.h"
+#include "GraphQLResponse.h"
 
 #include <memory>
 #include <string>
@@ -12,15 +13,10 @@
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>
-#include <exception>
+#include <stdexcept>
 #include <type_traits>
 #include <future>
 #include <queue>
-
-#define RAPIDJSON_NAMESPACE facebook::graphql::rapidjson
-#define RAPIDJSON_NAMESPACE_BEGIN namespace facebook { namespace graphql { namespace rapidjson {
-#define RAPIDJSON_NAMESPACE_END } /* namespace rapidjson */ } /* namespace graphql */ } /* namespace facebook */
-#include <rapidjson/document.h>
 
 namespace facebook {
 namespace graphql {
@@ -32,10 +28,10 @@ class schema_exception : public std::exception
 public:
 	schema_exception(std::vector<std::string>&& messages);
 
-	const rapidjson::Document& getErrors() const noexcept;
+	const response::Value& getErrors() const noexcept;
 
 private:
-	rapidjson::Document _errors;
+	response::Value _errors;
 };
 
 // The RequestId is optional, but if you have multiple threads processing requests and there's any
@@ -70,14 +66,13 @@ using FragmentMap = std::unordered_map<std::string, Fragment>;
 struct ResolverParams
 {
 	RequestId requestId;
-	rapidjson::Document::AllocatorType& allocator;
-	const rapidjson::Value::ConstObject& arguments;
+	const response::Value& arguments;
 	const peg::ast_node* selection;
 	const FragmentMap& fragments;
-	const rapidjson::Value::ConstObject& variables;
+	const response::Value& variables;
 };
 
-using Resolver = std::function<std::future<rapidjson::Value>(ResolverParams&&)>;
+using Resolver = std::function<std::future<response::Value>(ResolverParams&&)>;
 using ResolverMap = std::unordered_map<std::string, Resolver>;
 
 // Binary data and opaque strings like IDs are encoded in Base64.
@@ -157,30 +152,31 @@ struct ModifiedArgument
 	};
 
 	// Convert a single value to the specified type.
-	static _Type convert(rapidjson::Document::AllocatorType& allocator, const rapidjson::Value& value);
+	static _Type convert(const response::Value& value);
 
 	// Call convert on this type without any modifiers.
-	static _Type require(rapidjson::Document::AllocatorType& allocator, const std::string& name, const rapidjson::Value::ConstObject& arguments)
+	static _Type require(const std::string& name, const response::Value& arguments)
 	{
 		try
 		{
-			return convert(allocator, arguments[name.c_str()]);
+			return convert(arguments[name]);
 		}
 		catch (const schema_exception& ex)
 		{
 			std::ostringstream error;
 
-			error << "Invalid argument: " << name << " message: " << ex.getErrors()[0]["message"].GetString();
+			error << "Invalid argument: " << name
+				<< " message: " << ex.getErrors()[0]["message"].get<const response::Value::StringType&>();
 			throw schema_exception({ error.str() });
 		}
 	}
 
 	// Wrap require in a try/catch block.
-	static std::pair<_Type, bool> find(rapidjson::Document::AllocatorType& allocator, const std::string& name, const rapidjson::Value::ConstObject& arguments) noexcept
+	static std::pair<_Type, bool> find(const std::string& name, const response::Value& arguments) noexcept
 	{
 		try
 		{
-			return { require(allocator, name, arguments), true };
+			return { require(name, arguments), true };
 		}
 		catch (const schema_exception&)
 		{
@@ -191,26 +187,26 @@ struct ModifiedArgument
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier _Modifier = TypeModifier::None , TypeModifier... _Other >
 	static typename std::enable_if<TypeModifier::None == _Modifier && sizeof...(_Other) == 0, _Type>::type require(
-		rapidjson::Document::AllocatorType& allocator, const std::string& name, const rapidjson::Value::ConstObject& arguments)
+		const std::string& name, const response::Value& arguments)
 	{
 		// Just call through to the non-template method without the modifiers.
-		return require(allocator, name, arguments);
+		return require(name, arguments);
 	}
 
 	// Peel off nullable modifiers.
 	template <TypeModifier _Modifier, TypeModifier... _Other>
 	static typename std::enable_if<TypeModifier::Nullable == _Modifier, typename ArgumentTraits<_Type, _Modifier, _Other...>::type>::type require(
-		rapidjson::Document::AllocatorType& allocator, const std::string& name, const rapidjson::Value::ConstObject& arguments)
+		const std::string& name, const response::Value& arguments)
 	{
-		const auto& valueItr = arguments.FindMember(name.c_str());
+		const auto& valueItr = arguments.find(name);
 
-		if (valueItr == arguments.MemberEnd()
-			|| valueItr->value.IsNull())
+		if (valueItr == arguments.get<const response::Value::MapType&>().cend()
+			|| valueItr->second.type() == response::Value::Type::Null)
 		{
 			return nullptr;
 		}
 
-		auto result = require<_Other...>(allocator, name, arguments);
+		auto result = require<_Other...>(name, arguments);
 
 		return std::unique_ptr<decltype(result)> { new decltype(result)(std::move(result)) };
 	}
@@ -218,21 +214,20 @@ struct ModifiedArgument
 	// Peel off list modifiers.
 	template <TypeModifier _Modifier, TypeModifier... _Other>
 	static typename std::enable_if<TypeModifier::List == _Modifier, typename ArgumentTraits<_Type, _Modifier, _Other...>::type>::type require(
-		rapidjson::Document::AllocatorType& allocator, const std::string& name, const rapidjson::Value::ConstObject& arguments)
+		const std::string& name, const response::Value& arguments)
 	{
-		const auto& values = arguments[name.c_str()].GetArray();
-		typename ArgumentTraits<_Type, _Modifier, _Other...>::type result(values.Size());
+		const auto& values = arguments[name];
+		typename ArgumentTraits<_Type, _Modifier, _Other...>::type result(values.size());
+		const auto& elements = values.get<const response::Value::ListType&>();
 
-		std::transform(values.begin(), values.end(), result.begin(),
-			[&allocator, &name](const rapidjson::Value& element)
+		std::transform(elements.cbegin(), elements.cend(), result.begin(),
+			[&name](const response::Value& element)
 		{
-			rapidjson::Value single(rapidjson::Type::kObjectType);
-			rapidjson::Value entry;
+			response::Value single(response::Value::Type::Map);
 
-			entry.CopyFrom(element, allocator);
-			single.AddMember(rapidjson::StringRef(name.c_str()), entry, allocator);
+			single.emplace_back(std::string(name), response::Value(element));
 
-			return require<_Other...>(allocator, name.c_str(), const_cast<const rapidjson::Value&>(single).GetObject());
+			return require<_Other...>(name, single);
 		});
 
 		return result;
@@ -241,11 +236,11 @@ struct ModifiedArgument
 	// Wrap require with modifiers in a try/catch block.
 	template <TypeModifier _Modifier, TypeModifier... _Other>
 	static std::pair<typename ArgumentTraits<_Type, _Modifier, _Other...>::type, bool> find(
-		rapidjson::Document::AllocatorType& allocator, const std::string& name, const rapidjson::Value::ConstObject& arguments) noexcept
+		const std::string& name, const response::Value& arguments) noexcept
 	{
 		try
 		{
-			return { require<_Modifier, _Other...>(allocator, name, arguments), true };
+			return { require<_Modifier, _Other...>(name, arguments), true };
 		}
 		catch (const schema_exception&)
 		{
@@ -257,12 +252,12 @@ struct ModifiedArgument
 // Convenient type aliases for testing, generated code won't actually use these. These are also
 // the specializations which are implemented in the GraphQLService library, other specializations
 // for input types should be generated in schemagen.
-using IntArgument = ModifiedArgument<int>;
-using FloatArgument = ModifiedArgument<double>;
-using StringArgument = ModifiedArgument<std::string>;
-using BooleanArgument = ModifiedArgument<bool>;
+using IntArgument = ModifiedArgument<response::Value::IntType>;
+using FloatArgument = ModifiedArgument<response::Value::FloatType>;
+using StringArgument = ModifiedArgument<response::Value::StringType>;
+using BooleanArgument = ModifiedArgument<response::Value::BooleanType>;
 using IdArgument = ModifiedArgument<std::vector<uint8_t>>;
-using ScalarArgument = ModifiedArgument<rapidjson::Value>;
+using ScalarArgument = ModifiedArgument<response::Value>;
 
 // Each type should handle fragments with type conditions matching its own
 // name and any inheritted interfaces.
@@ -278,8 +273,7 @@ public:
 	explicit Object(TypeNames&& typeNames, ResolverMap&& resolvers);
 	virtual ~Object() = default;
 
-	std::future<rapidjson::Value> resolve(RequestId requestId, rapidjson::Document::AllocatorType& allocator,
-		const peg::ast_node& selection, const FragmentMap& fragments, const rapidjson::Value::ConstObject& variables) const;
+	std::future<response::Value> resolve(RequestId requestId, const peg::ast_node& selection, const FragmentMap& fragments, const response::Value& variables) const;
 
 protected:
 	// It's up to sub-classes to decide if they want to use const_cast, mutable, or separate storage
@@ -327,7 +321,7 @@ struct ModifiedResult
 	};
 
 	// Convert a single value of the specified type to JSON.
-	static std::future<rapidjson::Value> convert(
+	static std::future<response::Value> convert(
 		typename std::conditional<std::is_base_of<Object, _Type>::value,
 			std::future<std::shared_ptr<Object>>,
 			std::future<typename ResultTraits<_Type>::type>&&>::type result,
@@ -336,7 +330,7 @@ struct ModifiedResult
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier _Modifier = TypeModifier::None, TypeModifier... _Other>
 	static typename std::enable_if<TypeModifier::None == _Modifier && sizeof...(_Other) == 0 && !std::is_same<Object, _Type>::value && std::is_base_of<Object, _Type>::value,
-		std::future<rapidjson::Value>>::type convert(std::future<typename ResultTraits<_Type>::type>&& result, ResolverParams&& params)
+		std::future<response::Value>>::type convert(std::future<typename ResultTraits<_Type>::type>&& result, ResolverParams&& params)
 	{
 		// Call through to the Object specialization with a static_pointer_cast for subclasses of Object.
 		static_assert(std::is_same<std::shared_ptr<_Type>, typename ResultTraits<_Type>::type>::value, "this is the derived object type");
@@ -352,7 +346,7 @@ struct ModifiedResult
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier _Modifier = TypeModifier::None, TypeModifier... _Other>
 	static typename std::enable_if<TypeModifier::None == _Modifier && sizeof...(_Other) == 0 && (std::is_same<Object, _Type>::value || !std::is_base_of<Object, _Type>::value),
-		std::future<rapidjson::Value>>::type convert(std::future<typename ResultTraits<_Type>::type>&& result, ResolverParams&& params)
+		std::future<response::Value>>::type convert(std::future<typename ResultTraits<_Type>::type>&& result, ResolverParams&& params)
 	{
 		// Just call through to the partial specialization without the modifier.
 		return convert(std::move(result), std::move(params));
@@ -361,7 +355,7 @@ struct ModifiedResult
 	// Peel off final nullable modifiers for std::shared_ptr of Object and subclasses of Object.
 	template <TypeModifier _Modifier, TypeModifier... _Other>
 	static typename std::enable_if<TypeModifier::Nullable == _Modifier && std::is_same<std::shared_ptr<_Type>, typename ResultTraits<_Type, _Other...>::type>::value,
-		std::future<rapidjson::Value>>::type convert(std::future<typename ResultTraits<_Type, _Modifier, _Other...>::type>&& result, ResolverParams&& params)
+		std::future<response::Value>>::type convert(std::future<typename ResultTraits<_Type, _Modifier, _Other...>::type>&& result, ResolverParams&& params)
 	{
 		return std::async(std::launch::deferred,
 			[](std::future<typename ResultTraits<_Type, _Modifier, _Other...>::type>&& wrappedFuture, ResolverParams&& wrappedParams)
@@ -370,7 +364,7 @@ struct ModifiedResult
 
 			if (!wrappedResult)
 			{
-				return rapidjson::Value(rapidjson::Type::kNullType);
+				return response::Value();
 			}
 
 			std::promise<typename ResultTraits<_Type, _Other...>::type> promise;
@@ -384,7 +378,7 @@ struct ModifiedResult
 	// Peel off nullable modifiers for anything else, which should all be std::unique_ptr.
 	template <TypeModifier _Modifier, TypeModifier... _Other>
 	static typename std::enable_if<TypeModifier::Nullable == _Modifier && !std::is_same<std::shared_ptr<_Type>, typename ResultTraits<_Type, _Other...>::type>::value,
-		std::future<rapidjson::Value>>::type convert(std::future<typename ResultTraits<_Type, _Modifier, _Other...>::type>&& result, ResolverParams&& params)
+		std::future<response::Value>>::type convert(std::future<typename ResultTraits<_Type, _Modifier, _Other...>::type>&& result, ResolverParams&& params)
 	{
 		static_assert(std::is_same<std::unique_ptr<typename ResultTraits<_Type, _Other...>::type>, typename ResultTraits<_Type, _Modifier, _Other...>::type>::value,
 			"this is the unique_ptr version");
@@ -396,7 +390,7 @@ struct ModifiedResult
 
 			if (!wrappedResult)
 			{
-				return rapidjson::Value(rapidjson::Type::kNullType);
+				return response::Value();
 			}
 
 			std::promise<typename ResultTraits<_Type, _Other...>::type> promise;
@@ -410,13 +404,13 @@ struct ModifiedResult
 	// Peel off list modifiers.
 	template <TypeModifier _Modifier, TypeModifier... _Other>
 	static typename std::enable_if<TypeModifier::List == _Modifier,
-		std::future<rapidjson::Value>>::type convert(std::future<typename ResultTraits<_Type, _Modifier, _Other...>::type>&& result, ResolverParams&& params)
+		std::future<response::Value>>::type convert(std::future<typename ResultTraits<_Type, _Modifier, _Other...>::type>&& result, ResolverParams&& params)
 	{
 		return std::async(std::launch::deferred,
 			[](std::future<typename ResultTraits<_Type, _Modifier, _Other...>::type>&& wrappedFuture, ResolverParams&& wrappedParams)
 		{
 			auto wrappedResult = wrappedFuture.get();
-			std::queue<std::future<rapidjson::Value>> children;
+			std::queue<std::future<response::Value>> children;
 
 			for (auto& entry : wrappedResult)
 			{
@@ -427,13 +421,13 @@ struct ModifiedResult
 				children.push(convert<_Other...>(promise.get_future(), ResolverParams(wrappedParams)));
 			}
 
-			auto value = rapidjson::Value(rapidjson::Type::kArrayType);
+			auto value = response::Value(response::Value::Type::List);
 
-			value.Reserve(static_cast<rapidjson::SizeType>(wrappedResult.size()), wrappedParams.allocator);
+			value.reserve(wrappedResult.size());
 
 			while (!children.empty())
 			{
-				value.PushBack(children.front().get(), wrappedParams.allocator);
+				value.emplace_back(children.front().get());
 				children.pop();
 			}
 
@@ -445,12 +439,12 @@ struct ModifiedResult
 // Convenient type aliases for testing, generated code won't actually use these. These are also
 // the specializations which are implemented in the GraphQLService library, other specializations
 // for output types should be generated in schemagen.
-using IntResult = ModifiedResult<int>;
-using FloatResult = ModifiedResult<double>;
-using StringResult = ModifiedResult<std::string>;
-using BooleanResult = ModifiedResult<bool>;
-using IdResult = ModifiedResult<std::vector<unsigned char>>;
-using ScalarResult = ModifiedResult<rapidjson::Value>;
+using IntResult = ModifiedResult<response::Value::IntType>;
+using FloatResult = ModifiedResult<response::Value::FloatType>;
+using StringResult = ModifiedResult<response::Value::StringType>;
+using BooleanResult = ModifiedResult<response::Value::BooleanType>;
+using IdResult = ModifiedResult<std::vector<uint8_t>>;
+using ScalarResult = ModifiedResult<response::Value>;
 using ObjectResult = ModifiedResult<Object>;
 
 // Request scans the fragment definitions and finds the right operation definition to interpret
@@ -462,7 +456,7 @@ public:
 	explicit Request(TypeMap&& operationTypes);
 	virtual ~Request() = default;
 
-	std::future<rapidjson::Document> resolve(RequestId requestId, const peg::ast_node& root, const std::string& operationName, const rapidjson::Document::ConstObject& variables) const;
+	std::future<response::Value> resolve(RequestId requestId, const peg::ast_node& root, const std::string& operationName, const response::Value& variables) const;
 
 private:
 	TypeMap _operations;
@@ -473,12 +467,11 @@ private:
 class SelectionVisitor
 {
 public:
-	SelectionVisitor(RequestId requestId, rapidjson::Document::AllocatorType& allocator,
-		const FragmentMap& fragments, const rapidjson::Document::ConstObject& variables, const TypeNames& typeNames, const ResolverMap& resolvers);
+	SelectionVisitor(RequestId requestId, const FragmentMap& fragments, const response::Value& variables, const TypeNames& typeNames, const ResolverMap& resolvers);
 
 	void visit(const peg::ast_node& selection);
 
-	std::future<rapidjson::Value> getValues();
+	std::future<response::Value> getValues();
 
 private:
 	bool shouldSkip(const std::vector<std::unique_ptr<peg::ast_node>>* directives) const;
@@ -488,13 +481,12 @@ private:
 	void visitInlineFragment(const peg::ast_node& inlineFragment);
 
 	const RequestId _requestId;
-	rapidjson::Document::AllocatorType& _allocator;
 	const FragmentMap& _fragments;
-	const rapidjson::Document::ConstObject& _variables;
+	const response::Value& _variables;
 	const TypeNames& _typeNames;
 	const ResolverMap& _resolvers;
 
-	std::queue<std::pair<rapidjson::Value, std::future<rapidjson::Value>>> _values;
+	std::queue<std::pair<std::string, std::future<response::Value>>> _values;
 };
 
 // ValueVisitor visits the AST and builds a JSON representation of any value
@@ -502,11 +494,11 @@ private:
 class ValueVisitor
 {
 public:
-	ValueVisitor(rapidjson::Document::AllocatorType& allocator, const rapidjson::Document::ConstObject& variables);
+	ValueVisitor(const response::Value& variables);
 
 	void visit(const peg::ast_node& value);
 
-	rapidjson::Value getValue();
+	response::Value getValue();
 
 private:
 	void visitVariable(const peg::ast_node& variable);
@@ -519,9 +511,8 @@ private:
 	void visitListValue(const peg::ast_node& listValue);
 	void visitObjectValue(const peg::ast_node& objectValue);
 
-	rapidjson::Document::AllocatorType& _allocator;
-	const rapidjson::Document::ConstObject& _variables;
-	rapidjson::Value _value;
+	const response::Value& _variables;
+	response::Value _value;
 };
 
 // FragmentDefinitionVisitor visits the AST and collects all of the fragment
@@ -544,9 +535,9 @@ private:
 class OperationDefinitionVisitor
 {
 public:
-	OperationDefinitionVisitor(RequestId requestId, const TypeMap& operations, const std::string& operationName, const rapidjson::Document::ConstObject& variables, const FragmentMap& fragments);
+	OperationDefinitionVisitor(RequestId requestId, const TypeMap& operations, const std::string& operationName, const response::Value& variables, const FragmentMap& fragments);
 
-	std::future<rapidjson::Document> getValue();
+	std::future<response::Value> getValue();
 
 	void visit(const peg::ast_node& operationDefinition);
 
@@ -554,9 +545,9 @@ private:
 	const RequestId _requestId;
 	const TypeMap& _operations;
 	const std::string& _operationName;
-	const rapidjson::Document::ConstObject& _variables;
+	const response::Value& _variables;
 	const FragmentMap& _fragments;
-	std::future<rapidjson::Document> _result;
+	std::future<response::Value> _result;
 };
 
 } /* namespace service */

--- a/GraphQLTree.cpp
+++ b/GraphQLTree.cpp
@@ -181,15 +181,25 @@ struct ast_selector<string_value>
 {
 	static void transform(std::unique_ptr<ast_node>& n)
 	{
-		n->unescaped.reserve(std::accumulate(n->children.cbegin(), n->children.cend(), size_t(0),
-			[](size_t total, const std::unique_ptr<ast_node>& child)
+		if (!n->children.empty())
 		{
-			return total + child->unescaped.size();
-		}));
+			if (n->children.size() > 1)
+			{
+				n->unescaped.reserve(std::accumulate(n->children.cbegin(), n->children.cend(), size_t(0),
+					[](size_t total, const std::unique_ptr<ast_node>& child)
+				{
+					return total + child->unescaped.size();
+				}));
 
-		for (const auto& child : n->children)
-		{
-			n->unescaped.append(child->unescaped);
+				for (const auto& child : n->children)
+				{
+					n->unescaped.append(child->unescaped);
+				}
+			}
+			else
+			{
+				n->unescaped = std::move(n->children.front()->unescaped);
+			}
 		}
 
 		n->remove_content();

--- a/Introspection.h
+++ b/Introspection.h
@@ -219,7 +219,7 @@ private:
 class InputValue : public object::__InputValue
 {
 public:
-	explicit InputValue(std::string name, std::string description, std::shared_ptr<object::__Type> type, const rapidjson::Value& defaultValue);
+	explicit InputValue(std::string name, std::string description, std::shared_ptr<object::__Type> type, std::string defaultValue);
 
 	// Accessors
 	std::future<std::string> getName(service::RequestId requestId) const override;
@@ -228,8 +228,6 @@ public:
 	std::future<std::unique_ptr<std::string>> getDefaultValue(service::RequestId requestId) const override;
 
 private:
-	static std::string formatDefaultValue(const rapidjson::Value& defaultValue) noexcept;
-
 	const std::string _name;
 	const std::string _description;
 	const std::weak_ptr<object::__Type> _type;

--- a/JSONResponse.cpp
+++ b/JSONResponse.cpp
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "JSONResponse.h"
+
+namespace facebook {
+namespace graphql {
+namespace rapidjson {
+
+Value convertResponse(Document::AllocatorType& allocator, response::Value&& response)
+{
+	switch (response.type())
+	{
+		case response::Value::Type::Map:
+		{
+			Value result(Type::kObjectType);
+			auto members = response.release<response::Value::MapType>();
+
+			for (auto& entry : members)
+			{
+				result.AddMember(
+					Value(entry.first.c_str(), static_cast<SizeType>(entry.first.size()), allocator),
+					convertResponse(allocator, std::move(entry.second)), allocator);
+			}
+
+			return result;
+		}
+
+		case response::Value::Type::List:
+		{
+			Value result(Type::kArrayType);
+			auto elements = response.release<response::Value::ListType>();
+
+			result.Reserve(static_cast<SizeType>(elements.size()), allocator);
+			for (auto& entry : elements)
+			{
+				result.PushBack(convertResponse(allocator, std::move(entry)), allocator);
+			}
+
+			return result;
+		}
+
+		case response::Value::Type::String:
+		case response::Value::Type::EnumValue:
+		{
+			Value result(Type::kStringType);
+			auto value = response.release<response::Value::StringType>();
+
+			result.SetString(value.c_str(), static_cast<SizeType>(value.size()), allocator);
+
+			return result;
+		}
+
+		case response::Value::Type::Null:
+		{
+			Value result(Type::kNullType);
+
+			return result;
+		}
+
+		case response::Value::Type::Boolean:
+		{
+			Value result(response.get<response::Value::BooleanType>()
+				? Type::kTrueType
+				: Type::kFalseType);
+
+			return result;
+		}
+
+		case response::Value::Type::Int:
+		{
+			Value result(Type::kNumberType);
+
+			result.SetInt(response.get<response::Value::IntType>());
+
+			return result;
+		}
+
+		case response::Value::Type::Float:
+		{
+			Value result(Type::kNumberType);
+
+			result.SetDouble(response.get<response::Value::FloatType>());
+
+			return result;
+		}
+
+		case response::Value::Type::Scalar:
+		{
+			return convertResponse(allocator, response.release<response::Value::ScalarType>());
+		}
+
+		default:
+		{
+			return Value(Type::kNullType);
+		}
+	}
+}
+
+Document convertResponse(response::Value&& response)
+{
+	Document document;
+	auto result = convertResponse(document.GetAllocator(), std::move(response));
+
+	static_cast<Value&>(document).Swap(result);
+
+	return document;
+}
+
+
+response::Value convertResponse(const Value& value)
+{
+	switch (value.GetType())
+	{
+		case Type::kNullType:
+			return response::Value();
+
+		case Type::kFalseType:
+			return response::Value(false);
+
+		case Type::kTrueType:
+			return response::Value(true);
+
+		case Type::kObjectType:
+		{
+			response::Value response(response::Value::Type::Map);
+
+			response.reserve(static_cast<size_t>(value.MemberCount()));
+			for (const auto& member : value.GetObject())
+			{
+				response.emplace_back(member.name.GetString(),
+					convertResponse(member.value));
+			}
+
+			return response;
+		}
+
+		case Type::kArrayType:
+		{
+			response::Value response(response::Value::Type::List);
+
+			response.reserve(static_cast<size_t>(value.Size()));
+			for (const auto& element : value.GetArray())
+			{
+				response.emplace_back(convertResponse(element));
+			}
+
+			return response;
+		}
+
+		case Type::kStringType:
+			return response::Value(std::string(value.GetString()));
+
+		case Type::kNumberType:
+		{
+			response::Value response(value.IsInt()
+				? response::Value::Type::Int
+				: response::Value::Type::Float);
+
+			if (value.IsInt())
+			{
+				response.set<response::Value::IntType>(value.GetInt());
+			}
+			else
+			{
+				response.set<response::Value::FloatType>(value.GetDouble());
+			}
+
+			return response;
+		}
+
+		default:
+			return response::Value();
+	}
+}
+
+response::Value convertResponse(const Document& document)
+{
+	return convertResponse(static_cast<const Value&>(document));
+}
+
+} /* namespace rapidjson */
+} /* namespace graphql */
+} /* namespace facebook */

--- a/JSONResponse.cpp
+++ b/JSONResponse.cpp
@@ -11,10 +11,10 @@ Value convertResponse(Document::AllocatorType& allocator, response::Value&& resp
 {
 	switch (response.type())
 	{
-		case response::Value::Type::Map:
+		case response::Type::Map:
 		{
 			Value result(Type::kObjectType);
-			auto members = response.release<response::Value::MapType>();
+			auto members = response.release<response::MapType>();
 
 			for (auto& entry : members)
 			{
@@ -26,10 +26,10 @@ Value convertResponse(Document::AllocatorType& allocator, response::Value&& resp
 			return result;
 		}
 
-		case response::Value::Type::List:
+		case response::Type::List:
 		{
 			Value result(Type::kArrayType);
-			auto elements = response.release<response::Value::ListType>();
+			auto elements = response.release<response::ListType>();
 
 			result.Reserve(static_cast<SizeType>(elements.size()), allocator);
 			for (auto& entry : elements)
@@ -40,54 +40,54 @@ Value convertResponse(Document::AllocatorType& allocator, response::Value&& resp
 			return result;
 		}
 
-		case response::Value::Type::String:
-		case response::Value::Type::EnumValue:
+		case response::Type::String:
+		case response::Type::EnumValue:
 		{
 			Value result(Type::kStringType);
-			auto value = response.release<response::Value::StringType>();
+			auto value = response.release<response::StringType>();
 
 			result.SetString(value.c_str(), static_cast<SizeType>(value.size()), allocator);
 
 			return result;
 		}
 
-		case response::Value::Type::Null:
+		case response::Type::Null:
 		{
 			Value result(Type::kNullType);
 
 			return result;
 		}
 
-		case response::Value::Type::Boolean:
+		case response::Type::Boolean:
 		{
-			Value result(response.get<response::Value::BooleanType>()
+			Value result(response.get<response::BooleanType>()
 				? Type::kTrueType
 				: Type::kFalseType);
 
 			return result;
 		}
 
-		case response::Value::Type::Int:
+		case response::Type::Int:
 		{
 			Value result(Type::kNumberType);
 
-			result.SetInt(response.get<response::Value::IntType>());
+			result.SetInt(response.get<response::IntType>());
 
 			return result;
 		}
 
-		case response::Value::Type::Float:
+		case response::Type::Float:
 		{
 			Value result(Type::kNumberType);
 
-			result.SetDouble(response.get<response::Value::FloatType>());
+			result.SetDouble(response.get<response::FloatType>());
 
 			return result;
 		}
 
-		case response::Value::Type::Scalar:
+		case response::Type::Scalar:
 		{
-			return convertResponse(allocator, response.release<response::Value::ScalarType>());
+			return convertResponse(allocator, response.release<response::ScalarType>());
 		}
 
 		default:
@@ -123,7 +123,7 @@ response::Value convertResponse(const Value& value)
 
 		case Type::kObjectType:
 		{
-			response::Value response(response::Value::Type::Map);
+			response::Value response(response::Type::Map);
 
 			response.reserve(static_cast<size_t>(value.MemberCount()));
 			for (const auto& member : value.GetObject())
@@ -137,7 +137,7 @@ response::Value convertResponse(const Value& value)
 
 		case Type::kArrayType:
 		{
-			response::Value response(response::Value::Type::List);
+			response::Value response(response::Type::List);
 
 			response.reserve(static_cast<size_t>(value.Size()));
 			for (const auto& element : value.GetArray())
@@ -154,16 +154,16 @@ response::Value convertResponse(const Value& value)
 		case Type::kNumberType:
 		{
 			response::Value response(value.IsInt()
-				? response::Value::Type::Int
-				: response::Value::Type::Float);
+				? response::Type::Int
+				: response::Type::Float);
 
 			if (value.IsInt())
 			{
-				response.set<response::Value::IntType>(value.GetInt());
+				response.set<response::IntType>(value.GetInt());
 			}
 			else
 			{
-				response.set<response::Value::FloatType>(value.GetDouble());
+				response.set<response::FloatType>(value.GetDouble());
 			}
 
 			return response;

--- a/JSONResponse.h
+++ b/JSONResponse.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "GraphQLResponse.h"
+
+#define RAPIDJSON_NAMESPACE facebook::graphql::rapidjson
+#define RAPIDJSON_NAMESPACE_BEGIN namespace facebook { namespace graphql { namespace rapidjson {
+#define RAPIDJSON_NAMESPACE_END } /* namespace rapidjson */ } /* namespace graphql */ } /* namespace facebook */
+#include <rapidjson/document.h>
+
+namespace facebook {
+namespace graphql {
+namespace rapidjson {
+
+Document convertResponse(response::Value&& response);
+
+response::Value convertResponse(const Document& document);
+
+} /* namespace rapidjson */
+} /* namespace graphql */
+} /* namespace facebook */

--- a/SchemaGenerator.h
+++ b/SchemaGenerator.h
@@ -7,7 +7,6 @@
 #include <cstdio>
 
 #include "GraphQLService.h"
-#include "GraphQLTree.h"
 
 namespace facebook {
 namespace graphql {
@@ -94,7 +93,8 @@ struct InputField
 {
 	std::string type;
 	std::string name;
-	rapidjson::Document defaultValue;
+	std::string defaultValueString;
+	response::Value defaultValue;
 	InputFieldType fieldType = InputFieldType::Builtin;
 	TypeModifierStack modifiers;
 	std::string description;
@@ -237,7 +237,7 @@ private:
 	class DefaultValueVisitor
 	{
 	public:
-		rapidjson::Document getValue();
+		response::Value getValue();
 
 		void visit(const peg::ast_node& value);
 
@@ -251,7 +251,7 @@ private:
 		void visitListValue(const peg::ast_node& listValue);
 		void visitObjectValue(const peg::ast_node& objectValue);
 
-		rapidjson::Document _value;
+		response::Value _value;
 	};
 
 	bool validateSchema();
@@ -268,6 +268,7 @@ private:
 	std::string getResolverDeclaration(const OutputField& outputField) const noexcept;
 
 	bool outputSource() const noexcept;
+	std::string getArgumentDefaultValue(size_t level, const response::Value& defaultValue) const noexcept;
 	std::string getArgumentAccessType(const InputField& argument) const noexcept;
 	std::string getResultAccessType(const OutputField& result) const noexcept;
 	std::string getTypeModifiers(const TypeModifierStack& modifiers) const noexcept;

--- a/Today.cpp
+++ b/Today.cpp
@@ -160,14 +160,15 @@ struct EdgeConstraints
 	{
 	}
 
-	std::shared_ptr<_Connection> operator()(const int* first, const rapidjson::Value* after, const int* last, const rapidjson::Value* before) const
+	std::shared_ptr<_Connection> operator()(const int* first, const response::Value* after, const int* last, const response::Value* before) const
 	{
 		auto itrFirst = _objects.cbegin();
 		auto itrLast = _objects.cend();
 
 		if (after)
 		{
-			auto afterId = service::Base64::fromBase64(after->GetString(), after->GetStringLength());
+			const auto& encoded = after->get<const response::Value::StringType&>();
+			auto afterId = service::Base64::fromBase64(encoded.c_str(), encoded.size());
 			auto itrAfter = std::find_if(itrFirst, itrLast,
 				[this, &afterId](const std::shared_ptr<_Object>& entry)
 			{
@@ -182,7 +183,8 @@ struct EdgeConstraints
 
 		if (before)
 		{
-			auto beforeId = service::Base64::fromBase64(before->GetString(), before->GetStringLength());
+			const auto& encoded = before->get<const response::Value::StringType&>();
+			auto beforeId = service::Base64::fromBase64(encoded.c_str(), encoded.size());
 			auto itrBefore = std::find_if(itrFirst, itrLast,
 				[this, &beforeId](const std::shared_ptr<_Object>& entry)
 			{
@@ -240,11 +242,11 @@ private:
 	const vec_type& _objects;
 };
 
-std::future<std::shared_ptr<object::AppointmentConnection>> Query::getAppointments(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
+std::future<std::shared_ptr<object::AppointmentConnection>> Query::getAppointments(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<response::Value>&& before) const
 {
 	auto spThis = shared_from_this();
 	return std::async(std::launch::async,
-		[this, spThis](service::RequestId requestIdWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<rapidjson::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<rapidjson::Value>&& beforeWrapped)
+		[this, spThis](service::RequestId requestIdWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<response::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<response::Value>&& beforeWrapped)
 	{
 		loadAppointments();
 
@@ -255,11 +257,11 @@ std::future<std::shared_ptr<object::AppointmentConnection>> Query::getAppointmen
 	}, requestId, std::move(first), std::move(after), std::move(last), std::move(before));
 }
 
-std::future<std::shared_ptr<object::TaskConnection>> Query::getTasks(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
+std::future<std::shared_ptr<object::TaskConnection>> Query::getTasks(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<response::Value>&& before) const
 {
 	auto spThis = shared_from_this();
 	return std::async(std::launch::async,
-		[this, spThis](service::RequestId requestIdWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<rapidjson::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<rapidjson::Value>&& beforeWrapped)
+		[this, spThis](service::RequestId requestIdWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<response::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<response::Value>&& beforeWrapped)
 	{
 		loadTasks();
 
@@ -270,11 +272,11 @@ std::future<std::shared_ptr<object::TaskConnection>> Query::getTasks(service::Re
 	}, requestId, std::move(first), std::move(after), std::move(last), std::move(before));
 }
 
-std::future<std::shared_ptr<object::FolderConnection>> Query::getUnreadCounts(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const
+std::future<std::shared_ptr<object::FolderConnection>> Query::getUnreadCounts(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<response::Value>&& before) const
 {
 	auto spThis = shared_from_this();
 	return std::async(std::launch::async,
-		[this, spThis](service::RequestId requestIdWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<rapidjson::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<rapidjson::Value>&& beforeWrapped)
+		[this, spThis](service::RequestId requestIdWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<response::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<response::Value>&& beforeWrapped)
 	{
 		loadUnreadCounts();
 

--- a/Today.cpp
+++ b/Today.cpp
@@ -167,7 +167,7 @@ struct EdgeConstraints
 
 		if (after)
 		{
-			const auto& encoded = after->get<const response::Value::StringType&>();
+			const auto& encoded = after->get<const response::StringType&>();
 			auto afterId = service::Base64::fromBase64(encoded.c_str(), encoded.size());
 			auto itrAfter = std::find_if(itrFirst, itrLast,
 				[this, &afterId](const std::shared_ptr<_Object>& entry)
@@ -183,7 +183,7 @@ struct EdgeConstraints
 
 		if (before)
 		{
-			const auto& encoded = before->get<const response::Value::StringType&>();
+			const auto& encoded = before->get<const response::StringType&>();
 			auto beforeId = service::Base64::fromBase64(encoded.c_str(), encoded.size());
 			auto itrBefore = std::find_if(itrFirst, itrLast,
 				[this, &beforeId](const std::shared_ptr<_Object>& entry)

--- a/Today.h
+++ b/Today.h
@@ -23,9 +23,9 @@ public:
 	explicit Query(appointmentsLoader&& getAppointments, tasksLoader&& getTasks, unreadCountsLoader&& getUnreadCounts);
 
 	std::future<std::shared_ptr<service::Object>> getNode(service::RequestId requestId, std::vector<uint8_t>&& id) const override;
-	std::future<std::shared_ptr<object::AppointmentConnection>> getAppointments(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const override;
-	std::future<std::shared_ptr<object::TaskConnection>> getTasks(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const override;
-	std::future<std::shared_ptr<object::FolderConnection>> getUnreadCounts(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const override;
+	std::future<std::shared_ptr<object::AppointmentConnection>> getAppointments(service::RequestId requestId, std::unique_ptr<response::Value::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::Value::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
+	std::future<std::shared_ptr<object::TaskConnection>> getTasks(service::RequestId requestId, std::unique_ptr<response::Value::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::Value::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
+	std::future<std::shared_ptr<object::FolderConnection>> getUnreadCounts(service::RequestId requestId, std::unique_ptr<response::Value::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::Value::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
 	std::future<std::vector<std::shared_ptr<object::Appointment>>> getAppointmentsById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const override;
 	std::future<std::vector<std::shared_ptr<object::Task>>> getTasksById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const override;
 	std::future<std::vector<std::shared_ptr<object::Folder>>> getUnreadCountsById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const override;
@@ -95,22 +95,20 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<rapidjson::Value>> getWhen(service::RequestId, rapidjson::Document::AllocatorType& allocator) const override
+	std::future<std::unique_ptr<response::Value>> getWhen(service::RequestId) const override
 	{
-		std::promise<std::unique_ptr<rapidjson::Value>> promise;
-		std::unique_ptr<rapidjson::Value> result(new rapidjson::Value(rapidjson::Type::kStringType));
+		std::promise<std::unique_ptr<response::Value>> promise;
 
-		result->SetString(_when.c_str(), allocator);
-		promise.set_value(std::move(result));
+		promise.set_value(std::unique_ptr<response::Value>(new response::Value(std::string(_when))));
 
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<std::string>> getSubject(service::RequestId) const override
+	std::future<std::unique_ptr<response::Value::StringType>> getSubject(service::RequestId) const override
 	{
-		std::promise<std::unique_ptr<std::string>> promise;
+		std::promise<std::unique_ptr<response::Value::StringType>> promise;
 
-		promise.set_value(std::unique_ptr<std::string>(new std::string(_subject)));
+		promise.set_value(std::unique_ptr<response::Value::StringType>(new std::string(_subject)));
 
 		return promise.get_future();
 	}
@@ -148,13 +146,11 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<rapidjson::Value> getCursor(service::RequestId requestId, rapidjson::Document::AllocatorType& allocator) const override
+	std::future<response::Value> getCursor(service::RequestId requestId) const override
 	{
-		std::promise<rapidjson::Value> promise;
-		rapidjson::Value result(rapidjson::Type::kStringType);
+		std::promise<response::Value> promise;
 
-		result.SetString(service::Base64::toBase64(_appointment->getId(requestId).get()).c_str(), allocator);
-		promise.set_value(std::move(result));
+		promise.set_value(response::Value(service::Base64::toBase64(_appointment->getId(requestId).get())));
 
 		return promise.get_future();
 	}
@@ -215,11 +211,11 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<std::string>> getTitle(service::RequestId) const override
+	std::future<std::unique_ptr<response::Value::StringType>> getTitle(service::RequestId) const override
 	{
-		std::promise<std::unique_ptr<std::string>> promise;
+		std::promise<std::unique_ptr<response::Value::StringType>> promise;
 
-		promise.set_value(std::unique_ptr<std::string>(new std::string(_title)));
+		promise.set_value(std::unique_ptr<response::Value::StringType>(new std::string(_title)));
 
 		return promise.get_future();
 	}
@@ -257,13 +253,11 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<rapidjson::Value> getCursor(service::RequestId requestId, rapidjson::Document::AllocatorType& allocator) const override
+	std::future<response::Value> getCursor(service::RequestId requestId) const override
 	{
-		std::promise<rapidjson::Value> promise;
-		rapidjson::Value result(rapidjson::Type::kStringType);
+		std::promise<response::Value> promise;
 
-		result.SetString(service::Base64::toBase64(_task->getId(requestId).get()).c_str(), allocator);
-		promise.set_value(std::move(result));
+		promise.set_value(response::Value(service::Base64::toBase64(_task->getId(requestId).get())));
 
 		return promise.get_future();
 	}
@@ -324,11 +318,11 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<std::string>> getName(service::RequestId) const override
+	std::future<std::unique_ptr<response::Value::StringType>> getName(service::RequestId) const override
 	{
-		std::promise<std::unique_ptr<std::string>> promise;
+		std::promise<std::unique_ptr<response::Value::StringType>> promise;
 
-		promise.set_value(std::unique_ptr<std::string>(new std::string(_name)));
+		promise.set_value(std::unique_ptr<response::Value::StringType>(new std::string(_name)));
 
 		return promise.get_future();
 	}
@@ -365,13 +359,11 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<rapidjson::Value> getCursor(service::RequestId requestId, rapidjson::Document::AllocatorType& allocator) const override
+	std::future<response::Value> getCursor(service::RequestId requestId) const override
 	{
-		std::promise<rapidjson::Value> promise;
-		rapidjson::Value result(rapidjson::Type::kStringType);
+		std::promise<response::Value> promise;
 
-		result.SetString(service::Base64::toBase64(_folder->getId(requestId).get()).c_str(), allocator);
-		promise.set_value(std::move(result));
+		promise.set_value(response::Value(service::Base64::toBase64(_folder->getId(requestId).get())));
 
 		return promise.get_future();
 	}
@@ -421,7 +413,7 @@ private:
 class CompleteTaskPayload : public object::CompleteTaskPayload
 {
 public:
-	explicit CompleteTaskPayload(std::shared_ptr<Task> task, std::unique_ptr<std::string>&& clientMutationId)
+	explicit CompleteTaskPayload(std::shared_ptr<Task> task, std::unique_ptr<response::Value::StringType>&& clientMutationId)
 		: _task(std::move(task))
 		, _clientMutationId(std::move(clientMutationId))
 	{
@@ -436,11 +428,11 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<std::string>> getClientMutationId(service::RequestId) const override
+	std::future<std::unique_ptr<response::Value::StringType>> getClientMutationId(service::RequestId) const override
 	{
-		std::promise<std::unique_ptr<std::string>> promise;
+		std::promise<std::unique_ptr<response::Value::StringType>> promise;
 
-		promise.set_value(std::unique_ptr<std::string>(_clientMutationId
+		promise.set_value(std::unique_ptr<response::Value::StringType>(_clientMutationId
 			? new std::string(*_clientMutationId)
 			: nullptr));
 
@@ -449,7 +441,7 @@ public:
 
 private:
 	std::shared_ptr<Task> _task;
-	std::unique_ptr<std::string> _clientMutationId;
+	std::unique_ptr<response::Value::StringType> _clientMutationId;
 };
 
 class Mutation : public object::Mutation

--- a/Today.h
+++ b/Today.h
@@ -23,9 +23,9 @@ public:
 	explicit Query(appointmentsLoader&& getAppointments, tasksLoader&& getTasks, unreadCountsLoader&& getUnreadCounts);
 
 	std::future<std::shared_ptr<service::Object>> getNode(service::RequestId requestId, std::vector<uint8_t>&& id) const override;
-	std::future<std::shared_ptr<object::AppointmentConnection>> getAppointments(service::RequestId requestId, std::unique_ptr<response::Value::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::Value::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
-	std::future<std::shared_ptr<object::TaskConnection>> getTasks(service::RequestId requestId, std::unique_ptr<response::Value::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::Value::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
-	std::future<std::shared_ptr<object::FolderConnection>> getUnreadCounts(service::RequestId requestId, std::unique_ptr<response::Value::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::Value::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
+	std::future<std::shared_ptr<object::AppointmentConnection>> getAppointments(service::RequestId requestId, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
+	std::future<std::shared_ptr<object::TaskConnection>> getTasks(service::RequestId requestId, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
+	std::future<std::shared_ptr<object::FolderConnection>> getUnreadCounts(service::RequestId requestId, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
 	std::future<std::vector<std::shared_ptr<object::Appointment>>> getAppointmentsById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const override;
 	std::future<std::vector<std::shared_ptr<object::Task>>> getTasksById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const override;
 	std::future<std::vector<std::shared_ptr<object::Folder>>> getUnreadCountsById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const override;
@@ -104,11 +104,11 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<response::Value::StringType>> getSubject(service::RequestId) const override
+	std::future<std::unique_ptr<response::StringType>> getSubject(service::RequestId) const override
 	{
-		std::promise<std::unique_ptr<response::Value::StringType>> promise;
+		std::promise<std::unique_ptr<response::StringType>> promise;
 
-		promise.set_value(std::unique_ptr<response::Value::StringType>(new std::string(_subject)));
+		promise.set_value(std::unique_ptr<response::StringType>(new std::string(_subject)));
 
 		return promise.get_future();
 	}
@@ -211,11 +211,11 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<response::Value::StringType>> getTitle(service::RequestId) const override
+	std::future<std::unique_ptr<response::StringType>> getTitle(service::RequestId) const override
 	{
-		std::promise<std::unique_ptr<response::Value::StringType>> promise;
+		std::promise<std::unique_ptr<response::StringType>> promise;
 
-		promise.set_value(std::unique_ptr<response::Value::StringType>(new std::string(_title)));
+		promise.set_value(std::unique_ptr<response::StringType>(new std::string(_title)));
 
 		return promise.get_future();
 	}
@@ -318,11 +318,11 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<response::Value::StringType>> getName(service::RequestId) const override
+	std::future<std::unique_ptr<response::StringType>> getName(service::RequestId) const override
 	{
-		std::promise<std::unique_ptr<response::Value::StringType>> promise;
+		std::promise<std::unique_ptr<response::StringType>> promise;
 
-		promise.set_value(std::unique_ptr<response::Value::StringType>(new std::string(_name)));
+		promise.set_value(std::unique_ptr<response::StringType>(new std::string(_name)));
 
 		return promise.get_future();
 	}
@@ -413,7 +413,7 @@ private:
 class CompleteTaskPayload : public object::CompleteTaskPayload
 {
 public:
-	explicit CompleteTaskPayload(std::shared_ptr<Task> task, std::unique_ptr<response::Value::StringType>&& clientMutationId)
+	explicit CompleteTaskPayload(std::shared_ptr<Task> task, std::unique_ptr<response::StringType>&& clientMutationId)
 		: _task(std::move(task))
 		, _clientMutationId(std::move(clientMutationId))
 	{
@@ -428,11 +428,11 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<response::Value::StringType>> getClientMutationId(service::RequestId) const override
+	std::future<std::unique_ptr<response::StringType>> getClientMutationId(service::RequestId) const override
 	{
-		std::promise<std::unique_ptr<response::Value::StringType>> promise;
+		std::promise<std::unique_ptr<response::StringType>> promise;
 
-		promise.set_value(std::unique_ptr<response::Value::StringType>(_clientMutationId
+		promise.set_value(std::unique_ptr<response::StringType>(_clientMutationId
 			? new std::string(*_clientMutationId)
 			: nullptr));
 
@@ -441,7 +441,7 @@ public:
 
 private:
 	std::shared_ptr<Task> _task;
-	std::unique_ptr<response::Value::StringType> _clientMutationId;
+	std::unique_ptr<response::StringType> _clientMutationId;
 };
 
 class Mutation : public object::Mutation

--- a/samples/IntrospectionSchema.cpp
+++ b/samples/IntrospectionSchema.cpp
@@ -28,12 +28,12 @@ introspection::__TypeKind ModifiedArgument<introspection::__TypeKind>::convert(c
 		{ "NON_NULL", introspection::__TypeKind::NON_NULL }
 	};
 
-	if (value.type() != response::Value::Type::EnumValue)
+	if (value.type() != response::Type::EnumValue)
 	{
 		throw service::schema_exception({ "not a valid __TypeKind value" });
 	}
 
-	auto itr = s_names.find(value.get<const response::Value::StringType&>());
+	auto itr = s_names.find(value.get<const response::StringType&>());
 
 	if (itr == s_names.cend())
 	{
@@ -88,12 +88,12 @@ introspection::__DirectiveLocation ModifiedArgument<introspection::__DirectiveLo
 		{ "INPUT_FIELD_DEFINITION", introspection::__DirectiveLocation::INPUT_FIELD_DEFINITION }
 	};
 
-	if (value.type() != response::Value::Type::EnumValue)
+	if (value.type() != response::Type::EnumValue)
 	{
 		throw service::schema_exception({ "not a valid __DirectiveLocation value" });
 	}
 
-	auto itr = s_names.find(value.get<const response::Value::StringType&>());
+	auto itr = s_names.find(value.get<const response::StringType&>());
 
 	if (itr == s_names.cend())
 	{
@@ -226,21 +226,21 @@ std::future<response::Value> __Type::resolveName(service::ResolverParams&& param
 {
 	auto result = getName(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __Type::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __Type::resolveFields(service::ResolverParams&& params)
 {
 	const auto defaultArguments = []()
 	{
-		response::Value values(response::Value::Type::Map);
+		response::Value values(response::Type::Map);
 		response::Value entry;
 
 		entry = response::Value(false);
@@ -249,10 +249,10 @@ std::future<response::Value> __Type::resolveFields(service::ResolverParams&& par
 		return values;
 	}();
 
-	auto pairIncludeDeprecated = service::ModifiedArgument<response::Value::BooleanType>::find<service::TypeModifier::Nullable>("includeDeprecated", params.arguments);
+	auto pairIncludeDeprecated = service::ModifiedArgument<response::BooleanType>::find<service::TypeModifier::Nullable>("includeDeprecated", params.arguments);
 	auto argIncludeDeprecated = (pairIncludeDeprecated.second
 		? std::move(pairIncludeDeprecated.first)
-		: service::ModifiedArgument<response::Value::BooleanType>::require<service::TypeModifier::Nullable>("includeDeprecated", defaultArguments));
+		: service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable>("includeDeprecated", defaultArguments));
 	auto result = getFields(params.requestId, std::move(argIncludeDeprecated));
 
 	return service::ModifiedResult<__Field>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
@@ -276,7 +276,7 @@ std::future<response::Value> __Type::resolveEnumValues(service::ResolverParams&&
 {
 	const auto defaultArguments = []()
 	{
-		response::Value values(response::Value::Type::Map);
+		response::Value values(response::Type::Map);
 		response::Value entry;
 
 		entry = response::Value(false);
@@ -285,10 +285,10 @@ std::future<response::Value> __Type::resolveEnumValues(service::ResolverParams&&
 		return values;
 	}();
 
-	auto pairIncludeDeprecated = service::ModifiedArgument<response::Value::BooleanType>::find<service::TypeModifier::Nullable>("includeDeprecated", params.arguments);
+	auto pairIncludeDeprecated = service::ModifiedArgument<response::BooleanType>::find<service::TypeModifier::Nullable>("includeDeprecated", params.arguments);
 	auto argIncludeDeprecated = (pairIncludeDeprecated.second
 		? std::move(pairIncludeDeprecated.first)
-		: service::ModifiedArgument<response::Value::BooleanType>::require<service::TypeModifier::Nullable>("includeDeprecated", defaultArguments));
+		: service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable>("includeDeprecated", defaultArguments));
 	auto result = getEnumValues(params.requestId, std::move(argIncludeDeprecated));
 
 	return service::ModifiedResult<__EnumValue>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
@@ -336,14 +336,14 @@ std::future<response::Value> __Field::resolveName(service::ResolverParams&& para
 {
 	auto result = getName(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __Field::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __Field::resolveArgs(service::ResolverParams&& params)
@@ -364,14 +364,14 @@ std::future<response::Value> __Field::resolveIsDeprecated(service::ResolverParam
 {
 	auto result = getIsDeprecated(params.requestId);
 
-	return service::ModifiedResult<response::Value::BooleanType>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __Field::resolveDeprecationReason(service::ResolverParams&& params)
 {
 	auto result = getDeprecationReason(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __Field::resolve__typename(service::ResolverParams&&)
@@ -400,14 +400,14 @@ std::future<response::Value> __InputValue::resolveName(service::ResolverParams&&
 {
 	auto result = getName(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __InputValue::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __InputValue::resolveType(service::ResolverParams&& params)
@@ -421,7 +421,7 @@ std::future<response::Value> __InputValue::resolveDefaultValue(service::Resolver
 {
 	auto result = getDefaultValue(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __InputValue::resolve__typename(service::ResolverParams&&)
@@ -450,28 +450,28 @@ std::future<response::Value> __EnumValue::resolveName(service::ResolverParams&& 
 {
 	auto result = getName(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __EnumValue::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __EnumValue::resolveIsDeprecated(service::ResolverParams&& params)
 {
 	auto result = getIsDeprecated(params.requestId);
 
-	return service::ModifiedResult<response::Value::BooleanType>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __EnumValue::resolveDeprecationReason(service::ResolverParams&& params)
 {
 	auto result = getDeprecationReason(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __EnumValue::resolve__typename(service::ResolverParams&&)
@@ -500,14 +500,14 @@ std::future<response::Value> __Directive::resolveName(service::ResolverParams&& 
 {
 	auto result = getName(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __Directive::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> __Directive::resolveLocations(service::ResolverParams&& params)

--- a/samples/IntrospectionSchema.cpp
+++ b/samples/IntrospectionSchema.cpp
@@ -15,7 +15,7 @@ namespace graphql {
 namespace service {
 
 template <>
-introspection::__TypeKind ModifiedArgument<introspection::__TypeKind>::convert(rapidjson::Document::AllocatorType&, const rapidjson::Value& value)
+introspection::__TypeKind ModifiedArgument<introspection::__TypeKind>::convert(const response::Value& value)
 {
 	static const std::unordered_map<std::string, introspection::__TypeKind> s_names = {
 		{ "SCALAR", introspection::__TypeKind::SCALAR },
@@ -28,7 +28,12 @@ introspection::__TypeKind ModifiedArgument<introspection::__TypeKind>::convert(r
 		{ "NON_NULL", introspection::__TypeKind::NON_NULL }
 	};
 
-	auto itr = s_names.find(value.GetString());
+	if (value.type() != response::Value::Type::EnumValue)
+	{
+		throw service::schema_exception({ "not a valid __TypeKind value" });
+	}
+
+	auto itr = s_names.find(value.get<const response::Value::StringType&>());
 
 	if (itr == s_names.cend())
 	{
@@ -39,7 +44,7 @@ introspection::__TypeKind ModifiedArgument<introspection::__TypeKind>::convert(r
 }
 
 template <>
-std::future<rapidjson::Value> service::ModifiedResult<introspection::__TypeKind>::convert(std::future<introspection::__TypeKind>&& value, ResolverParams&&)
+std::future<response::Value> service::ModifiedResult<introspection::__TypeKind>::convert(std::future<introspection::__TypeKind>&& value, ResolverParams&&)
 {
 	static const std::string s_names[] = {
 		"SCALAR",
@@ -52,17 +57,15 @@ std::future<rapidjson::Value> service::ModifiedResult<introspection::__TypeKind>
 		"NON_NULL"
 	};
 
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef(s_names[static_cast<size_t>(value.get())].c_str()));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value(std::string(s_names[static_cast<size_t>(value.get())])));
 
 	return promise.get_future();
 }
 
 template <>
-introspection::__DirectiveLocation ModifiedArgument<introspection::__DirectiveLocation>::convert(rapidjson::Document::AllocatorType&, const rapidjson::Value& value)
+introspection::__DirectiveLocation ModifiedArgument<introspection::__DirectiveLocation>::convert(const response::Value& value)
 {
 	static const std::unordered_map<std::string, introspection::__DirectiveLocation> s_names = {
 		{ "QUERY", introspection::__DirectiveLocation::QUERY },
@@ -85,7 +88,12 @@ introspection::__DirectiveLocation ModifiedArgument<introspection::__DirectiveLo
 		{ "INPUT_FIELD_DEFINITION", introspection::__DirectiveLocation::INPUT_FIELD_DEFINITION }
 	};
 
-	auto itr = s_names.find(value.GetString());
+	if (value.type() != response::Value::Type::EnumValue)
+	{
+		throw service::schema_exception({ "not a valid __DirectiveLocation value" });
+	}
+
+	auto itr = s_names.find(value.get<const response::Value::StringType&>());
 
 	if (itr == s_names.cend())
 	{
@@ -96,7 +104,7 @@ introspection::__DirectiveLocation ModifiedArgument<introspection::__DirectiveLo
 }
 
 template <>
-std::future<rapidjson::Value> service::ModifiedResult<introspection::__DirectiveLocation>::convert(std::future<introspection::__DirectiveLocation>&& value, ResolverParams&&)
+std::future<response::Value> service::ModifiedResult<introspection::__DirectiveLocation>::convert(std::future<introspection::__DirectiveLocation>&& value, ResolverParams&&)
 {
 	static const std::string s_names[] = {
 		"QUERY",
@@ -119,11 +127,9 @@ std::future<rapidjson::Value> service::ModifiedResult<introspection::__Directive
 		"INPUT_FIELD_DEFINITION"
 	};
 
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef(s_names[static_cast<size_t>(value.get())].c_str()));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value(std::string(s_names[static_cast<size_t>(value.get())])));
 
 	return promise.get_future();
 }
@@ -147,48 +153,46 @@ __Schema::__Schema()
 {
 }
 
-std::future<rapidjson::Value> __Schema::resolveTypes(service::ResolverParams&& params)
+std::future<response::Value> __Schema::resolveTypes(service::ResolverParams&& params)
 {
 	auto result = getTypes(params.requestId);
 
 	return service::ModifiedResult<__Type>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Schema::resolveQueryType(service::ResolverParams&& params)
+std::future<response::Value> __Schema::resolveQueryType(service::ResolverParams&& params)
 {
 	auto result = getQueryType(params.requestId);
 
 	return service::ModifiedResult<__Type>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Schema::resolveMutationType(service::ResolverParams&& params)
+std::future<response::Value> __Schema::resolveMutationType(service::ResolverParams&& params)
 {
 	auto result = getMutationType(params.requestId);
 
 	return service::ModifiedResult<__Type>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Schema::resolveSubscriptionType(service::ResolverParams&& params)
+std::future<response::Value> __Schema::resolveSubscriptionType(service::ResolverParams&& params)
 {
 	auto result = getSubscriptionType(params.requestId);
 
 	return service::ModifiedResult<__Type>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Schema::resolveDirectives(service::ResolverParams&& params)
+std::future<response::Value> __Schema::resolveDirectives(service::ResolverParams&& params)
 {
 	auto result = getDirectives(params.requestId);
 
 	return service::ModifiedResult<__Directive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Schema::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> __Schema::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("__Schema"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("__Schema"));
 
 	return promise.get_future();
 }
@@ -211,112 +215,104 @@ __Type::__Type()
 {
 }
 
-std::future<rapidjson::Value> __Type::resolveKind(service::ResolverParams&& params)
+std::future<response::Value> __Type::resolveKind(service::ResolverParams&& params)
 {
 	auto result = getKind(params.requestId);
 
 	return service::ModifiedResult<__TypeKind>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Type::resolveName(service::ResolverParams&& params)
+std::future<response::Value> __Type::resolveName(service::ResolverParams&& params)
 {
 	auto result = getName(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Type::resolveDescription(service::ResolverParams&& params)
+std::future<response::Value> __Type::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Type::resolveFields(service::ResolverParams&& params)
+std::future<response::Value> __Type::resolveFields(service::ResolverParams&& params)
 {
 	const auto defaultArguments = []()
 	{
-		rapidjson::Document values(rapidjson::Type::kObjectType);
-		auto& valuesAllocator = values.GetAllocator();
-		rapidjson::Document parsed;
-		rapidjson::Value entry;
+		response::Value values(response::Value::Type::Map);
+		response::Value entry;
 
-		parsed.Parse(R"js(false)js");
-		entry.CopyFrom(parsed, valuesAllocator);
-		values.AddMember(rapidjson::StringRef("includeDeprecated"), entry, valuesAllocator);
+		entry = response::Value(false);
+		values.emplace_back("includeDeprecated", std::move(entry));
 
 		return values;
 	}();
 
-	auto pairIncludeDeprecated = service::ModifiedArgument<bool>::find<service::TypeModifier::Nullable>(params.allocator, "includeDeprecated", params.arguments);
+	auto pairIncludeDeprecated = service::ModifiedArgument<response::Value::BooleanType>::find<service::TypeModifier::Nullable>("includeDeprecated", params.arguments);
 	auto argIncludeDeprecated = (pairIncludeDeprecated.second
 		? std::move(pairIncludeDeprecated.first)
-		: service::ModifiedArgument<bool>::require<service::TypeModifier::Nullable>(params.allocator, "includeDeprecated", defaultArguments.GetObject()));
+		: service::ModifiedArgument<response::Value::BooleanType>::require<service::TypeModifier::Nullable>("includeDeprecated", defaultArguments));
 	auto result = getFields(params.requestId, std::move(argIncludeDeprecated));
 
 	return service::ModifiedResult<__Field>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Type::resolveInterfaces(service::ResolverParams&& params)
+std::future<response::Value> __Type::resolveInterfaces(service::ResolverParams&& params)
 {
 	auto result = getInterfaces(params.requestId);
 
 	return service::ModifiedResult<__Type>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Type::resolvePossibleTypes(service::ResolverParams&& params)
+std::future<response::Value> __Type::resolvePossibleTypes(service::ResolverParams&& params)
 {
 	auto result = getPossibleTypes(params.requestId);
 
 	return service::ModifiedResult<__Type>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Type::resolveEnumValues(service::ResolverParams&& params)
+std::future<response::Value> __Type::resolveEnumValues(service::ResolverParams&& params)
 {
 	const auto defaultArguments = []()
 	{
-		rapidjson::Document values(rapidjson::Type::kObjectType);
-		auto& valuesAllocator = values.GetAllocator();
-		rapidjson::Document parsed;
-		rapidjson::Value entry;
+		response::Value values(response::Value::Type::Map);
+		response::Value entry;
 
-		parsed.Parse(R"js(false)js");
-		entry.CopyFrom(parsed, valuesAllocator);
-		values.AddMember(rapidjson::StringRef("includeDeprecated"), entry, valuesAllocator);
+		entry = response::Value(false);
+		values.emplace_back("includeDeprecated", std::move(entry));
 
 		return values;
 	}();
 
-	auto pairIncludeDeprecated = service::ModifiedArgument<bool>::find<service::TypeModifier::Nullable>(params.allocator, "includeDeprecated", params.arguments);
+	auto pairIncludeDeprecated = service::ModifiedArgument<response::Value::BooleanType>::find<service::TypeModifier::Nullable>("includeDeprecated", params.arguments);
 	auto argIncludeDeprecated = (pairIncludeDeprecated.second
 		? std::move(pairIncludeDeprecated.first)
-		: service::ModifiedArgument<bool>::require<service::TypeModifier::Nullable>(params.allocator, "includeDeprecated", defaultArguments.GetObject()));
+		: service::ModifiedArgument<response::Value::BooleanType>::require<service::TypeModifier::Nullable>("includeDeprecated", defaultArguments));
 	auto result = getEnumValues(params.requestId, std::move(argIncludeDeprecated));
 
 	return service::ModifiedResult<__EnumValue>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Type::resolveInputFields(service::ResolverParams&& params)
+std::future<response::Value> __Type::resolveInputFields(service::ResolverParams&& params)
 {
 	auto result = getInputFields(params.requestId);
 
 	return service::ModifiedResult<__InputValue>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Type::resolveOfType(service::ResolverParams&& params)
+std::future<response::Value> __Type::resolveOfType(service::ResolverParams&& params)
 {
 	auto result = getOfType(params.requestId);
 
 	return service::ModifiedResult<__Type>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Type::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> __Type::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("__Type"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("__Type"));
 
 	return promise.get_future();
 }
@@ -336,55 +332,53 @@ __Field::__Field()
 {
 }
 
-std::future<rapidjson::Value> __Field::resolveName(service::ResolverParams&& params)
+std::future<response::Value> __Field::resolveName(service::ResolverParams&& params)
 {
 	auto result = getName(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Field::resolveDescription(service::ResolverParams&& params)
+std::future<response::Value> __Field::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Field::resolveArgs(service::ResolverParams&& params)
+std::future<response::Value> __Field::resolveArgs(service::ResolverParams&& params)
 {
 	auto result = getArgs(params.requestId);
 
 	return service::ModifiedResult<__InputValue>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Field::resolveType(service::ResolverParams&& params)
+std::future<response::Value> __Field::resolveType(service::ResolverParams&& params)
 {
 	auto result = getType(params.requestId);
 
 	return service::ModifiedResult<__Type>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Field::resolveIsDeprecated(service::ResolverParams&& params)
+std::future<response::Value> __Field::resolveIsDeprecated(service::ResolverParams&& params)
 {
 	auto result = getIsDeprecated(params.requestId);
 
-	return service::ModifiedResult<bool>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Field::resolveDeprecationReason(service::ResolverParams&& params)
+std::future<response::Value> __Field::resolveDeprecationReason(service::ResolverParams&& params)
 {
 	auto result = getDeprecationReason(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Field::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> __Field::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("__Field"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("__Field"));
 
 	return promise.get_future();
 }
@@ -402,41 +396,39 @@ __InputValue::__InputValue()
 {
 }
 
-std::future<rapidjson::Value> __InputValue::resolveName(service::ResolverParams&& params)
+std::future<response::Value> __InputValue::resolveName(service::ResolverParams&& params)
 {
 	auto result = getName(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __InputValue::resolveDescription(service::ResolverParams&& params)
+std::future<response::Value> __InputValue::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __InputValue::resolveType(service::ResolverParams&& params)
+std::future<response::Value> __InputValue::resolveType(service::ResolverParams&& params)
 {
 	auto result = getType(params.requestId);
 
 	return service::ModifiedResult<__Type>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __InputValue::resolveDefaultValue(service::ResolverParams&& params)
+std::future<response::Value> __InputValue::resolveDefaultValue(service::ResolverParams&& params)
 {
 	auto result = getDefaultValue(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __InputValue::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> __InputValue::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("__InputValue"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("__InputValue"));
 
 	return promise.get_future();
 }
@@ -454,41 +446,39 @@ __EnumValue::__EnumValue()
 {
 }
 
-std::future<rapidjson::Value> __EnumValue::resolveName(service::ResolverParams&& params)
+std::future<response::Value> __EnumValue::resolveName(service::ResolverParams&& params)
 {
 	auto result = getName(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __EnumValue::resolveDescription(service::ResolverParams&& params)
+std::future<response::Value> __EnumValue::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __EnumValue::resolveIsDeprecated(service::ResolverParams&& params)
+std::future<response::Value> __EnumValue::resolveIsDeprecated(service::ResolverParams&& params)
 {
 	auto result = getIsDeprecated(params.requestId);
 
-	return service::ModifiedResult<bool>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __EnumValue::resolveDeprecationReason(service::ResolverParams&& params)
+std::future<response::Value> __EnumValue::resolveDeprecationReason(service::ResolverParams&& params)
 {
 	auto result = getDeprecationReason(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __EnumValue::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> __EnumValue::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("__EnumValue"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("__EnumValue"));
 
 	return promise.get_future();
 }
@@ -506,41 +496,39 @@ __Directive::__Directive()
 {
 }
 
-std::future<rapidjson::Value> __Directive::resolveName(service::ResolverParams&& params)
+std::future<response::Value> __Directive::resolveName(service::ResolverParams&& params)
 {
 	auto result = getName(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Directive::resolveDescription(service::ResolverParams&& params)
+std::future<response::Value> __Directive::resolveDescription(service::ResolverParams&& params)
 {
 	auto result = getDescription(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Directive::resolveLocations(service::ResolverParams&& params)
+std::future<response::Value> __Directive::resolveLocations(service::ResolverParams&& params)
 {
 	auto result = getLocations(params.requestId);
 
 	return service::ModifiedResult<__DirectiveLocation>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Directive::resolveArgs(service::ResolverParams&& params)
+std::future<response::Value> __Directive::resolveArgs(service::ResolverParams&& params)
 {
 	auto result = getArgs(params.requestId);
 
 	return service::ModifiedResult<__InputValue>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> __Directive::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> __Directive::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("__Directive"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("__Directive"));
 
 	return promise.get_future();
 }
@@ -604,21 +592,17 @@ void AddTypesToSchema(std::shared_ptr<introspection::Schema> schema)
 		std::make_shared<introspection::Field>("subscriptionType", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("__Type")),
 		std::make_shared<introspection::Field>("directives", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>(), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("__Directive")))))
 	});
-	rapidjson::Document default__TypefieldsincludeDeprecated;
-	default__TypefieldsincludeDeprecated.Parse(R"js(false)js");
-	rapidjson::Document default__TypeenumValuesincludeDeprecated;
-	default__TypeenumValuesincludeDeprecated.Parse(R"js(false)js");
 	type__Type->AddFields({
 		std::make_shared<introspection::Field>("kind", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>(), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("__TypeKind"))),
 		std::make_shared<introspection::Field>("name", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String")),
 		std::make_shared<introspection::Field>("description", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String")),
 		std::make_shared<introspection::Field>("fields", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("includeDeprecated", R"md()md", schema->LookupType("Boolean"), default__TypefieldsincludeDeprecated)
+			std::make_shared<introspection::InputValue>("includeDeprecated", R"md()md", schema->LookupType("Boolean"), R"gql(false)gql")
 		}), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("__Field"))))),
 		std::make_shared<introspection::Field>("interfaces", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>(), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("__Type"))))),
 		std::make_shared<introspection::Field>("possibleTypes", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>(), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("__Type"))))),
 		std::make_shared<introspection::Field>("enumValues", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("includeDeprecated", R"md()md", schema->LookupType("Boolean"), default__TypeenumValuesincludeDeprecated)
+			std::make_shared<introspection::InputValue>("includeDeprecated", R"md()md", schema->LookupType("Boolean"), R"gql(false)gql")
 		}), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("__EnumValue"))))),
 		std::make_shared<introspection::Field>("inputFields", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>(), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("__InputValue"))))),
 		std::make_shared<introspection::Field>("ofType", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("__Type"))

--- a/samples/IntrospectionSchema.h
+++ b/samples/IntrospectionSchema.h
@@ -72,13 +72,13 @@ public:
 	virtual std::future<std::vector<std::shared_ptr<__Directive>>> getDirectives(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveTypes(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveQueryType(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveMutationType(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveSubscriptionType(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveDirectives(service::ResolverParams&& params);
+	std::future<response::Value> resolveTypes(service::ResolverParams&& params);
+	std::future<response::Value> resolveQueryType(service::ResolverParams&& params);
+	std::future<response::Value> resolveMutationType(service::ResolverParams&& params);
+	std::future<response::Value> resolveSubscriptionType(service::ResolverParams&& params);
+	std::future<response::Value> resolveDirectives(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class __Type
@@ -89,27 +89,27 @@ protected:
 
 public:
 	virtual std::future<__TypeKind> getKind(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::string>> getName(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Field>>>> getFields(service::RequestId requestId, std::unique_ptr<bool>&& includeDeprecated) const = 0;
+	virtual std::future<std::unique_ptr<response::Value::StringType>> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::Value::StringType>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Field>>>> getFields(service::RequestId requestId, std::unique_ptr<response::Value::BooleanType>&& includeDeprecated) const = 0;
 	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Type>>>> getInterfaces(service::RequestId requestId) const = 0;
 	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Type>>>> getPossibleTypes(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__EnumValue>>>> getEnumValues(service::RequestId requestId, std::unique_ptr<bool>&& includeDeprecated) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__EnumValue>>>> getEnumValues(service::RequestId requestId, std::unique_ptr<response::Value::BooleanType>&& includeDeprecated) const = 0;
 	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__InputValue>>>> getInputFields(service::RequestId requestId) const = 0;
 	virtual std::future<std::shared_ptr<__Type>> getOfType(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveKind(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveName(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveDescription(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveFields(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveInterfaces(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolvePossibleTypes(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveEnumValues(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveInputFields(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveOfType(service::ResolverParams&& params);
+	std::future<response::Value> resolveKind(service::ResolverParams&& params);
+	std::future<response::Value> resolveName(service::ResolverParams&& params);
+	std::future<response::Value> resolveDescription(service::ResolverParams&& params);
+	std::future<response::Value> resolveFields(service::ResolverParams&& params);
+	std::future<response::Value> resolveInterfaces(service::ResolverParams&& params);
+	std::future<response::Value> resolvePossibleTypes(service::ResolverParams&& params);
+	std::future<response::Value> resolveEnumValues(service::ResolverParams&& params);
+	std::future<response::Value> resolveInputFields(service::ResolverParams&& params);
+	std::future<response::Value> resolveOfType(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class __Field
@@ -119,22 +119,22 @@ protected:
 	__Field();
 
 public:
-	virtual std::future<std::string> getName(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<response::Value::StringType> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::Value::StringType>> getDescription(service::RequestId requestId) const = 0;
 	virtual std::future<std::vector<std::shared_ptr<__InputValue>>> getArgs(service::RequestId requestId) const = 0;
 	virtual std::future<std::shared_ptr<__Type>> getType(service::RequestId requestId) const = 0;
-	virtual std::future<bool> getIsDeprecated(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::string>> getDeprecationReason(service::RequestId requestId) const = 0;
+	virtual std::future<response::Value::BooleanType> getIsDeprecated(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::Value::StringType>> getDeprecationReason(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveName(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveDescription(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveArgs(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveType(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveIsDeprecated(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveDeprecationReason(service::ResolverParams&& params);
+	std::future<response::Value> resolveName(service::ResolverParams&& params);
+	std::future<response::Value> resolveDescription(service::ResolverParams&& params);
+	std::future<response::Value> resolveArgs(service::ResolverParams&& params);
+	std::future<response::Value> resolveType(service::ResolverParams&& params);
+	std::future<response::Value> resolveIsDeprecated(service::ResolverParams&& params);
+	std::future<response::Value> resolveDeprecationReason(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class __InputValue
@@ -144,18 +144,18 @@ protected:
 	__InputValue();
 
 public:
-	virtual std::future<std::string> getName(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<response::Value::StringType> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::Value::StringType>> getDescription(service::RequestId requestId) const = 0;
 	virtual std::future<std::shared_ptr<__Type>> getType(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::string>> getDefaultValue(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::Value::StringType>> getDefaultValue(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveName(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveDescription(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveType(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveDefaultValue(service::ResolverParams&& params);
+	std::future<response::Value> resolveName(service::ResolverParams&& params);
+	std::future<response::Value> resolveDescription(service::ResolverParams&& params);
+	std::future<response::Value> resolveType(service::ResolverParams&& params);
+	std::future<response::Value> resolveDefaultValue(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class __EnumValue
@@ -165,18 +165,18 @@ protected:
 	__EnumValue();
 
 public:
-	virtual std::future<std::string> getName(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const = 0;
-	virtual std::future<bool> getIsDeprecated(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::string>> getDeprecationReason(service::RequestId requestId) const = 0;
+	virtual std::future<response::Value::StringType> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::Value::StringType>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<response::Value::BooleanType> getIsDeprecated(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::Value::StringType>> getDeprecationReason(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveName(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveDescription(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveIsDeprecated(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveDeprecationReason(service::ResolverParams&& params);
+	std::future<response::Value> resolveName(service::ResolverParams&& params);
+	std::future<response::Value> resolveDescription(service::ResolverParams&& params);
+	std::future<response::Value> resolveIsDeprecated(service::ResolverParams&& params);
+	std::future<response::Value> resolveDeprecationReason(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class __Directive
@@ -186,18 +186,18 @@ protected:
 	__Directive();
 
 public:
-	virtual std::future<std::string> getName(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::string>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<response::Value::StringType> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::Value::StringType>> getDescription(service::RequestId requestId) const = 0;
 	virtual std::future<std::vector<__DirectiveLocation>> getLocations(service::RequestId requestId) const = 0;
 	virtual std::future<std::vector<std::shared_ptr<__InputValue>>> getArgs(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveName(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveDescription(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveLocations(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveArgs(service::ResolverParams&& params);
+	std::future<response::Value> resolveName(service::ResolverParams&& params);
+	std::future<response::Value> resolveDescription(service::ResolverParams&& params);
+	std::future<response::Value> resolveLocations(service::ResolverParams&& params);
+	std::future<response::Value> resolveArgs(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 } /* namespace object */

--- a/samples/IntrospectionSchema.h
+++ b/samples/IntrospectionSchema.h
@@ -89,12 +89,12 @@ protected:
 
 public:
 	virtual std::future<__TypeKind> getKind(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<response::Value::StringType>> getName(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<response::Value::StringType>> getDescription(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Field>>>> getFields(service::RequestId requestId, std::unique_ptr<response::Value::BooleanType>&& includeDeprecated) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Field>>>> getFields(service::RequestId requestId, std::unique_ptr<response::BooleanType>&& includeDeprecated) const = 0;
 	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Type>>>> getInterfaces(service::RequestId requestId) const = 0;
 	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Type>>>> getPossibleTypes(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__EnumValue>>>> getEnumValues(service::RequestId requestId, std::unique_ptr<response::Value::BooleanType>&& includeDeprecated) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__EnumValue>>>> getEnumValues(service::RequestId requestId, std::unique_ptr<response::BooleanType>&& includeDeprecated) const = 0;
 	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__InputValue>>>> getInputFields(service::RequestId requestId) const = 0;
 	virtual std::future<std::shared_ptr<__Type>> getOfType(service::RequestId requestId) const = 0;
 
@@ -119,12 +119,12 @@ protected:
 	__Field();
 
 public:
-	virtual std::future<response::Value::StringType> getName(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<response::Value::StringType>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<response::StringType> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDescription(service::RequestId requestId) const = 0;
 	virtual std::future<std::vector<std::shared_ptr<__InputValue>>> getArgs(service::RequestId requestId) const = 0;
 	virtual std::future<std::shared_ptr<__Type>> getType(service::RequestId requestId) const = 0;
-	virtual std::future<response::Value::BooleanType> getIsDeprecated(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<response::Value::StringType>> getDeprecationReason(service::RequestId requestId) const = 0;
+	virtual std::future<response::BooleanType> getIsDeprecated(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDeprecationReason(service::RequestId requestId) const = 0;
 
 private:
 	std::future<response::Value> resolveName(service::ResolverParams&& params);
@@ -144,10 +144,10 @@ protected:
 	__InputValue();
 
 public:
-	virtual std::future<response::Value::StringType> getName(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<response::Value::StringType>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<response::StringType> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDescription(service::RequestId requestId) const = 0;
 	virtual std::future<std::shared_ptr<__Type>> getType(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<response::Value::StringType>> getDefaultValue(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDefaultValue(service::RequestId requestId) const = 0;
 
 private:
 	std::future<response::Value> resolveName(service::ResolverParams&& params);
@@ -165,10 +165,10 @@ protected:
 	__EnumValue();
 
 public:
-	virtual std::future<response::Value::StringType> getName(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<response::Value::StringType>> getDescription(service::RequestId requestId) const = 0;
-	virtual std::future<response::Value::BooleanType> getIsDeprecated(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<response::Value::StringType>> getDeprecationReason(service::RequestId requestId) const = 0;
+	virtual std::future<response::StringType> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<response::BooleanType> getIsDeprecated(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDeprecationReason(service::RequestId requestId) const = 0;
 
 private:
 	std::future<response::Value> resolveName(service::ResolverParams&& params);
@@ -186,8 +186,8 @@ protected:
 	__Directive();
 
 public:
-	virtual std::future<response::Value::StringType> getName(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<response::Value::StringType>> getDescription(service::RequestId requestId) const = 0;
+	virtual std::future<response::StringType> getName(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDescription(service::RequestId requestId) const = 0;
 	virtual std::future<std::vector<__DirectiveLocation>> getLocations(service::RequestId requestId) const = 0;
 	virtual std::future<std::vector<std::shared_ptr<__InputValue>>> getArgs(service::RequestId requestId) const = 0;
 

--- a/samples/TodaySchema.cpp
+++ b/samples/TodaySchema.cpp
@@ -15,7 +15,7 @@ namespace graphql {
 namespace service {
 
 template <>
-today::TaskState ModifiedArgument<today::TaskState>::convert(rapidjson::Document::AllocatorType&, const rapidjson::Value& value)
+today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Value& value)
 {
 	static const std::unordered_map<std::string, today::TaskState> s_names = {
 		{ "New", today::TaskState::New },
@@ -24,7 +24,12 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(rapidjson::Document
 		{ "Unassigned", today::TaskState::Unassigned }
 	};
 
-	auto itr = s_names.find(value.GetString());
+	if (value.type() != response::Value::Type::EnumValue)
+	{
+		throw service::schema_exception({ "not a valid TaskState value" });
+	}
+
+	auto itr = s_names.find(value.get<const response::Value::StringType&>());
 
 	if (itr == s_names.cend())
 	{
@@ -35,7 +40,7 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(rapidjson::Document
 }
 
 template <>
-std::future<rapidjson::Value> service::ModifiedResult<today::TaskState>::convert(std::future<today::TaskState>&& value, ResolverParams&&)
+std::future<response::Value> service::ModifiedResult<today::TaskState>::convert(std::future<today::TaskState>&& value, ResolverParams&&)
 {
 	static const std::string s_names[] = {
 		"New",
@@ -44,38 +49,33 @@ std::future<rapidjson::Value> service::ModifiedResult<today::TaskState>::convert
 		"Unassigned"
 	};
 
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef(s_names[static_cast<size_t>(value.get())].c_str()));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value(std::string(s_names[static_cast<size_t>(value.get())])));
 
 	return promise.get_future();
 }
 
 template <>
-today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(rapidjson::Document::AllocatorType& allocator, const rapidjson::Value& value)
+today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(const response::Value& value)
 {
 	const auto defaultValue = []()
 	{
-		rapidjson::Document values(rapidjson::Type::kObjectType);
-		auto& valuesAllocator = values.GetAllocator();
-		rapidjson::Document parsed;
-		rapidjson::Value entry;
+		response::Value values(response::Value::Type::Map);
+		response::Value entry;
 
-		parsed.Parse(R"js(true)js");
-		entry.CopyFrom(parsed, valuesAllocator);
-		values.AddMember(rapidjson::StringRef("isComplete"), entry, valuesAllocator);
+		entry = response::Value(true);
+		values.emplace_back("isComplete", std::move(entry));
 
 		return values;
 	}();
 
-	auto valueId = service::ModifiedArgument<std::vector<uint8_t>>::require(allocator, "id", value.GetObject());
-	auto pairIsComplete = service::ModifiedArgument<bool>::find<service::TypeModifier::Nullable>(allocator, "isComplete", value.GetObject());
+	auto valueId = service::ModifiedArgument<std::vector<uint8_t>>::require("id", value);
+	auto pairIsComplete = service::ModifiedArgument<response::Value::BooleanType>::find<service::TypeModifier::Nullable>("isComplete", value);
 	auto valueIsComplete = (pairIsComplete.second
 		? std::move(pairIsComplete.first)
-		: service::ModifiedArgument<bool>::require<service::TypeModifier::Nullable>(allocator, "isComplete", defaultValue.GetObject()));
-	auto valueClientMutationId = service::ModifiedArgument<std::string>::require<service::TypeModifier::Nullable>(allocator, "clientMutationId", value.GetObject());
+		: service::ModifiedArgument<response::Value::BooleanType>::require<service::TypeModifier::Nullable>("isComplete", defaultValue));
+	auto valueClientMutationId = service::ModifiedArgument<response::Value::StringType>::require<service::TypeModifier::Nullable>("clientMutationId", value);
 
 	return {
 		std::move(valueId),
@@ -110,83 +110,81 @@ Query::Query()
 	today::AddTypesToSchema(_schema);
 }
 
-std::future<rapidjson::Value> Query::resolveNode(service::ResolverParams&& params)
+std::future<response::Value> Query::resolveNode(service::ResolverParams&& params)
 {
-	auto argId = service::ModifiedArgument<std::vector<uint8_t>>::require(params.allocator, "id", params.arguments);
+	auto argId = service::ModifiedArgument<std::vector<uint8_t>>::require("id", params.arguments);
 	auto result = getNode(params.requestId, std::move(argId));
 
 	return service::ModifiedResult<service::Object>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Query::resolveAppointments(service::ResolverParams&& params)
+std::future<response::Value> Query::resolveAppointments(service::ResolverParams&& params)
 {
-	auto argFirst = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>(params.allocator, "first", params.arguments);
-	auto argAfter = service::ModifiedArgument<rapidjson::Value>::require<service::TypeModifier::Nullable>(params.allocator, "after", params.arguments);
-	auto argLast = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>(params.allocator, "last", params.arguments);
-	auto argBefore = service::ModifiedArgument<rapidjson::Value>::require<service::TypeModifier::Nullable>(params.allocator, "before", params.arguments);
+	auto argFirst = service::ModifiedArgument<response::Value::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
+	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
+	auto argLast = service::ModifiedArgument<response::Value::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
+	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	auto result = getAppointments(params.requestId, std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 
 	return service::ModifiedResult<AppointmentConnection>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Query::resolveTasks(service::ResolverParams&& params)
+std::future<response::Value> Query::resolveTasks(service::ResolverParams&& params)
 {
-	auto argFirst = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>(params.allocator, "first", params.arguments);
-	auto argAfter = service::ModifiedArgument<rapidjson::Value>::require<service::TypeModifier::Nullable>(params.allocator, "after", params.arguments);
-	auto argLast = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>(params.allocator, "last", params.arguments);
-	auto argBefore = service::ModifiedArgument<rapidjson::Value>::require<service::TypeModifier::Nullable>(params.allocator, "before", params.arguments);
+	auto argFirst = service::ModifiedArgument<response::Value::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
+	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
+	auto argLast = service::ModifiedArgument<response::Value::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
+	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	auto result = getTasks(params.requestId, std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 
 	return service::ModifiedResult<TaskConnection>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Query::resolveUnreadCounts(service::ResolverParams&& params)
+std::future<response::Value> Query::resolveUnreadCounts(service::ResolverParams&& params)
 {
-	auto argFirst = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>(params.allocator, "first", params.arguments);
-	auto argAfter = service::ModifiedArgument<rapidjson::Value>::require<service::TypeModifier::Nullable>(params.allocator, "after", params.arguments);
-	auto argLast = service::ModifiedArgument<int>::require<service::TypeModifier::Nullable>(params.allocator, "last", params.arguments);
-	auto argBefore = service::ModifiedArgument<rapidjson::Value>::require<service::TypeModifier::Nullable>(params.allocator, "before", params.arguments);
+	auto argFirst = service::ModifiedArgument<response::Value::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
+	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
+	auto argLast = service::ModifiedArgument<response::Value::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
+	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	auto result = getUnreadCounts(params.requestId, std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 
 	return service::ModifiedResult<FolderConnection>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Query::resolveAppointmentsById(service::ResolverParams&& params)
+std::future<response::Value> Query::resolveAppointmentsById(service::ResolverParams&& params)
 {
-	auto argIds = service::ModifiedArgument<std::vector<uint8_t>>::require<service::TypeModifier::List>(params.allocator, "ids", params.arguments);
+	auto argIds = service::ModifiedArgument<std::vector<uint8_t>>::require<service::TypeModifier::List>("ids", params.arguments);
 	auto result = getAppointmentsById(params.requestId, std::move(argIds));
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Query::resolveTasksById(service::ResolverParams&& params)
+std::future<response::Value> Query::resolveTasksById(service::ResolverParams&& params)
 {
-	auto argIds = service::ModifiedArgument<std::vector<uint8_t>>::require<service::TypeModifier::List>(params.allocator, "ids", params.arguments);
+	auto argIds = service::ModifiedArgument<std::vector<uint8_t>>::require<service::TypeModifier::List>("ids", params.arguments);
 	auto result = getTasksById(params.requestId, std::move(argIds));
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Query::resolveUnreadCountsById(service::ResolverParams&& params)
+std::future<response::Value> Query::resolveUnreadCountsById(service::ResolverParams&& params)
 {
-	auto argIds = service::ModifiedArgument<std::vector<uint8_t>>::require<service::TypeModifier::List>(params.allocator, "ids", params.arguments);
+	auto argIds = service::ModifiedArgument<std::vector<uint8_t>>::require<service::TypeModifier::List>("ids", params.arguments);
 	auto result = getUnreadCountsById(params.requestId, std::move(argIds));
 
 	return service::ModifiedResult<Folder>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Query::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> Query::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("Query"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("Query"));
 
 	return promise.get_future();
 }
 
-std::future<rapidjson::Value> Query::resolve__schema(service::ResolverParams&& params)
+std::future<response::Value> Query::resolve__schema(service::ResolverParams&& params)
 {
 	std::promise<std::shared_ptr<service::Object>> promise;
 
@@ -195,9 +193,9 @@ std::future<rapidjson::Value> Query::resolve__schema(service::ResolverParams&& p
 	return service::ModifiedResult<service::Object>::convert(promise.get_future(), std::move(params));
 }
 
-std::future<rapidjson::Value> Query::resolve__type(service::ResolverParams&& params)
+std::future<response::Value> Query::resolve__type(service::ResolverParams&& params)
 {
-	auto argName = service::ModifiedArgument<std::string>::require(params.allocator, "name", params.arguments);
+	auto argName = service::ModifiedArgument<std::string>::require("name", params.arguments);
 	std::promise<std::shared_ptr<introspection::object::__Type>> promise;
 
 	promise.set_value(_schema->LookupType(argName));
@@ -216,27 +214,25 @@ PageInfo::PageInfo()
 {
 }
 
-std::future<rapidjson::Value> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
+std::future<response::Value> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
 {
 	auto result = getHasNextPage(params.requestId);
 
-	return service::ModifiedResult<bool>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
+std::future<response::Value> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
 {
 	auto result = getHasPreviousPage(params.requestId);
 
-	return service::ModifiedResult<bool>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> PageInfo::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> PageInfo::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("PageInfo"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("PageInfo"));
 
 	return promise.get_future();
 }
@@ -252,27 +248,25 @@ AppointmentEdge::AppointmentEdge()
 {
 }
 
-std::future<rapidjson::Value> AppointmentEdge::resolveNode(service::ResolverParams&& params)
+std::future<response::Value> AppointmentEdge::resolveNode(service::ResolverParams&& params)
 {
 	auto result = getNode(params.requestId);
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
+std::future<response::Value> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
 {
-	auto result = getCursor(params.requestId, params.allocator);
+	auto result = getCursor(params.requestId);
 
-	return service::ModifiedResult<rapidjson::Value>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> AppointmentEdge::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> AppointmentEdge::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("AppointmentEdge"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("AppointmentEdge"));
 
 	return promise.get_future();
 }
@@ -288,27 +282,25 @@ AppointmentConnection::AppointmentConnection()
 {
 }
 
-std::future<rapidjson::Value> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<response::Value> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	auto result = getPageInfo(params.requestId);
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
+std::future<response::Value> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
 {
 	auto result = getEdges(params.requestId);
 
 	return service::ModifiedResult<AppointmentEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> AppointmentConnection::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> AppointmentConnection::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("AppointmentConnection"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("AppointmentConnection"));
 
 	return promise.get_future();
 }
@@ -324,27 +316,25 @@ TaskEdge::TaskEdge()
 {
 }
 
-std::future<rapidjson::Value> TaskEdge::resolveNode(service::ResolverParams&& params)
+std::future<response::Value> TaskEdge::resolveNode(service::ResolverParams&& params)
 {
 	auto result = getNode(params.requestId);
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> TaskEdge::resolveCursor(service::ResolverParams&& params)
+std::future<response::Value> TaskEdge::resolveCursor(service::ResolverParams&& params)
 {
-	auto result = getCursor(params.requestId, params.allocator);
+	auto result = getCursor(params.requestId);
 
-	return service::ModifiedResult<rapidjson::Value>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> TaskEdge::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> TaskEdge::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("TaskEdge"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("TaskEdge"));
 
 	return promise.get_future();
 }
@@ -360,27 +350,25 @@ TaskConnection::TaskConnection()
 {
 }
 
-std::future<rapidjson::Value> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<response::Value> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	auto result = getPageInfo(params.requestId);
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> TaskConnection::resolveEdges(service::ResolverParams&& params)
+std::future<response::Value> TaskConnection::resolveEdges(service::ResolverParams&& params)
 {
 	auto result = getEdges(params.requestId);
 
 	return service::ModifiedResult<TaskEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> TaskConnection::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> TaskConnection::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("TaskConnection"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("TaskConnection"));
 
 	return promise.get_future();
 }
@@ -396,27 +384,25 @@ FolderEdge::FolderEdge()
 {
 }
 
-std::future<rapidjson::Value> FolderEdge::resolveNode(service::ResolverParams&& params)
+std::future<response::Value> FolderEdge::resolveNode(service::ResolverParams&& params)
 {
 	auto result = getNode(params.requestId);
 
 	return service::ModifiedResult<Folder>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> FolderEdge::resolveCursor(service::ResolverParams&& params)
+std::future<response::Value> FolderEdge::resolveCursor(service::ResolverParams&& params)
 {
-	auto result = getCursor(params.requestId, params.allocator);
+	auto result = getCursor(params.requestId);
 
-	return service::ModifiedResult<rapidjson::Value>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> FolderEdge::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> FolderEdge::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("FolderEdge"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("FolderEdge"));
 
 	return promise.get_future();
 }
@@ -432,27 +418,25 @@ FolderConnection::FolderConnection()
 {
 }
 
-std::future<rapidjson::Value> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<response::Value> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	auto result = getPageInfo(params.requestId);
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> FolderConnection::resolveEdges(service::ResolverParams&& params)
+std::future<response::Value> FolderConnection::resolveEdges(service::ResolverParams&& params)
 {
 	auto result = getEdges(params.requestId);
 
 	return service::ModifiedResult<FolderEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> FolderConnection::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> FolderConnection::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("FolderConnection"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("FolderConnection"));
 
 	return promise.get_future();
 }
@@ -468,27 +452,25 @@ CompleteTaskPayload::CompleteTaskPayload()
 {
 }
 
-std::future<rapidjson::Value> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
+std::future<response::Value> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
 {
 	auto result = getTask(params.requestId);
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
+std::future<response::Value> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
 {
 	auto result = getClientMutationId(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> CompleteTaskPayload::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> CompleteTaskPayload::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("CompleteTaskPayload"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("CompleteTaskPayload"));
 
 	return promise.get_future();
 }
@@ -503,21 +485,19 @@ Mutation::Mutation()
 {
 }
 
-std::future<rapidjson::Value> Mutation::resolveCompleteTask(service::ResolverParams&& params)
+std::future<response::Value> Mutation::resolveCompleteTask(service::ResolverParams&& params)
 {
-	auto argInput = service::ModifiedArgument<CompleteTaskInput>::require(params.allocator, "input", params.arguments);
+	auto argInput = service::ModifiedArgument<CompleteTaskInput>::require("input", params.arguments);
 	auto result = getCompleteTask(params.requestId, std::move(argInput));
 
 	return service::ModifiedResult<CompleteTaskPayload>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Mutation::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> Mutation::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("Mutation"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("Mutation"));
 
 	return promise.get_future();
 }
@@ -532,20 +512,18 @@ Subscription::Subscription()
 {
 }
 
-std::future<rapidjson::Value> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
+std::future<response::Value> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
 {
 	auto result = getNextAppointmentChange(params.requestId);
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Subscription::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> Subscription::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("Subscription"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("Subscription"));
 
 	return promise.get_future();
 }
@@ -564,41 +542,39 @@ Appointment::Appointment()
 {
 }
 
-std::future<rapidjson::Value> Appointment::resolveId(service::ResolverParams&& params)
+std::future<response::Value> Appointment::resolveId(service::ResolverParams&& params)
 {
 	auto result = getId(params.requestId);
 
 	return service::ModifiedResult<std::vector<uint8_t>>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Appointment::resolveWhen(service::ResolverParams&& params)
+std::future<response::Value> Appointment::resolveWhen(service::ResolverParams&& params)
 {
-	auto result = getWhen(params.requestId, params.allocator);
+	auto result = getWhen(params.requestId);
 
-	return service::ModifiedResult<rapidjson::Value>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Appointment::resolveSubject(service::ResolverParams&& params)
+std::future<response::Value> Appointment::resolveSubject(service::ResolverParams&& params)
 {
 	auto result = getSubject(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Appointment::resolveIsNow(service::ResolverParams&& params)
+std::future<response::Value> Appointment::resolveIsNow(service::ResolverParams&& params)
 {
 	auto result = getIsNow(params.requestId);
 
-	return service::ModifiedResult<bool>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Appointment::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> Appointment::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("Appointment"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("Appointment"));
 
 	return promise.get_future();
 }
@@ -616,34 +592,32 @@ Task::Task()
 {
 }
 
-std::future<rapidjson::Value> Task::resolveId(service::ResolverParams&& params)
+std::future<response::Value> Task::resolveId(service::ResolverParams&& params)
 {
 	auto result = getId(params.requestId);
 
 	return service::ModifiedResult<std::vector<uint8_t>>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Task::resolveTitle(service::ResolverParams&& params)
+std::future<response::Value> Task::resolveTitle(service::ResolverParams&& params)
 {
 	auto result = getTitle(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Task::resolveIsComplete(service::ResolverParams&& params)
+std::future<response::Value> Task::resolveIsComplete(service::ResolverParams&& params)
 {
 	auto result = getIsComplete(params.requestId);
 
-	return service::ModifiedResult<bool>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Task::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> Task::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("Task"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("Task"));
 
 	return promise.get_future();
 }
@@ -661,34 +635,32 @@ Folder::Folder()
 {
 }
 
-std::future<rapidjson::Value> Folder::resolveId(service::ResolverParams&& params)
+std::future<response::Value> Folder::resolveId(service::ResolverParams&& params)
 {
 	auto result = getId(params.requestId);
 
 	return service::ModifiedResult<std::vector<uint8_t>>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Folder::resolveName(service::ResolverParams&& params)
+std::future<response::Value> Folder::resolveName(service::ResolverParams&& params)
 {
 	auto result = getName(params.requestId);
 
-	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Folder::resolveUnreadCount(service::ResolverParams&& params)
+std::future<response::Value> Folder::resolveUnreadCount(service::ResolverParams&& params)
 {
 	auto result = getUnreadCount(params.requestId);
 
-	return service::ModifiedResult<int>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::Value::IntType>::convert(std::move(result), std::move(params));
 }
 
-std::future<rapidjson::Value> Folder::resolve__typename(service::ResolverParams&&)
+std::future<response::Value> Folder::resolve__typename(service::ResolverParams&&)
 {
-	std::promise<rapidjson::Value> promise;
-	rapidjson::Value result(rapidjson::Type::kStringType);
+	std::promise<response::Value> promise;
 
-	result.SetString(rapidjson::StringRef("Folder"));
-	promise.set_value(std::move(result));
+	promise.set_value(response::Value("Folder"));
 
 	return promise.get_future();
 }
@@ -753,84 +725,46 @@ void AddTypesToSchema(std::shared_ptr<introspection::Schema> schema)
 		{ "Unassigned", R"md()md", R"md(Need to deprecate an [enum value](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md" }
 	});
 
-	rapidjson::Document defaultCompleteTaskInputid;
-	defaultCompleteTaskInputid.Parse(R"js(null)js");
-	rapidjson::Document defaultCompleteTaskInputisComplete;
-	defaultCompleteTaskInputisComplete.Parse(R"js(true)js");
-	rapidjson::Document defaultCompleteTaskInputclientMutationId;
-	defaultCompleteTaskInputclientMutationId.Parse(R"js(null)js");
 	typeCompleteTaskInput->AddInputValues({
-		std::make_shared<introspection::InputValue>("id", R"md()md", std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("ID")), defaultCompleteTaskInputid),
-		std::make_shared<introspection::InputValue>("isComplete", R"md()md", schema->LookupType("Boolean"), defaultCompleteTaskInputisComplete),
-		std::make_shared<introspection::InputValue>("clientMutationId", R"md()md", schema->LookupType("String"), defaultCompleteTaskInputclientMutationId)
+		std::make_shared<introspection::InputValue>("id", R"md()md", std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"),
+		std::make_shared<introspection::InputValue>("isComplete", R"md()md", schema->LookupType("Boolean"), R"gql(true)gql"),
+		std::make_shared<introspection::InputValue>("clientMutationId", R"md()md", schema->LookupType("String"), R"gql()gql")
 	});
 
 	typeNode->AddFields({
 		std::make_shared<introspection::Field>("id", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>(), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("ID")))
 	});
 
-	rapidjson::Document defaultQuerynodeid;
-	defaultQuerynodeid.Parse(R"js(null)js");
-	rapidjson::Document defaultQueryappointmentsfirst;
-	defaultQueryappointmentsfirst.Parse(R"js(null)js");
-	rapidjson::Document defaultQueryappointmentsafter;
-	defaultQueryappointmentsafter.Parse(R"js(null)js");
-	rapidjson::Document defaultQueryappointmentslast;
-	defaultQueryappointmentslast.Parse(R"js(null)js");
-	rapidjson::Document defaultQueryappointmentsbefore;
-	defaultQueryappointmentsbefore.Parse(R"js(null)js");
-	rapidjson::Document defaultQuerytasksfirst;
-	defaultQuerytasksfirst.Parse(R"js(null)js");
-	rapidjson::Document defaultQuerytasksafter;
-	defaultQuerytasksafter.Parse(R"js(null)js");
-	rapidjson::Document defaultQuerytaskslast;
-	defaultQuerytaskslast.Parse(R"js(null)js");
-	rapidjson::Document defaultQuerytasksbefore;
-	defaultQuerytasksbefore.Parse(R"js(null)js");
-	rapidjson::Document defaultQueryunreadCountsfirst;
-	defaultQueryunreadCountsfirst.Parse(R"js(null)js");
-	rapidjson::Document defaultQueryunreadCountsafter;
-	defaultQueryunreadCountsafter.Parse(R"js(null)js");
-	rapidjson::Document defaultQueryunreadCountslast;
-	defaultQueryunreadCountslast.Parse(R"js(null)js");
-	rapidjson::Document defaultQueryunreadCountsbefore;
-	defaultQueryunreadCountsbefore.Parse(R"js(null)js");
-	rapidjson::Document defaultQueryappointmentsByIdids;
-	defaultQueryappointmentsByIdids.Parse(R"js(null)js");
-	rapidjson::Document defaultQuerytasksByIdids;
-	defaultQuerytasksByIdids.Parse(R"js(null)js");
-	rapidjson::Document defaultQueryunreadCountsByIdids;
-	defaultQueryunreadCountsByIdids.Parse(R"js(null)js");
 	typeQuery->AddFields({
 		std::make_shared<introspection::Field>("node", R"md([Object Identification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#object-identification))md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("id", R"md()md", std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("ID")), defaultQuerynodeid)
+			std::make_shared<introspection::InputValue>("id", R"md()md", std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql")
 		}), schema->LookupType("Node")),
 		std::make_shared<introspection::Field>("appointments", R"md(Appointments [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("first", R"md()md", schema->LookupType("Int"), defaultQueryappointmentsfirst),
-			std::make_shared<introspection::InputValue>("after", R"md()md", schema->LookupType("ItemCursor"), defaultQueryappointmentsafter),
-			std::make_shared<introspection::InputValue>("last", R"md()md", schema->LookupType("Int"), defaultQueryappointmentslast),
-			std::make_shared<introspection::InputValue>("before", R"md()md", schema->LookupType("ItemCursor"), defaultQueryappointmentsbefore)
+			std::make_shared<introspection::InputValue>("first", R"md()md", schema->LookupType("Int"), R"gql()gql"),
+			std::make_shared<introspection::InputValue>("after", R"md()md", schema->LookupType("ItemCursor"), R"gql()gql"),
+			std::make_shared<introspection::InputValue>("last", R"md()md", schema->LookupType("Int"), R"gql()gql"),
+			std::make_shared<introspection::InputValue>("before", R"md()md", schema->LookupType("ItemCursor"), R"gql()gql")
 		}), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("AppointmentConnection"))),
 		std::make_shared<introspection::Field>("tasks", R"md(Tasks [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("first", R"md()md", schema->LookupType("Int"), defaultQuerytasksfirst),
-			std::make_shared<introspection::InputValue>("after", R"md()md", schema->LookupType("ItemCursor"), defaultQuerytasksafter),
-			std::make_shared<introspection::InputValue>("last", R"md()md", schema->LookupType("Int"), defaultQuerytaskslast),
-			std::make_shared<introspection::InputValue>("before", R"md()md", schema->LookupType("ItemCursor"), defaultQuerytasksbefore)
+			std::make_shared<introspection::InputValue>("first", R"md()md", schema->LookupType("Int"), R"gql()gql"),
+			std::make_shared<introspection::InputValue>("after", R"md()md", schema->LookupType("ItemCursor"), R"gql()gql"),
+			std::make_shared<introspection::InputValue>("last", R"md()md", schema->LookupType("Int"), R"gql()gql"),
+			std::make_shared<introspection::InputValue>("before", R"md()md", schema->LookupType("ItemCursor"), R"gql()gql")
 		}), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("TaskConnection"))),
 		std::make_shared<introspection::Field>("unreadCounts", R"md(Folder unread counts [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("first", R"md()md", schema->LookupType("Int"), defaultQueryunreadCountsfirst),
-			std::make_shared<introspection::InputValue>("after", R"md()md", schema->LookupType("ItemCursor"), defaultQueryunreadCountsafter),
-			std::make_shared<introspection::InputValue>("last", R"md()md", schema->LookupType("Int"), defaultQueryunreadCountslast),
-			std::make_shared<introspection::InputValue>("before", R"md()md", schema->LookupType("ItemCursor"), defaultQueryunreadCountsbefore)
+			std::make_shared<introspection::InputValue>("first", R"md()md", schema->LookupType("Int"), R"gql()gql"),
+			std::make_shared<introspection::InputValue>("after", R"md()md", schema->LookupType("ItemCursor"), R"gql()gql"),
+			std::make_shared<introspection::InputValue>("last", R"md()md", schema->LookupType("Int"), R"gql()gql"),
+			std::make_shared<introspection::InputValue>("before", R"md()md", schema->LookupType("ItemCursor"), R"gql()gql")
 		}), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("FolderConnection"))),
 		std::make_shared<introspection::Field>("appointmentsById", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("ids", R"md()md", std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("ID")))), defaultQueryappointmentsByIdids)
+			std::make_shared<introspection::InputValue>("ids", R"md()md", std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql")
 		}), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, schema->LookupType("Appointment")))),
 		std::make_shared<introspection::Field>("tasksById", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("ids", R"md()md", std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("ID")))), defaultQuerytasksByIdids)
+			std::make_shared<introspection::InputValue>("ids", R"md()md", std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql")
 		}), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, schema->LookupType("Task")))),
 		std::make_shared<introspection::Field>("unreadCountsById", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("ids", R"md()md", std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("ID")))), defaultQueryunreadCountsByIdids)
+			std::make_shared<introspection::InputValue>("ids", R"md()md", std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql")
 		}), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, std::make_shared<introspection::WrapperType>(introspection::__TypeKind::LIST, schema->LookupType("Folder"))))
 	});
 	typePageInfo->AddFields({
@@ -865,11 +799,9 @@ void AddTypesToSchema(std::shared_ptr<introspection::Schema> schema)
 		std::make_shared<introspection::Field>("task", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("Task")),
 		std::make_shared<introspection::Field>("clientMutationId", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String"))
 	});
-	rapidjson::Document defaultMutationcompleteTaskinput;
-	defaultMutationcompleteTaskinput.Parse(R"js(null)js");
 	typeMutation->AddFields({
 		std::make_shared<introspection::Field>("completeTask", R"md()md", std::unique_ptr<std::string>(nullptr), std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("input", R"md()md", std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("CompleteTaskInput")), defaultMutationcompleteTaskinput)
+			std::make_shared<introspection::InputValue>("input", R"md()md", std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("CompleteTaskInput")), R"gql()gql")
 		}), std::make_shared<introspection::WrapperType>(introspection::__TypeKind::NON_NULL, schema->LookupType("CompleteTaskPayload")))
 	});
 	typeSubscription->AddFields({

--- a/samples/TodaySchema.cpp
+++ b/samples/TodaySchema.cpp
@@ -24,12 +24,12 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Val
 		{ "Unassigned", today::TaskState::Unassigned }
 	};
 
-	if (value.type() != response::Value::Type::EnumValue)
+	if (value.type() != response::Type::EnumValue)
 	{
 		throw service::schema_exception({ "not a valid TaskState value" });
 	}
 
-	auto itr = s_names.find(value.get<const response::Value::StringType&>());
+	auto itr = s_names.find(value.get<const response::StringType&>());
 
 	if (itr == s_names.cend())
 	{
@@ -61,7 +61,7 @@ today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(con
 {
 	const auto defaultValue = []()
 	{
-		response::Value values(response::Value::Type::Map);
+		response::Value values(response::Type::Map);
 		response::Value entry;
 
 		entry = response::Value(true);
@@ -71,11 +71,11 @@ today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(con
 	}();
 
 	auto valueId = service::ModifiedArgument<std::vector<uint8_t>>::require("id", value);
-	auto pairIsComplete = service::ModifiedArgument<response::Value::BooleanType>::find<service::TypeModifier::Nullable>("isComplete", value);
+	auto pairIsComplete = service::ModifiedArgument<response::BooleanType>::find<service::TypeModifier::Nullable>("isComplete", value);
 	auto valueIsComplete = (pairIsComplete.second
 		? std::move(pairIsComplete.first)
-		: service::ModifiedArgument<response::Value::BooleanType>::require<service::TypeModifier::Nullable>("isComplete", defaultValue));
-	auto valueClientMutationId = service::ModifiedArgument<response::Value::StringType>::require<service::TypeModifier::Nullable>("clientMutationId", value);
+		: service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable>("isComplete", defaultValue));
+	auto valueClientMutationId = service::ModifiedArgument<response::StringType>::require<service::TypeModifier::Nullable>("clientMutationId", value);
 
 	return {
 		std::move(valueId),
@@ -120,9 +120,9 @@ std::future<response::Value> Query::resolveNode(service::ResolverParams&& params
 
 std::future<response::Value> Query::resolveAppointments(service::ResolverParams&& params)
 {
-	auto argFirst = service::ModifiedArgument<response::Value::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
+	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
-	auto argLast = service::ModifiedArgument<response::Value::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
+	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	auto result = getAppointments(params.requestId, std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 
@@ -131,9 +131,9 @@ std::future<response::Value> Query::resolveAppointments(service::ResolverParams&
 
 std::future<response::Value> Query::resolveTasks(service::ResolverParams&& params)
 {
-	auto argFirst = service::ModifiedArgument<response::Value::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
+	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
-	auto argLast = service::ModifiedArgument<response::Value::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
+	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	auto result = getTasks(params.requestId, std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 
@@ -142,9 +142,9 @@ std::future<response::Value> Query::resolveTasks(service::ResolverParams&& param
 
 std::future<response::Value> Query::resolveUnreadCounts(service::ResolverParams&& params)
 {
-	auto argFirst = service::ModifiedArgument<response::Value::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
+	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
-	auto argLast = service::ModifiedArgument<response::Value::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
+	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	auto result = getUnreadCounts(params.requestId, std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 
@@ -218,14 +218,14 @@ std::future<response::Value> PageInfo::resolveHasNextPage(service::ResolverParam
 {
 	auto result = getHasNextPage(params.requestId);
 
-	return service::ModifiedResult<response::Value::BooleanType>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
 std::future<response::Value> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
 {
 	auto result = getHasPreviousPage(params.requestId);
 
-	return service::ModifiedResult<response::Value::BooleanType>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
 std::future<response::Value> PageInfo::resolve__typename(service::ResolverParams&&)
@@ -463,7 +463,7 @@ std::future<response::Value> CompleteTaskPayload::resolveClientMutationId(servic
 {
 	auto result = getClientMutationId(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> CompleteTaskPayload::resolve__typename(service::ResolverParams&&)
@@ -560,14 +560,14 @@ std::future<response::Value> Appointment::resolveSubject(service::ResolverParams
 {
 	auto result = getSubject(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> Appointment::resolveIsNow(service::ResolverParams&& params)
 {
 	auto result = getIsNow(params.requestId);
 
-	return service::ModifiedResult<response::Value::BooleanType>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
 std::future<response::Value> Appointment::resolve__typename(service::ResolverParams&&)
@@ -603,14 +603,14 @@ std::future<response::Value> Task::resolveTitle(service::ResolverParams&& params
 {
 	auto result = getTitle(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> Task::resolveIsComplete(service::ResolverParams&& params)
 {
 	auto result = getIsComplete(params.requestId);
 
-	return service::ModifiedResult<response::Value::BooleanType>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
 std::future<response::Value> Task::resolve__typename(service::ResolverParams&&)
@@ -646,14 +646,14 @@ std::future<response::Value> Folder::resolveName(service::ResolverParams&& param
 {
 	auto result = getName(params.requestId);
 
-	return service::ModifiedResult<response::Value::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> Folder::resolveUnreadCount(service::ResolverParams&& params)
 {
 	auto result = getUnreadCount(params.requestId);
 
-	return service::ModifiedResult<response::Value::IntType>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
 }
 
 std::future<response::Value> Folder::resolve__typename(service::ResolverParams&&)

--- a/samples/TodaySchema.h
+++ b/samples/TodaySchema.h
@@ -30,8 +30,8 @@ enum class TaskState
 struct CompleteTaskInput
 {
 	std::vector<uint8_t> id;
-	std::unique_ptr<bool> isComplete;
-	std::unique_ptr<std::string> clientMutationId;
+	std::unique_ptr<response::Value::BooleanType> isComplete;
+	std::unique_ptr<response::Value::StringType> clientMutationId;
 };
 
 struct Node
@@ -64,25 +64,25 @@ protected:
 
 public:
 	virtual std::future<std::shared_ptr<service::Object>> getNode(service::RequestId requestId, std::vector<uint8_t>&& id) const = 0;
-	virtual std::future<std::shared_ptr<AppointmentConnection>> getAppointments(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const = 0;
-	virtual std::future<std::shared_ptr<TaskConnection>> getTasks(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const = 0;
-	virtual std::future<std::shared_ptr<FolderConnection>> getUnreadCounts(service::RequestId requestId, std::unique_ptr<int>&& first, std::unique_ptr<rapidjson::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<rapidjson::Value>&& before) const = 0;
+	virtual std::future<std::shared_ptr<AppointmentConnection>> getAppointments(service::RequestId requestId, std::unique_ptr<response::Value::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::Value::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
+	virtual std::future<std::shared_ptr<TaskConnection>> getTasks(service::RequestId requestId, std::unique_ptr<response::Value::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::Value::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
+	virtual std::future<std::shared_ptr<FolderConnection>> getUnreadCounts(service::RequestId requestId, std::unique_ptr<response::Value::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::Value::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
 	virtual std::future<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const = 0;
 	virtual std::future<std::vector<std::shared_ptr<Task>>> getTasksById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const = 0;
 	virtual std::future<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveNode(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveAppointments(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveTasks(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveUnreadCounts(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveAppointmentsById(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveTasksById(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveUnreadCountsById(service::ResolverParams&& params);
+	std::future<response::Value> resolveNode(service::ResolverParams&& params);
+	std::future<response::Value> resolveAppointments(service::ResolverParams&& params);
+	std::future<response::Value> resolveTasks(service::ResolverParams&& params);
+	std::future<response::Value> resolveUnreadCounts(service::ResolverParams&& params);
+	std::future<response::Value> resolveAppointmentsById(service::ResolverParams&& params);
+	std::future<response::Value> resolveTasksById(service::ResolverParams&& params);
+	std::future<response::Value> resolveUnreadCountsById(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolve__schema(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolve__type(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__schema(service::ResolverParams&& params);
+	std::future<response::Value> resolve__type(service::ResolverParams&& params);
 
 	std::shared_ptr<introspection::Schema> _schema;
 };
@@ -94,14 +94,14 @@ protected:
 	PageInfo();
 
 public:
-	virtual std::future<bool> getHasNextPage(service::RequestId requestId) const = 0;
-	virtual std::future<bool> getHasPreviousPage(service::RequestId requestId) const = 0;
+	virtual std::future<response::Value::BooleanType> getHasNextPage(service::RequestId requestId) const = 0;
+	virtual std::future<response::Value::BooleanType> getHasPreviousPage(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveHasNextPage(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveHasPreviousPage(service::ResolverParams&& params);
+	std::future<response::Value> resolveHasNextPage(service::ResolverParams&& params);
+	std::future<response::Value> resolveHasPreviousPage(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class AppointmentEdge
@@ -112,13 +112,13 @@ protected:
 
 public:
 	virtual std::future<std::shared_ptr<Appointment>> getNode(service::RequestId requestId) const = 0;
-	virtual std::future<rapidjson::Value> getCursor(service::RequestId requestId, rapidjson::Document::AllocatorType& allocator) const = 0;
+	virtual std::future<response::Value> getCursor(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveNode(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<response::Value> resolveNode(service::ResolverParams&& params);
+	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class AppointmentConnection
@@ -132,10 +132,10 @@ public:
 	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
+	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class TaskEdge
@@ -146,13 +146,13 @@ protected:
 
 public:
 	virtual std::future<std::shared_ptr<Task>> getNode(service::RequestId requestId) const = 0;
-	virtual std::future<rapidjson::Value> getCursor(service::RequestId requestId, rapidjson::Document::AllocatorType& allocator) const = 0;
+	virtual std::future<response::Value> getCursor(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveNode(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<response::Value> resolveNode(service::ResolverParams&& params);
+	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class TaskConnection
@@ -166,10 +166,10 @@ public:
 	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
+	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class FolderEdge
@@ -180,13 +180,13 @@ protected:
 
 public:
 	virtual std::future<std::shared_ptr<Folder>> getNode(service::RequestId requestId) const = 0;
-	virtual std::future<rapidjson::Value> getCursor(service::RequestId requestId, rapidjson::Document::AllocatorType& allocator) const = 0;
+	virtual std::future<response::Value> getCursor(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveNode(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<response::Value> resolveNode(service::ResolverParams&& params);
+	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class FolderConnection
@@ -200,10 +200,10 @@ public:
 	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
+	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class CompleteTaskPayload
@@ -214,13 +214,13 @@ protected:
 
 public:
 	virtual std::future<std::shared_ptr<Task>> getTask(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<std::string>> getClientMutationId(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::Value::StringType>> getClientMutationId(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveTask(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveClientMutationId(service::ResolverParams&& params);
+	std::future<response::Value> resolveTask(service::ResolverParams&& params);
+	std::future<response::Value> resolveClientMutationId(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class Mutation
@@ -233,9 +233,9 @@ public:
 	virtual std::future<std::shared_ptr<CompleteTaskPayload>> getCompleteTask(service::RequestId requestId, CompleteTaskInput&& input) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveCompleteTask(service::ResolverParams&& params);
+	std::future<response::Value> resolveCompleteTask(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class Subscription
@@ -248,9 +248,9 @@ public:
 	virtual std::future<std::shared_ptr<Appointment>> getNextAppointmentChange(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveNextAppointmentChange(service::ResolverParams&& params);
+	std::future<response::Value> resolveNextAppointmentChange(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class Appointment
@@ -261,17 +261,17 @@ protected:
 	Appointment();
 
 public:
-	virtual std::future<std::unique_ptr<rapidjson::Value>> getWhen(service::RequestId requestId, rapidjson::Document::AllocatorType& allocator) const = 0;
-	virtual std::future<std::unique_ptr<std::string>> getSubject(service::RequestId requestId) const = 0;
-	virtual std::future<bool> getIsNow(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::Value>> getWhen(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::Value::StringType>> getSubject(service::RequestId requestId) const = 0;
+	virtual std::future<response::Value::BooleanType> getIsNow(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveId(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveWhen(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveSubject(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveIsNow(service::ResolverParams&& params);
+	std::future<response::Value> resolveId(service::ResolverParams&& params);
+	std::future<response::Value> resolveWhen(service::ResolverParams&& params);
+	std::future<response::Value> resolveSubject(service::ResolverParams&& params);
+	std::future<response::Value> resolveIsNow(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class Task
@@ -282,15 +282,15 @@ protected:
 	Task();
 
 public:
-	virtual std::future<std::unique_ptr<std::string>> getTitle(service::RequestId requestId) const = 0;
-	virtual std::future<bool> getIsComplete(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::Value::StringType>> getTitle(service::RequestId requestId) const = 0;
+	virtual std::future<response::Value::BooleanType> getIsComplete(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveId(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveTitle(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveIsComplete(service::ResolverParams&& params);
+	std::future<response::Value> resolveId(service::ResolverParams&& params);
+	std::future<response::Value> resolveTitle(service::ResolverParams&& params);
+	std::future<response::Value> resolveIsComplete(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 class Folder
@@ -301,15 +301,15 @@ protected:
 	Folder();
 
 public:
-	virtual std::future<std::unique_ptr<std::string>> getName(service::RequestId requestId) const = 0;
-	virtual std::future<int> getUnreadCount(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::Value::StringType>> getName(service::RequestId requestId) const = 0;
+	virtual std::future<response::Value::IntType> getUnreadCount(service::RequestId requestId) const = 0;
 
 private:
-	std::future<rapidjson::Value> resolveId(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveName(service::ResolverParams&& params);
-	std::future<rapidjson::Value> resolveUnreadCount(service::ResolverParams&& params);
+	std::future<response::Value> resolveId(service::ResolverParams&& params);
+	std::future<response::Value> resolveName(service::ResolverParams&& params);
+	std::future<response::Value> resolveUnreadCount(service::ResolverParams&& params);
 
-	std::future<rapidjson::Value> resolve__typename(service::ResolverParams&& params);
+	std::future<response::Value> resolve__typename(service::ResolverParams&& params);
 };
 
 } /* namespace object */

--- a/samples/TodaySchema.h
+++ b/samples/TodaySchema.h
@@ -30,8 +30,8 @@ enum class TaskState
 struct CompleteTaskInput
 {
 	std::vector<uint8_t> id;
-	std::unique_ptr<response::Value::BooleanType> isComplete;
-	std::unique_ptr<response::Value::StringType> clientMutationId;
+	std::unique_ptr<response::BooleanType> isComplete;
+	std::unique_ptr<response::StringType> clientMutationId;
 };
 
 struct Node
@@ -64,9 +64,9 @@ protected:
 
 public:
 	virtual std::future<std::shared_ptr<service::Object>> getNode(service::RequestId requestId, std::vector<uint8_t>&& id) const = 0;
-	virtual std::future<std::shared_ptr<AppointmentConnection>> getAppointments(service::RequestId requestId, std::unique_ptr<response::Value::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::Value::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
-	virtual std::future<std::shared_ptr<TaskConnection>> getTasks(service::RequestId requestId, std::unique_ptr<response::Value::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::Value::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
-	virtual std::future<std::shared_ptr<FolderConnection>> getUnreadCounts(service::RequestId requestId, std::unique_ptr<response::Value::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::Value::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
+	virtual std::future<std::shared_ptr<AppointmentConnection>> getAppointments(service::RequestId requestId, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
+	virtual std::future<std::shared_ptr<TaskConnection>> getTasks(service::RequestId requestId, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
+	virtual std::future<std::shared_ptr<FolderConnection>> getUnreadCounts(service::RequestId requestId, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
 	virtual std::future<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const = 0;
 	virtual std::future<std::vector<std::shared_ptr<Task>>> getTasksById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const = 0;
 	virtual std::future<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::RequestId requestId, std::vector<std::vector<uint8_t>>&& ids) const = 0;
@@ -94,8 +94,8 @@ protected:
 	PageInfo();
 
 public:
-	virtual std::future<response::Value::BooleanType> getHasNextPage(service::RequestId requestId) const = 0;
-	virtual std::future<response::Value::BooleanType> getHasPreviousPage(service::RequestId requestId) const = 0;
+	virtual std::future<response::BooleanType> getHasNextPage(service::RequestId requestId) const = 0;
+	virtual std::future<response::BooleanType> getHasPreviousPage(service::RequestId requestId) const = 0;
 
 private:
 	std::future<response::Value> resolveHasNextPage(service::ResolverParams&& params);
@@ -214,7 +214,7 @@ protected:
 
 public:
 	virtual std::future<std::shared_ptr<Task>> getTask(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<response::Value::StringType>> getClientMutationId(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getClientMutationId(service::RequestId requestId) const = 0;
 
 private:
 	std::future<response::Value> resolveTask(service::ResolverParams&& params);
@@ -262,8 +262,8 @@ protected:
 
 public:
 	virtual std::future<std::unique_ptr<response::Value>> getWhen(service::RequestId requestId) const = 0;
-	virtual std::future<std::unique_ptr<response::Value::StringType>> getSubject(service::RequestId requestId) const = 0;
-	virtual std::future<response::Value::BooleanType> getIsNow(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getSubject(service::RequestId requestId) const = 0;
+	virtual std::future<response::BooleanType> getIsNow(service::RequestId requestId) const = 0;
 
 private:
 	std::future<response::Value> resolveId(service::ResolverParams&& params);
@@ -282,8 +282,8 @@ protected:
 	Task();
 
 public:
-	virtual std::future<std::unique_ptr<response::Value::StringType>> getTitle(service::RequestId requestId) const = 0;
-	virtual std::future<response::Value::BooleanType> getIsComplete(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getTitle(service::RequestId requestId) const = 0;
+	virtual std::future<response::BooleanType> getIsComplete(service::RequestId requestId) const = 0;
 
 private:
 	std::future<response::Value> resolveId(service::ResolverParams&& params);
@@ -301,8 +301,8 @@ protected:
 	Folder();
 
 public:
-	virtual std::future<std::unique_ptr<response::Value::StringType>> getName(service::RequestId requestId) const = 0;
-	virtual std::future<response::Value::IntType> getUnreadCount(service::RequestId requestId) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getName(service::RequestId requestId) const = 0;
+	virtual std::future<response::IntType> getUnreadCount(service::RequestId requestId) const = 0;
 
 private:
 	std::future<response::Value> resolveId(service::ResolverParams&& params);

--- a/test_today.cpp
+++ b/test_today.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "Today.h"
-#include "GraphQLTree.h"
+#include "JSONResponse.h"
 
 #include <iostream>
 #include <stdexcept>
@@ -94,9 +94,9 @@ int main(int argc, char** argv)
 
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-		const rapidjson::Document variables(rapidjson::Type::kObjectType);
+		response::Value variables(response::Value::Type::Map);
 		
-		service->resolve(0, *ast, ((argc > 2) ? argv[2] : ""), variables.GetObject()).get().Accept(writer);
+		rapidjson::convertResponse(service->resolve(0, *ast, ((argc > 2) ? argv[2] : ""), variables).get()).Accept(writer);
 		std::cout << buffer.GetString() << std::endl;
 	}
 	catch (const std::runtime_error& ex)

--- a/test_today.cpp
+++ b/test_today.cpp
@@ -94,7 +94,7 @@ int main(int argc, char** argv)
 
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-		response::Value variables(response::Value::Type::Map);
+		response::Value variables(response::Type::Map);
 		
 		rapidjson::convertResponse(service->resolve(0, *ast, ((argc > 2) ? argv[2] : ""), variables).get()).Accept(writer);
 		std::cout << buffer.GetString() << std::endl;

--- a/tests.cpp
+++ b/tests.cpp
@@ -122,7 +122,7 @@ TEST_F(TodayServiceCase, QueryEverything)
 				}
 			}
 		})"_graphql;
-	response::Value variables(response::Value::Type::Map);
+	response::Value variables(response::Type::Map);
 	auto result = _service->resolve(0, *ast->root, "Everything", variables).get();
 	EXPECT_EQ(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_EQ(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
@@ -130,9 +130,9 @@ TEST_F(TodayServiceCase, QueryEverything)
 
 	try
 	{
-		ASSERT_TRUE(result.type() == response::Value::Type::Map);
+		ASSERT_TRUE(result.type() == response::Type::Map);
 		auto errorsItr = result.find("errors");
-		if (errorsItr != result.get<const response::Value::MapType&>().cend())
+		if (errorsItr != result.get<const response::MapType&>().cend())
 		{
 			rapidjson::StringBuffer buffer;
 			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -146,7 +146,7 @@ TEST_F(TodayServiceCase, QueryEverything)
 		const auto appointments = service::ScalarArgument::require("appointments", data);
 		const auto appointmentEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", appointments);
 		ASSERT_EQ(1, appointmentEdges.size()) << "appointments should have 1 entry";
-		ASSERT_TRUE(appointmentEdges[0].type() == response::Value::Type::Map) << "appointment should be an object";
+		ASSERT_TRUE(appointmentEdges[0].type() == response::Type::Map) << "appointment should be an object";
 		const auto appointmentNode = service::ScalarArgument::require("node", appointmentEdges[0]);
 		EXPECT_EQ(_fakeAppointmentId, service::IdArgument::require("id", appointmentNode)) << "id should match in base64 encoding";
 		EXPECT_EQ("Lunch?", service::StringArgument::require("subject", appointmentNode)) << "subject should match";
@@ -156,7 +156,7 @@ TEST_F(TodayServiceCase, QueryEverything)
 		const auto tasks = service::ScalarArgument::require("tasks", data);
 		const auto taskEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", tasks);
 		ASSERT_EQ(1, taskEdges.size()) << "tasks should have 1 entry";
-		ASSERT_TRUE(taskEdges[0].type() == response::Value::Type::Map) << "task should be an object";
+		ASSERT_TRUE(taskEdges[0].type() == response::Type::Map) << "task should be an object";
 		const auto taskNode = service::ScalarArgument::require("node", taskEdges[0]);
 		EXPECT_EQ(_fakeTaskId, service::IdArgument::require("id", taskNode)) << "id should match in base64 encoding";
 		EXPECT_EQ("Don't forget", service::StringArgument::require("title", taskNode)) << "title should match";
@@ -165,7 +165,7 @@ TEST_F(TodayServiceCase, QueryEverything)
 		const auto unreadCounts = service::ScalarArgument::require("unreadCounts", data);
 		const auto unreadCountEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", unreadCounts);
 		ASSERT_EQ(1, unreadCountEdges.size()) << "unreadCounts should have 1 entry";
-		ASSERT_TRUE(unreadCountEdges[0].type() == response::Value::Type::Map) << "unreadCount should be an object";
+		ASSERT_TRUE(unreadCountEdges[0].type() == response::Type::Map) << "unreadCount should be an object";
 		const auto unreadCountNode = service::ScalarArgument::require("node", unreadCountEdges[0]);
 		EXPECT_EQ(_fakeFolderId, service::IdArgument::require("id", unreadCountNode)) << "id should match in base64 encoding";
 		EXPECT_EQ("\"Fake\" Inbox", service::StringArgument::require("name", unreadCountNode)) << "name should match";
@@ -196,7 +196,7 @@ TEST_F(TodayServiceCase, QueryAppointments)
 				}
 			}
 		})"_graphql;
-	response::Value variables(response::Value::Type::Map);
+	response::Value variables(response::Type::Map);
 	auto result = _service->resolve(1, *ast->root, "", variables).get();
 	EXPECT_EQ(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_GE(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
@@ -204,9 +204,9 @@ TEST_F(TodayServiceCase, QueryAppointments)
 
 	try
 	{
-		ASSERT_TRUE(result.type() == response::Value::Type::Map);
+		ASSERT_TRUE(result.type() == response::Type::Map);
 		auto errorsItr = result.find("errors");
-		if (errorsItr != result.get<const response::Value::MapType&>().cend())
+		if (errorsItr != result.get<const response::MapType&>().cend())
 		{
 			rapidjson::StringBuffer buffer;
 			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -220,7 +220,7 @@ TEST_F(TodayServiceCase, QueryAppointments)
 		const auto appointments = service::ScalarArgument::require("appointments", data);
 		const auto appointmentEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", appointments);
 		ASSERT_EQ(1, appointmentEdges.size()) << "appointments should have 1 entry";
-		ASSERT_TRUE(appointmentEdges[0].type() == response::Value::Type::Map) << "appointment should be an object";
+		ASSERT_TRUE(appointmentEdges[0].type() == response::Type::Map) << "appointment should be an object";
 		const auto appointmentNode = service::ScalarArgument::require("node", appointmentEdges[0]);
 		EXPECT_EQ(_fakeAppointmentId, service::IdArgument::require("appointmentId", appointmentNode)) << "id should match in base64 encoding";
 		EXPECT_EQ("Lunch?", service::StringArgument::require("subject", appointmentNode)) << "subject should match";
@@ -251,7 +251,7 @@ TEST_F(TodayServiceCase, QueryTasks)
 				}
 			}
 		})gql"_graphql;
-	response::Value variables(response::Value::Type::Map);
+	response::Value variables(response::Type::Map);
 	auto result = _service->resolve(2, *ast->root, "", variables).get();
 	EXPECT_GE(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_EQ(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
@@ -259,9 +259,9 @@ TEST_F(TodayServiceCase, QueryTasks)
 
 	try
 	{
-		ASSERT_TRUE(result.type() == response::Value::Type::Map);
+		ASSERT_TRUE(result.type() == response::Type::Map);
 		auto errorsItr = result.find("errors");
-		if (errorsItr != result.get<const response::Value::MapType&>().cend())
+		if (errorsItr != result.get<const response::MapType&>().cend())
 		{
 			rapidjson::StringBuffer buffer;
 			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -275,7 +275,7 @@ TEST_F(TodayServiceCase, QueryTasks)
 		const auto tasks = service::ScalarArgument::require("tasks", data);
 		const auto taskEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", tasks);
 		ASSERT_EQ(1, taskEdges.size()) << "tasks should have 1 entry";
-		ASSERT_TRUE(taskEdges[0].type() == response::Value::Type::Map) << "task should be an object";
+		ASSERT_TRUE(taskEdges[0].type() == response::Type::Map) << "task should be an object";
 		const auto taskNode = service::ScalarArgument::require("node", taskEdges[0]);
 		EXPECT_EQ(_fakeTaskId, service::IdArgument::require("taskId", taskNode)) << "id should match in base64 encoding";
 		EXPECT_EQ("Don't forget", service::StringArgument::require("title", taskNode)) << "title should match";
@@ -305,7 +305,7 @@ TEST_F(TodayServiceCase, QueryUnreadCounts)
 				}
 			}
 		})"_graphql;
-	response::Value variables(response::Value::Type::Map);
+	response::Value variables(response::Type::Map);
 	auto result = _service->resolve(3, *ast->root, "", variables).get();
 	EXPECT_GE(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_GE(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
@@ -313,9 +313,9 @@ TEST_F(TodayServiceCase, QueryUnreadCounts)
 
 	try
 	{
-		ASSERT_TRUE(result.type() == response::Value::Type::Map);
+		ASSERT_TRUE(result.type() == response::Type::Map);
 		auto errorsItr = result.find("errors");
-		if (errorsItr != result.get<const response::Value::MapType&>().cend())
+		if (errorsItr != result.get<const response::MapType&>().cend())
 		{
 			rapidjson::StringBuffer buffer;
 			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -329,7 +329,7 @@ TEST_F(TodayServiceCase, QueryUnreadCounts)
 		const auto unreadCounts = service::ScalarArgument::require("unreadCounts", data);
 		const auto unreadCountEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", unreadCounts);
 		ASSERT_EQ(1, unreadCountEdges.size()) << "unreadCounts should have 1 entry";
-		ASSERT_TRUE(unreadCountEdges[0].type() == response::Value::Type::Map) << "unreadCount should be an object";
+		ASSERT_TRUE(unreadCountEdges[0].type() == response::Type::Map) << "unreadCount should be an object";
 		const auto unreadCountNode = service::ScalarArgument::require("node", unreadCountEdges[0]);
 		EXPECT_EQ(_fakeFolderId, service::IdArgument::require("folderId", unreadCountNode)) << "id should match in base64 encoding";
 		EXPECT_EQ("\"Fake\" Inbox", service::StringArgument::require("name", unreadCountNode)) << "name should match";
@@ -358,14 +358,14 @@ TEST_F(TodayServiceCase, MutateCompleteTask)
 				clientMutationId
 			}
 		})"_graphql;
-	response::Value variables(response::Value::Type::Map);
+	response::Value variables(response::Type::Map);
 	auto result = _service->resolve(4, *ast->root, "", variables).get();
 
 	try
 	{
-		ASSERT_TRUE(result.type() == response::Value::Type::Map);
+		ASSERT_TRUE(result.type() == response::Type::Map);
 		auto errorsItr = result.find("errors");
-		if (errorsItr != result.get<const response::Value::MapType&>().cend())
+		if (errorsItr != result.get<const response::MapType&>().cend())
 		{
 			rapidjson::StringBuffer buffer;
 			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -377,10 +377,10 @@ TEST_F(TodayServiceCase, MutateCompleteTask)
 		const auto data = service::ScalarArgument::require("data", result);
 
 		const auto completedTask = service::ScalarArgument::require("completedTask", data);
-		ASSERT_TRUE(completedTask.type() == response::Value::Type::Map) << "payload should be an object";
+		ASSERT_TRUE(completedTask.type() == response::Type::Map) << "payload should be an object";
 
 		const auto task = service::ScalarArgument::require("completedTask", completedTask);
-		EXPECT_TRUE(task.type() == response::Value::Type::Map) << "should get back a task";
+		EXPECT_TRUE(task.type() == response::Type::Map) << "should get back a task";
 		EXPECT_EQ(_fakeTaskId, service::IdArgument::require("completedTaskId", task)) << "id should match in base64 encoding";
 		EXPECT_EQ("Mutated Task!", service::StringArgument::require("title", task)) << "title should match";
 		EXPECT_TRUE(service::BooleanArgument::require("isComplete", task)) << "isComplete should match";
@@ -433,14 +433,14 @@ TEST_F(TodayServiceCase, Introspection)
 				}
 			}
 		})"_graphql;
-	response::Value variables(response::Value::Type::Map);
+	response::Value variables(response::Type::Map);
 	auto result = _service->resolve(5, *ast->root, "", variables).get();
 
 	try
 	{
-		ASSERT_TRUE(result.type() == response::Value::Type::Map);
+		ASSERT_TRUE(result.type() == response::Type::Map);
 		auto errorsItr = result.find("errors");
-		if (errorsItr != result.get<const response::Value::MapType&>().cend())
+		if (errorsItr != result.get<const response::MapType&>().cend())
 		{
 			rapidjson::StringBuffer buffer;
 			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -456,8 +456,8 @@ TEST_F(TodayServiceCase, Introspection)
 		const auto mutationType = service::ScalarArgument::require("mutationType", schema);
 
 		ASSERT_FALSE(types.empty());
-		ASSERT_TRUE(queryType.type() == response::Value::Type::Map);
-		ASSERT_TRUE(mutationType.type() == response::Value::Type::Map);
+		ASSERT_TRUE(queryType.type() == response::Type::Map);
+		ASSERT_TRUE(mutationType.type() == response::Type::Map);
 	}
 	catch (const service::schema_exception& ex)
 	{
@@ -640,9 +640,9 @@ TEST(ArgumentsCase, ListArgumentNullableListArgumentStrings)
 
 TEST(ArgumentsCase, TaskStateEnum)
 {
-	response::Value response(response::Value::Type::Map);
-	response::Value status(response::Value::Type::EnumValue);
-	status.set<response::Value::StringType>("Started");
+	response::Value response(response::Type::Map);
+	response::Value status(response::Type::EnumValue);
+	status.set<response::StringType>("Started");
 	response.emplace_back("status", std::move(status));
 	today::TaskState actual = static_cast<today::TaskState>(-1);
 

--- a/tests.cpp
+++ b/tests.cpp
@@ -4,8 +4,8 @@
 #include <gtest/gtest.h>
 
 #include "Today.h"
-#include "GraphQLTree.h"
 #include "GraphQLGrammar.h"
+#include "JSONResponse.h"
 
 #include <tao/pegtl/analyze.hpp>
 
@@ -122,62 +122,61 @@ TEST_F(TodayServiceCase, QueryEverything)
 				}
 			}
 		})"_graphql;
-	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	auto result = _service->resolve(0, *ast->root, "Everything", variables.GetObject()).get();
-	auto& allocator = result.GetAllocator();
+	response::Value variables(response::Value::Type::Map);
+	auto result = _service->resolve(0, *ast->root, "Everything", variables).get();
 	EXPECT_EQ(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_EQ(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
 	EXPECT_EQ(size_t(1), _getUnreadCountsCount) << "today service lazy loads the unreadCounts and caches the result";
 
 	try
 	{
-		ASSERT_TRUE(result.IsObject());
-		auto errorsItr = result.FindMember("errors");
-		if (errorsItr != result.MemberEnd())
+		ASSERT_TRUE(result.type() == response::Value::Type::Map);
+		auto errorsItr = result.find("errors");
+		if (errorsItr != result.get<const response::Value::MapType&>().cend())
 		{
 			rapidjson::StringBuffer buffer;
 			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-			errorsItr->value.Accept(writer);
+			rapidjson::convertResponse(response::Value(errorsItr->second)).Accept(writer);
 
 			FAIL() << buffer.GetString();
 		}
-		const auto data = service::ScalarArgument::require(allocator, "data", const_cast<const rapidjson::Document&>(result).GetObject());
+		const auto data = service::ScalarArgument::require("data", result);
 		
-		const auto appointments = service::ScalarArgument::require(allocator, "appointments", data.GetObject());
-		const auto appointmentEdges = service::ScalarArgument::require<service::TypeModifier::List>(allocator, "edges", appointments.GetObject());
+		const auto appointments = service::ScalarArgument::require("appointments", data);
+		const auto appointmentEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", appointments);
 		ASSERT_EQ(1, appointmentEdges.size()) << "appointments should have 1 entry";
-		ASSERT_TRUE(appointmentEdges[0].IsObject()) << "appointment should be an object";
-		const auto appointmentNode = service::ScalarArgument::require(allocator, "node", appointmentEdges[0].GetObject());
-		EXPECT_EQ(_fakeAppointmentId, service::IdArgument::require(allocator, "id", appointmentNode.GetObject())) << "id should match in base64 encoding";
-		EXPECT_EQ("Lunch?", service::StringArgument::require(allocator, "subject", appointmentNode.GetObject())) << "subject should match";
-		EXPECT_EQ("tomorrow", service::StringArgument::require(allocator, "when", appointmentNode.GetObject())) << "when should match";
-		EXPECT_FALSE(service::BooleanArgument::require(allocator, "isNow", appointmentNode.GetObject())) << "isNow should match";
+		ASSERT_TRUE(appointmentEdges[0].type() == response::Value::Type::Map) << "appointment should be an object";
+		const auto appointmentNode = service::ScalarArgument::require("node", appointmentEdges[0]);
+		EXPECT_EQ(_fakeAppointmentId, service::IdArgument::require("id", appointmentNode)) << "id should match in base64 encoding";
+		EXPECT_EQ("Lunch?", service::StringArgument::require("subject", appointmentNode)) << "subject should match";
+		EXPECT_EQ("tomorrow", service::StringArgument::require("when", appointmentNode)) << "when should match";
+		EXPECT_FALSE(service::BooleanArgument::require("isNow", appointmentNode)) << "isNow should match";
 
-		const auto tasks = service::ScalarArgument::require(allocator, "tasks", data.GetObject());
-		const auto taskEdges = service::ScalarArgument::require<service::TypeModifier::List>(allocator, "edges", tasks.GetObject());
+		const auto tasks = service::ScalarArgument::require("tasks", data);
+		const auto taskEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", tasks);
 		ASSERT_EQ(1, taskEdges.size()) << "tasks should have 1 entry";
-		ASSERT_TRUE(taskEdges[0].IsObject()) << "task should be an object";
-		const auto taskNode = service::ScalarArgument::require(allocator, "node", taskEdges[0].GetObject());
-		EXPECT_EQ(_fakeTaskId, service::IdArgument::require(allocator, "id", taskNode.GetObject())) << "id should match in base64 encoding";
-		EXPECT_EQ("Don't forget", service::StringArgument::require(allocator, "title", taskNode.GetObject())) << "title should match";
-		EXPECT_TRUE(service::BooleanArgument::require(allocator, "isComplete", taskNode.GetObject())) << "isComplete should match";
+		ASSERT_TRUE(taskEdges[0].type() == response::Value::Type::Map) << "task should be an object";
+		const auto taskNode = service::ScalarArgument::require("node", taskEdges[0]);
+		EXPECT_EQ(_fakeTaskId, service::IdArgument::require("id", taskNode)) << "id should match in base64 encoding";
+		EXPECT_EQ("Don't forget", service::StringArgument::require("title", taskNode)) << "title should match";
+		EXPECT_TRUE(service::BooleanArgument::require("isComplete", taskNode)) << "isComplete should match";
 
-		const auto unreadCounts = service::ScalarArgument::require(allocator, "unreadCounts", data.GetObject());
-		const auto unreadCountEdges = service::ScalarArgument::require<service::TypeModifier::List>(allocator, "edges", unreadCounts.GetObject());
+		const auto unreadCounts = service::ScalarArgument::require("unreadCounts", data);
+		const auto unreadCountEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", unreadCounts);
 		ASSERT_EQ(1, unreadCountEdges.size()) << "unreadCounts should have 1 entry";
-		ASSERT_TRUE(unreadCountEdges[0].IsObject()) << "unreadCount should be an object";
-		const auto unreadCountNode = service::ScalarArgument::require(allocator, "node", unreadCountEdges[0].GetObject());
-		EXPECT_EQ(_fakeFolderId, service::IdArgument::require(allocator, "id", unreadCountNode.GetObject())) << "id should match in base64 encoding";
-		EXPECT_EQ("\"Fake\" Inbox", service::StringArgument::require(allocator, "name", unreadCountNode.GetObject())) << "name should match";
-		EXPECT_EQ(3, service::IntArgument::require(allocator, "unreadCount", unreadCountNode.GetObject())) << "unreadCount should match";
+		ASSERT_TRUE(unreadCountEdges[0].type() == response::Value::Type::Map) << "unreadCount should be an object";
+		const auto unreadCountNode = service::ScalarArgument::require("node", unreadCountEdges[0]);
+		EXPECT_EQ(_fakeFolderId, service::IdArgument::require("id", unreadCountNode)) << "id should match in base64 encoding";
+		EXPECT_EQ("\"Fake\" Inbox", service::StringArgument::require("name", unreadCountNode)) << "name should match";
+		EXPECT_EQ(3, service::IntArgument::require("unreadCount", unreadCountNode)) << "unreadCount should match";
 	}
 	catch (const service::schema_exception& ex)
 	{
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-		ex.getErrors().Accept(writer);
+		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
 
 		FAIL() << buffer.GetString();
 	}
@@ -197,44 +196,43 @@ TEST_F(TodayServiceCase, QueryAppointments)
 				}
 			}
 		})"_graphql;
-	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	auto result = _service->resolve(1, *ast->root, "", variables.GetObject()).get();
-	auto& allocator = result.GetAllocator();
+	response::Value variables(response::Value::Type::Map);
+	auto result = _service->resolve(1, *ast->root, "", variables).get();
 	EXPECT_EQ(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_GE(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
 	EXPECT_GE(size_t(1), _getUnreadCountsCount) << "today service lazy loads the unreadCounts and caches the result";
 
 	try
 	{
-		ASSERT_TRUE(result.IsObject());
-		auto errorsItr = result.FindMember("errors");
-		if (errorsItr != result.MemberEnd())
+		ASSERT_TRUE(result.type() == response::Value::Type::Map);
+		auto errorsItr = result.find("errors");
+		if (errorsItr != result.get<const response::Value::MapType&>().cend())
 		{
 			rapidjson::StringBuffer buffer;
 			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-			errorsItr->value.Accept(writer);
+			rapidjson::convertResponse(response::Value(errorsItr->second)).Accept(writer);
 
 			FAIL() << buffer.GetString();
 		}
-		const auto data = service::ScalarArgument::require(allocator, "data", const_cast<const rapidjson::Document&>(result).GetObject());
+		const auto data = service::ScalarArgument::require("data", result);
 
-		const auto appointments = service::ScalarArgument::require(allocator, "appointments", data.GetObject());
-		const auto appointmentEdges = service::ScalarArgument::require<service::TypeModifier::List>(allocator, "edges", appointments.GetObject());
+		const auto appointments = service::ScalarArgument::require("appointments", data);
+		const auto appointmentEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", appointments);
 		ASSERT_EQ(1, appointmentEdges.size()) << "appointments should have 1 entry";
-		ASSERT_TRUE(appointmentEdges[0].IsObject()) << "appointment should be an object";
-		const auto appointmentNode = service::ScalarArgument::require(allocator, "node", appointmentEdges[0].GetObject());
-		EXPECT_EQ(_fakeAppointmentId, service::IdArgument::require(allocator, "appointmentId", appointmentNode.GetObject())) << "id should match in base64 encoding";
-		EXPECT_EQ("Lunch?", service::StringArgument::require(allocator, "subject", appointmentNode.GetObject())) << "subject should match";
-		EXPECT_EQ("tomorrow", service::StringArgument::require(allocator, "when", appointmentNode.GetObject())) << "when should match";
-		EXPECT_FALSE(service::BooleanArgument::require(allocator, "isNow", appointmentNode.GetObject())) << "isNow should match";
+		ASSERT_TRUE(appointmentEdges[0].type() == response::Value::Type::Map) << "appointment should be an object";
+		const auto appointmentNode = service::ScalarArgument::require("node", appointmentEdges[0]);
+		EXPECT_EQ(_fakeAppointmentId, service::IdArgument::require("appointmentId", appointmentNode)) << "id should match in base64 encoding";
+		EXPECT_EQ("Lunch?", service::StringArgument::require("subject", appointmentNode)) << "subject should match";
+		EXPECT_EQ("tomorrow", service::StringArgument::require("when", appointmentNode)) << "when should match";
+		EXPECT_FALSE(service::BooleanArgument::require("isNow", appointmentNode)) << "isNow should match";
 	}
 	catch (const service::schema_exception& ex)
 	{
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-		ex.getErrors().Accept(writer);
+		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
 
 		FAIL() << buffer.GetString();
 	}
@@ -253,43 +251,42 @@ TEST_F(TodayServiceCase, QueryTasks)
 				}
 			}
 		})gql"_graphql;
-	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	auto result = _service->resolve(2, *ast->root, "", variables.GetObject()).get();
-	auto& allocator = result.GetAllocator();
+	response::Value variables(response::Value::Type::Map);
+	auto result = _service->resolve(2, *ast->root, "", variables).get();
 	EXPECT_GE(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_EQ(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
 	EXPECT_GE(size_t(1), _getUnreadCountsCount) << "today service lazy loads the unreadCounts and caches the result";
 
 	try
 	{
-		ASSERT_TRUE(result.IsObject());
-		auto errorsItr = result.FindMember("errors");
-		if (errorsItr != result.MemberEnd())
+		ASSERT_TRUE(result.type() == response::Value::Type::Map);
+		auto errorsItr = result.find("errors");
+		if (errorsItr != result.get<const response::Value::MapType&>().cend())
 		{
 			rapidjson::StringBuffer buffer;
 			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-			errorsItr->value.Accept(writer);
+			rapidjson::convertResponse(response::Value(errorsItr->second)).Accept(writer);
 
 			FAIL() << buffer.GetString();
 		}
-		const auto data = service::ScalarArgument::require(allocator, "data", const_cast<const rapidjson::Document&>(result).GetObject());
+		const auto data = service::ScalarArgument::require("data", result);
 
-		const auto tasks = service::ScalarArgument::require(allocator, "tasks", data.GetObject());
-		const auto taskEdges = service::ScalarArgument::require<service::TypeModifier::List>(allocator, "edges", tasks.GetObject());
+		const auto tasks = service::ScalarArgument::require("tasks", data);
+		const auto taskEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", tasks);
 		ASSERT_EQ(1, taskEdges.size()) << "tasks should have 1 entry";
-		ASSERT_TRUE(taskEdges[0].IsObject()) << "task should be an object";
-		const auto taskNode = service::ScalarArgument::require(allocator, "node", taskEdges[0].GetObject());
-		EXPECT_EQ(_fakeTaskId, service::IdArgument::require(allocator, "taskId", taskNode.GetObject())) << "id should match in base64 encoding";
-		EXPECT_EQ("Don't forget", service::StringArgument::require(allocator, "title", taskNode.GetObject())) << "title should match";
-		EXPECT_TRUE(service::BooleanArgument::require(allocator, "isComplete", taskNode.GetObject())) << "isComplete should match";
+		ASSERT_TRUE(taskEdges[0].type() == response::Value::Type::Map) << "task should be an object";
+		const auto taskNode = service::ScalarArgument::require("node", taskEdges[0]);
+		EXPECT_EQ(_fakeTaskId, service::IdArgument::require("taskId", taskNode)) << "id should match in base64 encoding";
+		EXPECT_EQ("Don't forget", service::StringArgument::require("title", taskNode)) << "title should match";
+		EXPECT_TRUE(service::BooleanArgument::require("isComplete", taskNode)) << "isComplete should match";
 	}
 	catch (const service::schema_exception& ex)
 	{
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-		ex.getErrors().Accept(writer);
+		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
 
 		FAIL() << buffer.GetString();
 	}
@@ -308,43 +305,42 @@ TEST_F(TodayServiceCase, QueryUnreadCounts)
 				}
 			}
 		})"_graphql;
-	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	auto result = _service->resolve(3, *ast->root, "", variables.GetObject()).get();
-	auto& allocator = result.GetAllocator();
+	response::Value variables(response::Value::Type::Map);
+	auto result = _service->resolve(3, *ast->root, "", variables).get();
 	EXPECT_GE(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
 	EXPECT_GE(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
 	EXPECT_EQ(size_t(1), _getUnreadCountsCount) << "today service lazy loads the unreadCounts and caches the result";
 
 	try
 	{
-		ASSERT_TRUE(result.IsObject());
-		auto errorsItr = result.FindMember("errors");
-		if (errorsItr != result.MemberEnd())
+		ASSERT_TRUE(result.type() == response::Value::Type::Map);
+		auto errorsItr = result.find("errors");
+		if (errorsItr != result.get<const response::Value::MapType&>().cend())
 		{
 			rapidjson::StringBuffer buffer;
 			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-			errorsItr->value.Accept(writer);
+			rapidjson::convertResponse(response::Value(errorsItr->second)).Accept(writer);
 
 			FAIL() << buffer.GetString();
 		}
-		const auto data = service::ScalarArgument::require(allocator, "data", const_cast<const rapidjson::Document&>(result).GetObject());
+		const auto data = service::ScalarArgument::require("data", result);
 
-		const auto unreadCounts = service::ScalarArgument::require(allocator, "unreadCounts", data.GetObject());
-		const auto unreadCountEdges = service::ScalarArgument::require<service::TypeModifier::List>(allocator, "edges", unreadCounts.GetObject());
+		const auto unreadCounts = service::ScalarArgument::require("unreadCounts", data);
+		const auto unreadCountEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", unreadCounts);
 		ASSERT_EQ(1, unreadCountEdges.size()) << "unreadCounts should have 1 entry";
-		ASSERT_TRUE(unreadCountEdges[0].IsObject()) << "unreadCount should be an object";
-		const auto unreadCountNode = service::ScalarArgument::require(allocator, "node", unreadCountEdges[0].GetObject());
-		EXPECT_EQ(_fakeFolderId, service::IdArgument::require(allocator, "folderId", unreadCountNode.GetObject())) << "id should match in base64 encoding";
-		EXPECT_EQ("\"Fake\" Inbox", service::StringArgument::require(allocator, "name", unreadCountNode.GetObject())) << "name should match";
-		EXPECT_EQ(3, service::IntArgument::require(allocator, "unreadCount", unreadCountNode.GetObject())) << "unreadCount should match";
+		ASSERT_TRUE(unreadCountEdges[0].type() == response::Value::Type::Map) << "unreadCount should be an object";
+		const auto unreadCountNode = service::ScalarArgument::require("node", unreadCountEdges[0]);
+		EXPECT_EQ(_fakeFolderId, service::IdArgument::require("folderId", unreadCountNode)) << "id should match in base64 encoding";
+		EXPECT_EQ("\"Fake\" Inbox", service::StringArgument::require("name", unreadCountNode)) << "name should match";
+		EXPECT_EQ(3, service::IntArgument::require("unreadCount", unreadCountNode)) << "unreadCount should match";
 	}
 	catch (const service::schema_exception& ex)
 	{
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-		ex.getErrors().Accept(writer);
+		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
 
 		FAIL() << buffer.GetString();
 	}
@@ -362,35 +358,34 @@ TEST_F(TodayServiceCase, MutateCompleteTask)
 				clientMutationId
 			}
 		})"_graphql;
-	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	auto result = _service->resolve(4, *ast->root, "", variables.GetObject()).get();
-	auto& allocator = result.GetAllocator();
+	response::Value variables(response::Value::Type::Map);
+	auto result = _service->resolve(4, *ast->root, "", variables).get();
 
 	try
 	{
-		ASSERT_TRUE(result.IsObject());
-		auto errorsItr = result.FindMember("errors");
-		if (errorsItr != result.MemberEnd())
+		ASSERT_TRUE(result.type() == response::Value::Type::Map);
+		auto errorsItr = result.find("errors");
+		if (errorsItr != result.get<const response::Value::MapType&>().cend())
 		{
 			rapidjson::StringBuffer buffer;
 			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-			errorsItr->value.Accept(writer);
+			rapidjson::convertResponse(response::Value(errorsItr->second)).Accept(writer);
 
 			FAIL() << buffer.GetString();
 		}
-		const auto data = service::ScalarArgument::require(allocator, "data", const_cast<const rapidjson::Document&>(result).GetObject());
+		const auto data = service::ScalarArgument::require("data", result);
 
-		const auto completedTask = service::ScalarArgument::require(allocator, "completedTask", data.GetObject());
-		ASSERT_TRUE(completedTask.IsObject()) << "payload should be an object";
+		const auto completedTask = service::ScalarArgument::require("completedTask", data);
+		ASSERT_TRUE(completedTask.type() == response::Value::Type::Map) << "payload should be an object";
 
-		const auto task = service::ScalarArgument::require(allocator, "completedTask", completedTask.GetObject());
-		EXPECT_TRUE(task.IsObject()) << "should get back a task";
-		EXPECT_EQ(_fakeTaskId, service::IdArgument::require(allocator, "completedTaskId", task.GetObject())) << "id should match in base64 encoding";
-		EXPECT_EQ("Mutated Task!", service::StringArgument::require(allocator, "title", task.GetObject())) << "title should match";
-		EXPECT_TRUE(service::BooleanArgument::require(allocator, "isComplete", task.GetObject())) << "isComplete should match";
+		const auto task = service::ScalarArgument::require("completedTask", completedTask);
+		EXPECT_TRUE(task.type() == response::Value::Type::Map) << "should get back a task";
+		EXPECT_EQ(_fakeTaskId, service::IdArgument::require("completedTaskId", task)) << "id should match in base64 encoding";
+		EXPECT_EQ("Mutated Task!", service::StringArgument::require("title", task)) << "title should match";
+		EXPECT_TRUE(service::BooleanArgument::require("isComplete", task)) << "isComplete should match";
 
-		const auto clientMutationId = service::StringArgument::require(allocator, "clientMutationId", completedTask.GetObject());
+		const auto clientMutationId = service::StringArgument::require("clientMutationId", completedTask);
 		EXPECT_EQ("Hi There!", clientMutationId) << "clientMutationId should match";
 	}
 	catch (const service::schema_exception& ex)
@@ -398,7 +393,7 @@ TEST_F(TodayServiceCase, MutateCompleteTask)
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-		ex.getErrors().Accept(writer);
+		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
 
 		FAIL() << buffer.GetString();
 	}
@@ -438,39 +433,38 @@ TEST_F(TodayServiceCase, Introspection)
 				}
 			}
 		})"_graphql;
-	const rapidjson::Document variables(rapidjson::Type::kObjectType);
-	auto result = _service->resolve(5, *ast->root, "", variables.GetObject()).get();
-	auto& allocator = result.GetAllocator();
+	response::Value variables(response::Value::Type::Map);
+	auto result = _service->resolve(5, *ast->root, "", variables).get();
 
 	try
 	{
-		ASSERT_TRUE(result.IsObject());
-		auto errorsItr = result.FindMember("errors");
-		if (errorsItr != result.MemberEnd())
+		ASSERT_TRUE(result.type() == response::Value::Type::Map);
+		auto errorsItr = result.find("errors");
+		if (errorsItr != result.get<const response::Value::MapType&>().cend())
 		{
 			rapidjson::StringBuffer buffer;
 			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-			errorsItr->value.Accept(writer);
+			rapidjson::convertResponse(response::Value(errorsItr->second)).Accept(writer);
 
 			FAIL() << buffer.GetString();
 		}
-		const auto data = service::ScalarArgument::require(allocator, "data", const_cast<const rapidjson::Document&>(result).GetObject());
-		const auto schema = service::ScalarArgument::require(allocator, "__schema", data.GetObject());
-		const auto types = service::ScalarArgument::require<service::TypeModifier::List>(allocator, "types", schema.GetObject());
-		const auto queryType = service::ScalarArgument::require(allocator, "queryType", schema.GetObject());
-		const auto mutationType = service::ScalarArgument::require(allocator, "mutationType", schema.GetObject());
+		const auto data = service::ScalarArgument::require("data", result);
+		const auto schema = service::ScalarArgument::require("__schema", data);
+		const auto types = service::ScalarArgument::require<service::TypeModifier::List>("types", schema);
+		const auto queryType = service::ScalarArgument::require("queryType", schema);
+		const auto mutationType = service::ScalarArgument::require("mutationType", schema);
 
 		ASSERT_FALSE(types.empty());
-		ASSERT_TRUE(queryType.IsObject());
-		ASSERT_TRUE(mutationType.IsObject());
+		ASSERT_TRUE(queryType.type() == response::Value::Type::Map);
+		ASSERT_TRUE(mutationType.type() == response::Value::Type::Map);
 	}
 	catch (const service::schema_exception& ex)
 	{
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-		ex.getErrors().Accept(writer);
+		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
 
 		FAIL() << buffer.GetString();
 	}
@@ -488,14 +482,14 @@ TEST(ArgumentsCase, ListArgumentStrings)
 
 	try
 	{
-		actual = service::StringArgument::require<service::TypeModifier::List>(parsed.GetAllocator(), "value", const_cast<const rapidjson::Document&>(parsed).GetObject());
+		actual = service::StringArgument::require<service::TypeModifier::List>("value", rapidjson::convertResponse(parsed));
 	}
 	catch (const service::schema_exception& ex)
 	{
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-		ex.getErrors().Accept(writer);
+		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
 
 		FAIL() << buffer.GetString();
 	}
@@ -520,14 +514,14 @@ TEST(ArgumentsCase, ListArgumentStringsNonNullable)
 
 	try
 	{
-		service::StringArgument::require<service::TypeModifier::List>(parsed.GetAllocator(), "value", const_cast<const rapidjson::Document&>(parsed).GetObject());
+		service::StringArgument::require<service::TypeModifier::List>("value", rapidjson::convertResponse(parsed));
 	}
 	catch (const service::schema_exception& ex)
 	{
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-		ex.getErrors().Accept(writer);
+		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
 
 		exceptionWhat = buffer.GetString();
 		caughtException = true;
@@ -553,14 +547,14 @@ TEST(ArgumentsCase, ListArgumentStringsNullable)
 		actual = service::StringArgument::require<
 			service::TypeModifier::List,
 			service::TypeModifier::Nullable
-		>(parsed.GetAllocator(), "value", const_cast<const rapidjson::Document&>(parsed).GetObject());
+		>("value", rapidjson::convertResponse(parsed));
 	}
 	catch (const service::schema_exception& ex)
 	{
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-		ex.getErrors().Accept(writer);
+		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
 
 		FAIL() << buffer.GetString();
 	}
@@ -589,14 +583,14 @@ TEST(ArgumentsCase, ListArgumentListArgumentStrings)
 		actual = service::StringArgument::require<
 			service::TypeModifier::List,
 			service::TypeModifier::List
-		>(parsed.GetAllocator(), "value", const_cast<const rapidjson::Document&>(parsed).GetObject());
+		>("value", rapidjson::convertResponse(parsed));
 	}
 	catch (const service::schema_exception& ex)
 	{
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-		ex.getErrors().Accept(writer);
+		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
 
 		FAIL() << buffer.GetString();
 	}
@@ -625,14 +619,14 @@ TEST(ArgumentsCase, ListArgumentNullableListArgumentStrings)
 			service::TypeModifier::List,
 			service::TypeModifier::Nullable,
 			service::TypeModifier::List
-		>(parsed.GetAllocator(), "value", const_cast<const rapidjson::Document&>(parsed).GetObject());
+		>("value", rapidjson::convertResponse(parsed));
 	}
 	catch (const service::schema_exception& ex)
 	{
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-		ex.getErrors().Accept(writer);
+		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
 
 		FAIL() << buffer.GetString();
 	}
@@ -646,20 +640,22 @@ TEST(ArgumentsCase, ListArgumentNullableListArgumentStrings)
 
 TEST(ArgumentsCase, TaskStateEnum)
 {
-	rapidjson::Document parsed;
-	parsed.Parse(R"js({"status":"Started"})js");
+	response::Value response(response::Value::Type::Map);
+	response::Value status(response::Value::Type::EnumValue);
+	status.set<response::Value::StringType>("Started");
+	response.emplace_back("status", std::move(status));
 	today::TaskState actual = static_cast<today::TaskState>(-1);
 
 	try
 	{
-		actual = service::ModifiedArgument<today::TaskState>::require(parsed.GetAllocator(), "status", const_cast<const rapidjson::Document&>(parsed).GetObject());
+		actual = service::ModifiedArgument<today::TaskState>::require("status", response);
 	}
 	catch (const service::schema_exception& ex)
 	{
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-		ex.getErrors().Accept(writer);
+		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
 
 		FAIL() << buffer.GetString();
 	}


### PR DESCRIPTION
This should complete the suggestions in #11. Instead of taking a dependency on a specific JSON library and requiring JSON serialization, I'm building the GraphQL responses in a `response::Value` object that acts as a discriminated union of the primitive types supported in GraphQL.

It's still convenient to be able to serialize to and from JSON, particularly in the unit tests, so I also added a couple of conversion routines in `JSONResponse.h` which still use RapidJSON. The service library itself doesn't link against that though, so consumers are free to replace RapidJSON with the parser/generator of their choice when integrating it into another project. You could even skip using JSON entirely and pick another format that's compatible with GraphQL serialization.