### PR TITLE
Switch back to passing const std::shared_ptr<service::RequestState>& where possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,10 @@ Debug/
 Release/
 Testing/
 Win32/
-/IntrospectionSchema.*
-/TodaySchema.*
+/include/graphqlservice/IntrospectionSchema.h
+/IntrospectionSchema.cpp
+/include/TodaySchema.h
+/TodaySchema.cpp
 *.filters
 *.vcxproj
 *.vcxproj.user

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ LastTest.log
 lib*.a
 lib*.so
 Makefile
+*.ninja
+.ninja_*
 schemagen
 settings.json
 test_today

--- a/GraphQLService.cpp
+++ b/GraphQLService.cpp
@@ -347,7 +347,7 @@ Object::Object(TypeNames&& typeNames, ResolverMap&& resolvers)
 {
 }
 
-std::future<response::Value> Object::resolve(std::shared_ptr<RequestState> state, const peg::ast_node& selection, const FragmentMap& fragments, const response::Value& variables) const
+std::future<response::Value> Object::resolve(const std::shared_ptr<RequestState>& state, const peg::ast_node& selection, const FragmentMap& fragments, const response::Value& variables) const
 {
 	std::queue<std::future<response::Value>> selections;
 
@@ -389,11 +389,11 @@ std::future<response::Value> Object::resolve(std::shared_ptr<RequestState> state
 	}, std::move(selections));
 }
 
-void Object::beginSelectionSet(std::shared_ptr<RequestState>) const
+void Object::beginSelectionSet(const std::shared_ptr<RequestState>&) const
 {
 }
 
-void Object::endSelectionSet(std::shared_ptr<RequestState>) const
+void Object::endSelectionSet(const std::shared_ptr<RequestState>&) const
 {
 }
 
@@ -402,7 +402,7 @@ Request::Request(TypeMap&& operationTypes)
 {
 }
 
-std::future<response::Value> Request::resolve(std::shared_ptr<RequestState> state, const peg::ast_node& root, const std::string& operationName, const response::Value& variables) const
+std::future<response::Value> Request::resolve(const std::shared_ptr<RequestState>& state, const peg::ast_node& root, const std::string& operationName, const response::Value& variables) const
 {
 	FragmentDefinitionVisitor fragmentVisitor;
 
@@ -425,7 +425,7 @@ std::future<response::Value> Request::resolve(std::shared_ptr<RequestState> stat
 }
 
 SelectionVisitor::SelectionVisitor(std::shared_ptr<RequestState> state, const FragmentMap& fragments, const response::Value& variables, const TypeNames& typeNames, const ResolverMap& resolvers)
-	: _state(state)
+	: _state(std::move(state))
 	, _fragments(fragments)
 	, _variables(variables)
 	, _typeNames(typeNames)
@@ -880,7 +880,7 @@ void FragmentDefinitionVisitor::visit(const peg::ast_node& fragmentDefinition)
 }
 
 OperationDefinitionVisitor::OperationDefinitionVisitor(std::shared_ptr<RequestState> state, const TypeMap& operations, const std::string& operationName, const response::Value& variables, const FragmentMap& fragments)
-	: _state(state)
+	: _state(std::move(state))
 	, _operations(operations)
 	, _operationName(operationName)
 	, _variables(variables)

--- a/Introspection.cpp
+++ b/Introspection.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<object::__Type> Schema::LookupType(const std::string& name) cons
 	return _types[itr->second].second;
 }
 
-std::future<std::vector<std::shared_ptr<object::__Type>>> Schema::getTypes(std::shared_ptr<service::RequestState>) const
+std::future<std::vector<std::shared_ptr<object::__Type>>> Schema::getTypes(const std::shared_ptr<service::RequestState>&) const
 {
 	return std::async(std::launch::deferred,
 		[this]()
@@ -66,7 +66,7 @@ std::future<std::vector<std::shared_ptr<object::__Type>>> Schema::getTypes(std::
 	});
 }
 
-std::future<std::shared_ptr<object::__Type>> Schema::getQueryType(std::shared_ptr<service::RequestState>) const
+std::future<std::shared_ptr<object::__Type>> Schema::getQueryType(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::shared_ptr<object::__Type>> promise;
 
@@ -75,7 +75,7 @@ std::future<std::shared_ptr<object::__Type>> Schema::getQueryType(std::shared_pt
 	return promise.get_future();
 }
 
-std::future<std::shared_ptr<object::__Type>> Schema::getMutationType(std::shared_ptr<service::RequestState>) const
+std::future<std::shared_ptr<object::__Type>> Schema::getMutationType(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::shared_ptr<object::__Type>> promise;
 
@@ -84,7 +84,7 @@ std::future<std::shared_ptr<object::__Type>> Schema::getMutationType(std::shared
 	return promise.get_future();
 }
 
-std::future<std::shared_ptr<object::__Type>> Schema::getSubscriptionType(std::shared_ptr<service::RequestState>) const
+std::future<std::shared_ptr<object::__Type>> Schema::getSubscriptionType(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::shared_ptr<object::__Type>> promise;
 
@@ -93,7 +93,7 @@ std::future<std::shared_ptr<object::__Type>> Schema::getSubscriptionType(std::sh
 	return promise.get_future();
 }
 
-std::future<std::vector<std::shared_ptr<object::__Directive>>> Schema::getDirectives(std::shared_ptr<service::RequestState>) const
+std::future<std::vector<std::shared_ptr<object::__Directive>>> Schema::getDirectives(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::vector<std::shared_ptr<object::__Directive>>> promise;
 
@@ -108,7 +108,7 @@ BaseType::BaseType(std::string description)
 {
 }
 
-std::future<std::unique_ptr<std::string>> BaseType::getName(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> BaseType::getName(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 
@@ -117,7 +117,7 @@ std::future<std::unique_ptr<std::string>> BaseType::getName(std::shared_ptr<serv
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::string>> BaseType::getDescription(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> BaseType::getDescription(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 
@@ -128,7 +128,7 @@ std::future<std::unique_ptr<std::string>> BaseType::getDescription(std::shared_p
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> BaseType::getFields(std::shared_ptr<service::RequestState>, std::unique_ptr<bool>&& /*includeDeprecated*/) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> BaseType::getFields(const std::shared_ptr<service::RequestState>&, std::unique_ptr<bool>&& /*includeDeprecated*/) const
 {
 	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> promise;
 
@@ -137,7 +137,7 @@ std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> Base
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> BaseType::getInterfaces(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> BaseType::getInterfaces(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> promise;
 
@@ -146,7 +146,7 @@ std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> BaseT
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> BaseType::getPossibleTypes(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> BaseType::getPossibleTypes(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> promise;
 
@@ -155,7 +155,7 @@ std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> BaseT
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> BaseType::getEnumValues(std::shared_ptr<service::RequestState>, std::unique_ptr<bool>&& /*includeDeprecated*/) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> BaseType::getEnumValues(const std::shared_ptr<service::RequestState>&, std::unique_ptr<bool>&& /*includeDeprecated*/) const
 {
 	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> promise;
 
@@ -164,7 +164,7 @@ std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> 
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> BaseType::getInputFields(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> BaseType::getInputFields(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> promise;
 
@@ -173,7 +173,7 @@ std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>>
 	return promise.get_future();
 }
 
-std::future<std::shared_ptr<object::__Type>> BaseType::getOfType(std::shared_ptr<service::RequestState>) const
+std::future<std::shared_ptr<object::__Type>> BaseType::getOfType(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::shared_ptr<object::__Type>> promise;
 
@@ -188,7 +188,7 @@ ScalarType::ScalarType(std::string name, std::string description)
 {
 }
 
-std::future<__TypeKind> ScalarType::getKind(std::shared_ptr<service::RequestState>) const
+std::future<__TypeKind> ScalarType::getKind(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<__TypeKind> promise;
 
@@ -197,7 +197,7 @@ std::future<__TypeKind> ScalarType::getKind(std::shared_ptr<service::RequestStat
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::string>> ScalarType::getName(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> ScalarType::getName(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 
@@ -222,7 +222,7 @@ void ObjectType::AddFields(std::vector<std::shared_ptr<Field>> fields)
 	_fields = std::move(fields);
 }
 
-std::future<__TypeKind> ObjectType::getKind(std::shared_ptr<service::RequestState>) const
+std::future<__TypeKind> ObjectType::getKind(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<__TypeKind> promise;
 
@@ -231,7 +231,7 @@ std::future<__TypeKind> ObjectType::getKind(std::shared_ptr<service::RequestStat
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::string>> ObjectType::getName(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> ObjectType::getName(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 
@@ -240,7 +240,7 @@ std::future<std::unique_ptr<std::string>> ObjectType::getName(std::shared_ptr<se
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> ObjectType::getFields(std::shared_ptr<service::RequestState> state, std::unique_ptr<bool>&& includeDeprecated) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> ObjectType::getFields(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<bool>&& includeDeprecated) const
 {
 	const bool deprecated = includeDeprecated && *includeDeprecated;
 	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> promise;
@@ -258,7 +258,7 @@ std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> Obje
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> ObjectType::getInterfaces(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> ObjectType::getInterfaces(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> promise;
 	std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>> result(new std::vector<std::shared_ptr<object::__Type>>(_interfaces.size()));
@@ -280,7 +280,7 @@ void InterfaceType::AddFields(std::vector<std::shared_ptr<Field>> fields)
 	_fields = std::move(fields);
 }
 
-std::future<__TypeKind> InterfaceType::getKind(std::shared_ptr<service::RequestState>) const
+std::future<__TypeKind> InterfaceType::getKind(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<__TypeKind> promise;
 
@@ -289,7 +289,7 @@ std::future<__TypeKind> InterfaceType::getKind(std::shared_ptr<service::RequestS
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::string>> InterfaceType::getName(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> InterfaceType::getName(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 
@@ -298,7 +298,7 @@ std::future<std::unique_ptr<std::string>> InterfaceType::getName(std::shared_ptr
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> InterfaceType::getFields(std::shared_ptr<service::RequestState> state, std::unique_ptr<bool>&& includeDeprecated) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> InterfaceType::getFields(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<bool>&& includeDeprecated) const
 {
 	const bool deprecated = includeDeprecated && *includeDeprecated;
 	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> promise;
@@ -332,7 +332,7 @@ void UnionType::AddPossibleTypes(std::vector<std::shared_ptr<object::__Type>> po
 	});
 }
 
-std::future<__TypeKind> UnionType::getKind(std::shared_ptr<service::RequestState>) const
+std::future<__TypeKind> UnionType::getKind(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<__TypeKind> promise;
 
@@ -341,7 +341,7 @@ std::future<__TypeKind> UnionType::getKind(std::shared_ptr<service::RequestState
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::string>> UnionType::getName(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> UnionType::getName(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 
@@ -350,7 +350,7 @@ std::future<std::unique_ptr<std::string>> UnionType::getName(std::shared_ptr<ser
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> UnionType::getPossibleTypes(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> UnionType::getPossibleTypes(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> promise;
 	std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>> result(new std::vector<std::shared_ptr<object::__Type>>(_possibleTypes.size()));
@@ -385,7 +385,7 @@ void EnumType::AddEnumValues(std::vector<EnumValueType> enumValues)
 	}
 }
 
-std::future<__TypeKind> EnumType::getKind(std::shared_ptr<service::RequestState>) const
+std::future<__TypeKind> EnumType::getKind(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<__TypeKind> promise;
 
@@ -394,7 +394,7 @@ std::future<__TypeKind> EnumType::getKind(std::shared_ptr<service::RequestState>
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::string>> EnumType::getName(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> EnumType::getName(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 
@@ -403,7 +403,7 @@ std::future<std::unique_ptr<std::string>> EnumType::getName(std::shared_ptr<serv
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> EnumType::getEnumValues(std::shared_ptr<service::RequestState> state, std::unique_ptr<bool>&& includeDeprecated) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> EnumType::getEnumValues(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<bool>&& includeDeprecated) const
 {
 	const bool deprecated = includeDeprecated && *includeDeprecated;
 	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> promise;
@@ -432,7 +432,7 @@ void InputObjectType::AddInputValues(std::vector<std::shared_ptr<InputValue>> in
 	_inputValues = std::move(inputValues);
 }
 
-std::future<__TypeKind> InputObjectType::getKind(std::shared_ptr<service::RequestState>) const
+std::future<__TypeKind> InputObjectType::getKind(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<__TypeKind> promise;
 
@@ -441,7 +441,7 @@ std::future<__TypeKind> InputObjectType::getKind(std::shared_ptr<service::Reques
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::string>> InputObjectType::getName(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> InputObjectType::getName(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 
@@ -450,7 +450,7 @@ std::future<std::unique_ptr<std::string>> InputObjectType::getName(std::shared_p
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> InputObjectType::getInputFields(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> InputObjectType::getInputFields(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> promise;
 	std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>> result(new std::vector<std::shared_ptr<object::__InputValue>>(_inputValues.size()));
@@ -468,7 +468,7 @@ WrapperType::WrapperType(__TypeKind kind, std::shared_ptr<object::__Type> ofType
 {
 }
 
-std::future<__TypeKind> WrapperType::getKind(std::shared_ptr<service::RequestState>) const
+std::future<__TypeKind> WrapperType::getKind(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<__TypeKind> promise;
 
@@ -477,7 +477,7 @@ std::future<__TypeKind> WrapperType::getKind(std::shared_ptr<service::RequestSta
 	return promise.get_future();
 }
 
-std::future<std::shared_ptr<object::__Type>> WrapperType::getOfType(std::shared_ptr<service::RequestState>) const
+std::future<std::shared_ptr<object::__Type>> WrapperType::getOfType(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::shared_ptr<object::__Type>> promise;
 
@@ -495,7 +495,7 @@ Field::Field(std::string name, std::string description, std::unique_ptr<std::str
 {
 }
 
-std::future<std::string> Field::getName(std::shared_ptr<service::RequestState>) const
+std::future<std::string> Field::getName(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::string> promise;
 
@@ -504,7 +504,7 @@ std::future<std::string> Field::getName(std::shared_ptr<service::RequestState>) 
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::string>> Field::getDescription(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> Field::getDescription(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 
@@ -515,7 +515,7 @@ std::future<std::unique_ptr<std::string>> Field::getDescription(std::shared_ptr<
 	return promise.get_future();
 }
 
-std::future<std::vector<std::shared_ptr<object::__InputValue>>> Field::getArgs(std::shared_ptr<service::RequestState>) const
+std::future<std::vector<std::shared_ptr<object::__InputValue>>> Field::getArgs(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::vector<std::shared_ptr<object::__InputValue>>> promise;
 	std::vector<std::shared_ptr<object::__InputValue>> result(_args.size());
@@ -526,7 +526,7 @@ std::future<std::vector<std::shared_ptr<object::__InputValue>>> Field::getArgs(s
 	return promise.get_future();
 }
 
-std::future<std::shared_ptr<object::__Type>> Field::getType(std::shared_ptr<service::RequestState>) const
+std::future<std::shared_ptr<object::__Type>> Field::getType(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::shared_ptr<object::__Type>> promise;
 
@@ -535,7 +535,7 @@ std::future<std::shared_ptr<object::__Type>> Field::getType(std::shared_ptr<serv
 	return promise.get_future();
 }
 
-std::future<bool> Field::getIsDeprecated(std::shared_ptr<service::RequestState>) const
+std::future<bool> Field::getIsDeprecated(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<bool> promise;
 
@@ -544,7 +544,7 @@ std::future<bool> Field::getIsDeprecated(std::shared_ptr<service::RequestState>)
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::string>> Field::getDeprecationReason(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> Field::getDeprecationReason(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 
@@ -563,7 +563,7 @@ InputValue::InputValue(std::string name, std::string description, std::shared_pt
 {
 }
 
-std::future<std::string> InputValue::getName(std::shared_ptr<service::RequestState>) const
+std::future<std::string> InputValue::getName(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::string> promise;
 
@@ -572,7 +572,7 @@ std::future<std::string> InputValue::getName(std::shared_ptr<service::RequestSta
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::string>> InputValue::getDescription(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> InputValue::getDescription(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 
@@ -583,7 +583,7 @@ std::future<std::unique_ptr<std::string>> InputValue::getDescription(std::shared
 	return promise.get_future();
 }
 
-std::future<std::shared_ptr<object::__Type>> InputValue::getType(std::shared_ptr<service::RequestState>) const
+std::future<std::shared_ptr<object::__Type>> InputValue::getType(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::shared_ptr<object::__Type>> promise;
 
@@ -592,7 +592,7 @@ std::future<std::shared_ptr<object::__Type>> InputValue::getType(std::shared_ptr
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::string>> InputValue::getDefaultValue(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> InputValue::getDefaultValue(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 
@@ -610,7 +610,7 @@ EnumValue::EnumValue(std::string name, std::string description, std::unique_ptr<
 {
 }
 
-std::future<std::string> EnumValue::getName(std::shared_ptr<service::RequestState>) const
+std::future<std::string> EnumValue::getName(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::string> promise;
 
@@ -619,7 +619,7 @@ std::future<std::string> EnumValue::getName(std::shared_ptr<service::RequestStat
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::string>> EnumValue::getDescription(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> EnumValue::getDescription(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 
@@ -630,7 +630,7 @@ std::future<std::unique_ptr<std::string>> EnumValue::getDescription(std::shared_
 	return promise.get_future();
 }
 
-std::future<bool> EnumValue::getIsDeprecated(std::shared_ptr<service::RequestState>) const
+std::future<bool> EnumValue::getIsDeprecated(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<bool> promise;
 
@@ -639,7 +639,7 @@ std::future<bool> EnumValue::getIsDeprecated(std::shared_ptr<service::RequestSta
 	return promise.get_future();
 }
 
-std::future<std::unique_ptr<std::string>> EnumValue::getDeprecationReason(std::shared_ptr<service::RequestState>) const
+std::future<std::unique_ptr<std::string>> EnumValue::getDeprecationReason(const std::shared_ptr<service::RequestState>&) const
 {
 	std::promise<std::unique_ptr<std::string>> promise;
 

--- a/SchemaGenerator.cpp
+++ b/SchemaGenerator.cpp
@@ -1462,7 +1462,7 @@ std::string Generator::getFieldDeclaration(const OutputField& outputField) const
 
 	fieldName[0] = std::toupper(fieldName[0]);
 	output << R"cpp(	virtual std::future<)cpp" << getOutputCppType(outputField)
-		<< R"cpp(> get)cpp" << fieldName << R"cpp((std::shared_ptr<service::RequestState> state)cpp";
+		<< R"cpp(> get)cpp" << fieldName << R"cpp((const std::shared_ptr<service::RequestState>& state)cpp";
 
 	for (const auto& argument : outputField.arguments)
 	{

--- a/Today.cpp
+++ b/Today.cpp
@@ -39,8 +39,16 @@ Query::Query(appointmentsLoader&& getAppointments, tasksLoader&& getTasks, unrea
 {
 }
 
-void Query::loadAppointments() const
+void Query::loadAppointments(const std::shared_ptr<service::RequestState>& state) const
 {
+	if (state)
+	{
+		auto todayState = std::static_pointer_cast<RequestState>(state);
+
+		todayState->appointmentsRequestId = todayState->requestId;
+		todayState->loadAppointmentsCount++;
+	}
+
 	if (_getAppointments)
 	{
 		_appointments = _getAppointments();
@@ -50,7 +58,7 @@ void Query::loadAppointments() const
 
 std::shared_ptr<Appointment> Query::findAppointment(const std::shared_ptr<service::RequestState>& state, const std::vector<uint8_t>& id) const
 {
-	loadAppointments();
+	loadAppointments(state);
 
 	for (const auto& appointment : _appointments)
 	{
@@ -65,8 +73,16 @@ std::shared_ptr<Appointment> Query::findAppointment(const std::shared_ptr<servic
 	return nullptr;
 }
 
-void Query::loadTasks() const
+void Query::loadTasks(const std::shared_ptr<service::RequestState>& state) const
 {
+	if (state)
+	{
+		auto todayState = std::static_pointer_cast<RequestState>(state);
+
+		todayState->tasksRequestId = todayState->requestId;
+		todayState->loadTasksCount++;
+	}
+
 	if (_getTasks)
 	{
 		_tasks = _getTasks();
@@ -76,7 +92,7 @@ void Query::loadTasks() const
 
 std::shared_ptr<Task> Query::findTask(const std::shared_ptr<service::RequestState>& state, const std::vector<uint8_t>& id) const
 {
-	loadTasks();
+	loadTasks(state);
 
 	for (const auto& task : _tasks)
 	{
@@ -91,8 +107,16 @@ std::shared_ptr<Task> Query::findTask(const std::shared_ptr<service::RequestStat
 	return nullptr;
 }
 
-void Query::loadUnreadCounts() const
+void Query::loadUnreadCounts(const std::shared_ptr<service::RequestState>& state) const
 {
+	if (state)
+	{
+		auto todayState = std::static_pointer_cast<RequestState>(state);
+
+		todayState->unreadCountsRequestId = todayState->requestId;
+		todayState->loadUnreadCountsCount++;
+	}
+
 	if (_getUnreadCounts)
 	{
 		_unreadCounts = _getUnreadCounts();
@@ -102,7 +126,7 @@ void Query::loadUnreadCounts() const
 
 std::shared_ptr<Folder> Query::findUnreadCount(const std::shared_ptr<service::RequestState>& state, const std::vector<uint8_t>& id) const
 {
-	loadUnreadCounts();
+	loadUnreadCounts(state);
 
 	for (const auto& folder : _unreadCounts)
 	{
@@ -248,7 +272,7 @@ std::future<std::shared_ptr<object::AppointmentConnection>> Query::getAppointmen
 	return std::async(std::launch::async,
 		[this, spThis](const std::shared_ptr<service::RequestState>& stateWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<response::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<response::Value>&& beforeWrapped)
 	{
-		loadAppointments();
+		loadAppointments(stateWrapped);
 
 		EdgeConstraints<Appointment, AppointmentConnection> constraints(stateWrapped, _appointments);
 		auto connection = constraints(firstWrapped.get(), afterWrapped.get(), lastWrapped.get(), beforeWrapped.get());
@@ -263,7 +287,7 @@ std::future<std::shared_ptr<object::TaskConnection>> Query::getTasks(const std::
 	return std::async(std::launch::async,
 		[this, spThis](const std::shared_ptr<service::RequestState>& stateWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<response::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<response::Value>&& beforeWrapped)
 	{
-		loadTasks();
+		loadTasks(stateWrapped);
 
 		EdgeConstraints<Task, TaskConnection> constraints(stateWrapped, _tasks);
 		auto connection = constraints(firstWrapped.get(), afterWrapped.get(), lastWrapped.get(), beforeWrapped.get());
@@ -278,7 +302,7 @@ std::future<std::shared_ptr<object::FolderConnection>> Query::getUnreadCounts(co
 	return std::async(std::launch::async,
 		[this, spThis](const std::shared_ptr<service::RequestState>& stateWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<response::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<response::Value>&& beforeWrapped)
 	{
-		loadUnreadCounts();
+		loadUnreadCounts(stateWrapped);
 
 		EdgeConstraints<Folder, FolderConnection> constraints(stateWrapped, _unreadCounts);
 		auto connection = constraints(firstWrapped.get(), afterWrapped.get(), lastWrapped.get(), beforeWrapped.get());

--- a/Today.cpp
+++ b/Today.cpp
@@ -48,7 +48,7 @@ void Query::loadAppointments() const
 	}
 }
 
-std::shared_ptr<Appointment> Query::findAppointment(std::shared_ptr<service::RequestState> state, const std::vector<uint8_t>& id) const
+std::shared_ptr<Appointment> Query::findAppointment(const std::shared_ptr<service::RequestState>& state, const std::vector<uint8_t>& id) const
 {
 	loadAppointments();
 
@@ -74,7 +74,7 @@ void Query::loadTasks() const
 	}
 }
 
-std::shared_ptr<Task> Query::findTask(std::shared_ptr<service::RequestState> state, const std::vector<uint8_t>& id) const
+std::shared_ptr<Task> Query::findTask(const std::shared_ptr<service::RequestState>& state, const std::vector<uint8_t>& id) const
 {
 	loadTasks();
 
@@ -100,7 +100,7 @@ void Query::loadUnreadCounts() const
 	}
 }
 
-std::shared_ptr<Folder> Query::findUnreadCount(std::shared_ptr<service::RequestState> state, const std::vector<uint8_t>& id) const
+std::shared_ptr<Folder> Query::findUnreadCount(const std::shared_ptr<service::RequestState>& state, const std::vector<uint8_t>& id) const
 {
 	loadUnreadCounts();
 
@@ -117,7 +117,7 @@ std::shared_ptr<Folder> Query::findUnreadCount(std::shared_ptr<service::RequestS
 	return nullptr;
 }
 
-std::future<std::shared_ptr<service::Object>> Query::getNode(std::shared_ptr<service::RequestState> state, std::vector<uint8_t>&& id) const
+std::future<std::shared_ptr<service::Object>> Query::getNode(const std::shared_ptr<service::RequestState>& state, std::vector<uint8_t>&& id) const
 {
 	std::promise<std::shared_ptr<service::Object>> promise;
 	auto appointment = findAppointment(state, id);
@@ -154,7 +154,7 @@ struct EdgeConstraints
 	using vec_type = std::vector<std::shared_ptr<_Object>>;
 	using itr_type = typename vec_type::const_iterator;
 
-	EdgeConstraints(std::shared_ptr<service::RequestState> state, const vec_type& objects)
+	EdgeConstraints(const std::shared_ptr<service::RequestState>& state, const vec_type& objects)
 		: _state(state)
 		, _objects(objects)
 	{
@@ -242,11 +242,11 @@ private:
 	const vec_type& _objects;
 };
 
-std::future<std::shared_ptr<object::AppointmentConnection>> Query::getAppointments(std::shared_ptr<service::RequestState> state, std::unique_ptr<int>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<response::Value>&& before) const
+std::future<std::shared_ptr<object::AppointmentConnection>> Query::getAppointments(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<int>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<response::Value>&& before) const
 {
 	auto spThis = shared_from_this();
 	return std::async(std::launch::async,
-		[this, spThis](std::shared_ptr<service::RequestState> stateWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<response::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<response::Value>&& beforeWrapped)
+		[this, spThis](const std::shared_ptr<service::RequestState>& stateWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<response::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<response::Value>&& beforeWrapped)
 	{
 		loadAppointments();
 
@@ -257,11 +257,11 @@ std::future<std::shared_ptr<object::AppointmentConnection>> Query::getAppointmen
 	}, std::move(state), std::move(first), std::move(after), std::move(last), std::move(before));
 }
 
-std::future<std::shared_ptr<object::TaskConnection>> Query::getTasks(std::shared_ptr<service::RequestState> state, std::unique_ptr<int>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<response::Value>&& before) const
+std::future<std::shared_ptr<object::TaskConnection>> Query::getTasks(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<int>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<response::Value>&& before) const
 {
 	auto spThis = shared_from_this();
 	return std::async(std::launch::async,
-		[this, spThis](std::shared_ptr<service::RequestState> stateWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<response::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<response::Value>&& beforeWrapped)
+		[this, spThis](const std::shared_ptr<service::RequestState>& stateWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<response::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<response::Value>&& beforeWrapped)
 	{
 		loadTasks();
 
@@ -272,11 +272,11 @@ std::future<std::shared_ptr<object::TaskConnection>> Query::getTasks(std::shared
 	}, std::move(state), std::move(first), std::move(after), std::move(last), std::move(before));
 }
 
-std::future<std::shared_ptr<object::FolderConnection>> Query::getUnreadCounts(std::shared_ptr<service::RequestState> state, std::unique_ptr<int>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<response::Value>&& before) const
+std::future<std::shared_ptr<object::FolderConnection>> Query::getUnreadCounts(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<int>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<int>&& last, std::unique_ptr<response::Value>&& before) const
 {
 	auto spThis = shared_from_this();
 	return std::async(std::launch::async,
-		[this, spThis](std::shared_ptr<service::RequestState> stateWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<response::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<response::Value>&& beforeWrapped)
+		[this, spThis](const std::shared_ptr<service::RequestState>& stateWrapped, std::unique_ptr<int>&& firstWrapped, std::unique_ptr<response::Value>&& afterWrapped, std::unique_ptr<int>&& lastWrapped, std::unique_ptr<response::Value>&& beforeWrapped)
 	{
 		loadUnreadCounts();
 
@@ -287,7 +287,7 @@ std::future<std::shared_ptr<object::FolderConnection>> Query::getUnreadCounts(st
 	}, std::move(state), std::move(first), std::move(after), std::move(last), std::move(before));
 }
 
-std::future<std::vector<std::shared_ptr<object::Appointment>>> Query::getAppointmentsById(std::shared_ptr<service::RequestState> state, std::vector<std::vector<uint8_t>>&& ids) const
+std::future<std::vector<std::shared_ptr<object::Appointment>>> Query::getAppointmentsById(const std::shared_ptr<service::RequestState>& state, std::vector<std::vector<uint8_t>>&& ids) const
 {
 	std::promise<std::vector<std::shared_ptr<object::Appointment>>> promise;
 	std::vector<std::shared_ptr<object::Appointment>> result(ids.size());
@@ -302,7 +302,7 @@ std::future<std::vector<std::shared_ptr<object::Appointment>>> Query::getAppoint
 	return promise.get_future();
 }
 
-std::future<std::vector<std::shared_ptr<object::Task>>> Query::getTasksById(std::shared_ptr<service::RequestState> state, std::vector<std::vector<uint8_t>>&& ids) const
+std::future<std::vector<std::shared_ptr<object::Task>>> Query::getTasksById(const std::shared_ptr<service::RequestState>& state, std::vector<std::vector<uint8_t>>&& ids) const
 {
 	std::promise<std::vector<std::shared_ptr<object::Task>>> promise;
 	std::vector<std::shared_ptr<object::Task>> result(ids.size());
@@ -317,7 +317,7 @@ std::future<std::vector<std::shared_ptr<object::Task>>> Query::getTasksById(std:
 	return promise.get_future();
 }
 
-std::future<std::vector<std::shared_ptr<object::Folder>>> Query::getUnreadCountsById(std::shared_ptr<service::RequestState> state, std::vector<std::vector<uint8_t>>&& ids) const
+std::future<std::vector<std::shared_ptr<object::Folder>>> Query::getUnreadCountsById(const std::shared_ptr<service::RequestState>& state, std::vector<std::vector<uint8_t>>&& ids) const
 {
 	std::promise<std::vector<std::shared_ptr<object::Folder>>> promise;
 	std::vector<std::shared_ptr<object::Folder>> result(ids.size());
@@ -337,7 +337,7 @@ Mutation::Mutation(completeTaskMutation&& mutateCompleteTask)
 {
 }
 
-std::future<std::shared_ptr<object::CompleteTaskPayload>> Mutation::getCompleteTask(std::shared_ptr<service::RequestState> state, CompleteTaskInput&& input) const
+std::future<std::shared_ptr<object::CompleteTaskPayload>> Mutation::getCompleteTask(const std::shared_ptr<service::RequestState>& state, CompleteTaskInput&& input) const
 {
 	std::promise<std::shared_ptr<object::CompleteTaskPayload>> promise;
 

--- a/include/Today.h
+++ b/include/Today.h
@@ -22,18 +22,18 @@ public:
 
 	explicit Query(appointmentsLoader&& getAppointments, tasksLoader&& getTasks, unreadCountsLoader&& getUnreadCounts);
 
-	std::future<std::shared_ptr<service::Object>> getNode(std::shared_ptr<service::RequestState> state, std::vector<uint8_t>&& id) const override;
-	std::future<std::shared_ptr<object::AppointmentConnection>> getAppointments(std::shared_ptr<service::RequestState> state, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
-	std::future<std::shared_ptr<object::TaskConnection>> getTasks(std::shared_ptr<service::RequestState> state, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
-	std::future<std::shared_ptr<object::FolderConnection>> getUnreadCounts(std::shared_ptr<service::RequestState> state, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
-	std::future<std::vector<std::shared_ptr<object::Appointment>>> getAppointmentsById(std::shared_ptr<service::RequestState> state, std::vector<std::vector<uint8_t>>&& ids) const override;
-	std::future<std::vector<std::shared_ptr<object::Task>>> getTasksById(std::shared_ptr<service::RequestState> state, std::vector<std::vector<uint8_t>>&& ids) const override;
-	std::future<std::vector<std::shared_ptr<object::Folder>>> getUnreadCountsById(std::shared_ptr<service::RequestState> state, std::vector<std::vector<uint8_t>>&& ids) const override;
+	std::future<std::shared_ptr<service::Object>> getNode(const std::shared_ptr<service::RequestState>& state, std::vector<uint8_t>&& id) const override;
+	std::future<std::shared_ptr<object::AppointmentConnection>> getAppointments(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
+	std::future<std::shared_ptr<object::TaskConnection>> getTasks(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
+	std::future<std::shared_ptr<object::FolderConnection>> getUnreadCounts(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const override;
+	std::future<std::vector<std::shared_ptr<object::Appointment>>> getAppointmentsById(const std::shared_ptr<service::RequestState>& state, std::vector<std::vector<uint8_t>>&& ids) const override;
+	std::future<std::vector<std::shared_ptr<object::Task>>> getTasksById(const std::shared_ptr<service::RequestState>& state, std::vector<std::vector<uint8_t>>&& ids) const override;
+	std::future<std::vector<std::shared_ptr<object::Folder>>> getUnreadCountsById(const std::shared_ptr<service::RequestState>& state, std::vector<std::vector<uint8_t>>&& ids) const override;
 
 private:
-	std::shared_ptr<Appointment> findAppointment(std::shared_ptr<service::RequestState> state, const std::vector<uint8_t>& id) const;
-	std::shared_ptr<Task> findTask(std::shared_ptr<service::RequestState> state, const std::vector<uint8_t>& id) const;
-	std::shared_ptr<Folder> findUnreadCount(std::shared_ptr<service::RequestState> state, const std::vector<uint8_t>& id) const;
+	std::shared_ptr<Appointment> findAppointment(const std::shared_ptr<service::RequestState>& state, const std::vector<uint8_t>& id) const;
+	std::shared_ptr<Task> findTask(const std::shared_ptr<service::RequestState>& state, const std::vector<uint8_t>& id) const;
+	std::shared_ptr<Folder> findUnreadCount(const std::shared_ptr<service::RequestState>& state, const std::vector<uint8_t>& id) const;
 
 	// Lazy load the fields in each query
 	void loadAppointments() const;
@@ -58,7 +58,7 @@ public:
 	{
 	}
 
-	std::future<bool> getHasNextPage(std::shared_ptr<service::RequestState>) const override
+	std::future<bool> getHasNextPage(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<bool> promise;
 
@@ -67,7 +67,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<bool> getHasPreviousPage(std::shared_ptr<service::RequestState>) const override
+	std::future<bool> getHasPreviousPage(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<bool> promise;
 
@@ -86,7 +86,7 @@ class Appointment : public object::Appointment
 public:
 	explicit Appointment(std::vector<uint8_t>&& id, std::string&& when, std::string&& subject, bool isNow);
 
-	std::future<std::vector<uint8_t>> getId(std::shared_ptr<service::RequestState>) const override
+	std::future<std::vector<uint8_t>> getId(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::vector<uint8_t>> promise;
 
@@ -95,7 +95,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<response::Value>> getWhen(std::shared_ptr<service::RequestState>) const override
+	std::future<std::unique_ptr<response::Value>> getWhen(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::unique_ptr<response::Value>> promise;
 
@@ -104,7 +104,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<response::StringType>> getSubject(std::shared_ptr<service::RequestState>) const override
+	std::future<std::unique_ptr<response::StringType>> getSubject(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::unique_ptr<response::StringType>> promise;
 
@@ -113,7 +113,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<bool> getIsNow(std::shared_ptr<service::RequestState>) const override
+	std::future<bool> getIsNow(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<bool> promise;
 
@@ -137,7 +137,7 @@ public:
 	{
 	}
 
-	std::future<std::shared_ptr<object::Appointment>> getNode(std::shared_ptr<service::RequestState>) const override
+	std::future<std::shared_ptr<object::Appointment>> getNode(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::shared_ptr<object::Appointment>> promise;
 
@@ -146,7 +146,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<response::Value> getCursor(std::shared_ptr<service::RequestState> state) const override
+	std::future<response::Value> getCursor(const std::shared_ptr<service::RequestState>& state) const override
 	{
 		std::promise<response::Value> promise;
 
@@ -168,7 +168,7 @@ public:
 	{
 	}
 
-	std::future<std::shared_ptr<object::PageInfo>> getPageInfo(std::shared_ptr<service::RequestState>) const override
+	std::future<std::shared_ptr<object::PageInfo>> getPageInfo(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::shared_ptr<object::PageInfo>> promise;
 
@@ -177,7 +177,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::AppointmentEdge>>>> getEdges(std::shared_ptr<service::RequestState>) const override
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::AppointmentEdge>>>> getEdges(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::AppointmentEdge>>>> promise;
 		auto result = std::unique_ptr<std::vector<std::shared_ptr<object::AppointmentEdge>>>(new std::vector<std::shared_ptr<object::AppointmentEdge>>(_appointments.size()));
@@ -202,7 +202,7 @@ class Task : public object::Task
 public:
 	explicit Task(std::vector<uint8_t>&& id, std::string&& title, bool isComplete);
 
-	std::future<std::vector<uint8_t>> getId(std::shared_ptr<service::RequestState>) const override
+	std::future<std::vector<uint8_t>> getId(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::vector<uint8_t>> promise;
 
@@ -211,7 +211,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<response::StringType>> getTitle(std::shared_ptr<service::RequestState>) const override
+	std::future<std::unique_ptr<response::StringType>> getTitle(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::unique_ptr<response::StringType>> promise;
 
@@ -220,7 +220,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<bool> getIsComplete(std::shared_ptr<service::RequestState>) const override
+	std::future<bool> getIsComplete(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<bool> promise;
 
@@ -244,7 +244,7 @@ public:
 	{
 	}
 
-	std::future<std::shared_ptr<object::Task>> getNode(std::shared_ptr<service::RequestState>) const override
+	std::future<std::shared_ptr<object::Task>> getNode(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::shared_ptr<object::Task>> promise;
 
@@ -253,7 +253,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<response::Value> getCursor(std::shared_ptr<service::RequestState> state) const override
+	std::future<response::Value> getCursor(const std::shared_ptr<service::RequestState>& state) const override
 	{
 		std::promise<response::Value> promise;
 
@@ -275,7 +275,7 @@ public:
 	{
 	}
 
-	std::future<std::shared_ptr<object::PageInfo>> getPageInfo(std::shared_ptr<service::RequestState>) const override
+	std::future<std::shared_ptr<object::PageInfo>> getPageInfo(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::shared_ptr<object::PageInfo>> promise;
 
@@ -284,7 +284,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::TaskEdge>>>> getEdges(std::shared_ptr<service::RequestState>) const override
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::TaskEdge>>>> getEdges(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::TaskEdge>>>> promise;
 		auto result = std::unique_ptr<std::vector<std::shared_ptr<object::TaskEdge>>>(new std::vector<std::shared_ptr<object::TaskEdge>>(_tasks.size()));
@@ -309,7 +309,7 @@ class Folder : public object::Folder
 public:
 	explicit Folder(std::vector<uint8_t>&& id, std::string&& name, int unreadCount);
 
-	std::future<std::vector<uint8_t>> getId(std::shared_ptr<service::RequestState>) const override
+	std::future<std::vector<uint8_t>> getId(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::vector<uint8_t>> promise;
 
@@ -318,7 +318,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<response::StringType>> getName(std::shared_ptr<service::RequestState>) const override
+	std::future<std::unique_ptr<response::StringType>> getName(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::unique_ptr<response::StringType>> promise;
 
@@ -327,7 +327,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<int> getUnreadCount(std::shared_ptr<service::RequestState>) const override
+	std::future<int> getUnreadCount(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<int> promise;
 
@@ -350,7 +350,7 @@ public:
 	{
 	}
 
-	std::future<std::shared_ptr<object::Folder>> getNode(std::shared_ptr<service::RequestState>) const override
+	std::future<std::shared_ptr<object::Folder>> getNode(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::shared_ptr<object::Folder>> promise;
 
@@ -359,7 +359,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<response::Value> getCursor(std::shared_ptr<service::RequestState> state) const override
+	std::future<response::Value> getCursor(const std::shared_ptr<service::RequestState>& state) const override
 	{
 		std::promise<response::Value> promise;
 
@@ -381,7 +381,7 @@ public:
 	{
 	}
 
-	std::future<std::shared_ptr<object::PageInfo>> getPageInfo(std::shared_ptr<service::RequestState>) const override
+	std::future<std::shared_ptr<object::PageInfo>> getPageInfo(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::shared_ptr<object::PageInfo>> promise;
 
@@ -390,7 +390,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::FolderEdge>>>> getEdges(std::shared_ptr<service::RequestState>) const override
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::FolderEdge>>>> getEdges(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::unique_ptr<std::vector<std::shared_ptr<object::FolderEdge>>>> promise;
 		auto result = std::unique_ptr<std::vector<std::shared_ptr<object::FolderEdge>>>(new std::vector<std::shared_ptr<object::FolderEdge>>(_folders.size()));
@@ -419,7 +419,7 @@ public:
 	{
 	}
 
-	std::future<std::shared_ptr<object::Task>> getTask(std::shared_ptr<service::RequestState>) const override
+	std::future<std::shared_ptr<object::Task>> getTask(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::shared_ptr<object::Task>> promise;
 
@@ -428,7 +428,7 @@ public:
 		return promise.get_future();
 	}
 
-	std::future<std::unique_ptr<response::StringType>> getClientMutationId(std::shared_ptr<service::RequestState>) const override
+	std::future<std::unique_ptr<response::StringType>> getClientMutationId(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::unique_ptr<response::StringType>> promise;
 
@@ -451,7 +451,7 @@ public:
 
 	explicit Mutation(completeTaskMutation&& mutateCompleteTask);
 
-	std::future<std::shared_ptr<object::CompleteTaskPayload>> getCompleteTask(std::shared_ptr<service::RequestState> state, CompleteTaskInput&& input) const override;
+	std::future<std::shared_ptr<object::CompleteTaskPayload>> getCompleteTask(const std::shared_ptr<service::RequestState>& state, CompleteTaskInput&& input) const override;
 
 private:
 	completeTaskMutation _mutateCompleteTask;
@@ -462,7 +462,7 @@ class Subscription : public object::Subscription
 public:
 	explicit Subscription() = default;
 
-	std::future<std::shared_ptr<object::Appointment>> getNextAppointmentChange(std::shared_ptr<service::RequestState>) const override
+	std::future<std::shared_ptr<object::Appointment>> getNextAppointmentChange(const std::shared_ptr<service::RequestState>&) const override
 	{
 		std::promise<std::shared_ptr<object::Appointment>> promise;
 

--- a/include/Today.h
+++ b/include/Today.h
@@ -9,6 +9,24 @@ namespace facebook {
 namespace graphql {
 namespace today {
 
+struct RequestState : service::RequestState
+{
+	RequestState(size_t id)
+		: requestId(id)
+	{
+	}
+
+	const size_t requestId;
+
+	size_t appointmentsRequestId = 0;
+	size_t tasksRequestId = 0;
+	size_t unreadCountsRequestId = 0;
+
+	size_t loadAppointmentsCount = 0;
+	size_t loadTasksCount = 0;
+	size_t loadUnreadCountsCount = 0;
+};
+
 class Appointment;
 class Task;
 class Folder;
@@ -36,9 +54,9 @@ private:
 	std::shared_ptr<Folder> findUnreadCount(const std::shared_ptr<service::RequestState>& state, const std::vector<uint8_t>& id) const;
 
 	// Lazy load the fields in each query
-	void loadAppointments() const;
-	void loadTasks() const;
-	void loadUnreadCounts() const;
+	void loadAppointments(const std::shared_ptr<service::RequestState>& state) const;
+	void loadTasks(const std::shared_ptr<service::RequestState>& state) const;
+	void loadUnreadCounts(const std::shared_ptr<service::RequestState>& state) const;
 
 	mutable appointmentsLoader _getAppointments;
 	mutable tasksLoader _getTasks;

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -36,7 +36,7 @@ private:
 
 // The RequestState is optional, but if you have multiple threads processing requests and there's any
 // per-request state that you want to maintain throughout the request (e.g. optimizing or batching
-// backend requests), you can subclass RequestState and pass it to Request::resolve to correlate the
+// backend requests), you can inherit from RequestState and pass it to Request::resolve to correlate the
 // asynchronous/recursive callbacks and accumulate state in it.
 struct RequestState : std::enable_shared_from_this<RequestState>
 {
@@ -276,13 +276,13 @@ public:
 	explicit Object(TypeNames&& typeNames, ResolverMap&& resolvers);
 	virtual ~Object() = default;
 
-	std::future<response::Value> resolve(std::shared_ptr<RequestState> state, const peg::ast_node& selection, const FragmentMap& fragments, const response::Value& variables) const;
+	std::future<response::Value> resolve(const std::shared_ptr<RequestState>& state, const peg::ast_node& selection, const FragmentMap& fragments, const response::Value& variables) const;
 
 protected:
 	// It's up to sub-classes to decide if they want to use const_cast, mutable, or separate storage
 	// to accumulate state. By default these callbacks should treat the Object itself as const.
-	virtual void beginSelectionSet(std::shared_ptr<RequestState> state) const;
-	virtual void endSelectionSet(std::shared_ptr<RequestState> state) const;
+	virtual void beginSelectionSet(const std::shared_ptr<RequestState>& state) const;
+	virtual void endSelectionSet(const std::shared_ptr<RequestState>& state) const;
 
 private:
 	TypeNames _typeNames;
@@ -459,7 +459,7 @@ public:
 	explicit Request(TypeMap&& operationTypes);
 	virtual ~Request() = default;
 
-	std::future<response::Value> resolve(std::shared_ptr<RequestState> state, const peg::ast_node& root, const std::string& operationName, const response::Value& variables) const;
+	std::future<response::Value> resolve(const std::shared_ptr<RequestState>& state, const peg::ast_node& root, const std::string& operationName, const response::Value& variables) const;
 
 private:
 	TypeMap _operations;

--- a/include/graphqlservice/Introspection.h
+++ b/include/graphqlservice/Introspection.h
@@ -34,11 +34,11 @@ public:
 	std::shared_ptr<object::__Type> LookupType(const std::string& name) const;
 
 	// Accessors
-	std::future<std::vector<std::shared_ptr<object::__Type>>> getTypes(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::shared_ptr<object::__Type>> getQueryType(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::shared_ptr<object::__Type>> getMutationType(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::shared_ptr<object::__Type>> getSubscriptionType(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::vector<std::shared_ptr<object::__Directive>>> getDirectives(std::shared_ptr<service::RequestState> state) const override;
+	std::future<std::vector<std::shared_ptr<object::__Type>>> getTypes(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::shared_ptr<object::__Type>> getQueryType(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::shared_ptr<object::__Type>> getMutationType(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::shared_ptr<object::__Type>> getSubscriptionType(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::vector<std::shared_ptr<object::__Directive>>> getDirectives(const std::shared_ptr<service::RequestState>& state) const override;
 
 private:
 	std::shared_ptr<ObjectType> _query;
@@ -52,14 +52,14 @@ class BaseType : public object::__Type
 {
 public:
 	// Accessors
-	std::future<std::unique_ptr<std::string>> getName(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::string>> getDescription(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> getFields(std::shared_ptr<service::RequestState> state, std::unique_ptr<bool>&& includeDeprecated) const override;
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> getInterfaces(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> getPossibleTypes(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> getEnumValues(std::shared_ptr<service::RequestState> state, std::unique_ptr<bool>&& includeDeprecated) const override;
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> getInputFields(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::shared_ptr<object::__Type>> getOfType(std::shared_ptr<service::RequestState> state) const override;
+	std::future<std::unique_ptr<std::string>> getName(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::string>> getDescription(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> getFields(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<bool>&& includeDeprecated) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> getInterfaces(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> getPossibleTypes(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> getEnumValues(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<bool>&& includeDeprecated) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> getInputFields(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::shared_ptr<object::__Type>> getOfType(const std::shared_ptr<service::RequestState>& state) const override;
 
 protected:
 	BaseType(std::string description);
@@ -74,8 +74,8 @@ public:
 	explicit ScalarType(std::string name, std::string description);
 
 	// Accessors
-	std::future<__TypeKind> getKind(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::string>> getName(std::shared_ptr<service::RequestState> state) const override;
+	std::future<__TypeKind> getKind(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::string>> getName(const std::shared_ptr<service::RequestState>& state) const override;
 
 private:
 	const std::string _name;
@@ -90,10 +90,10 @@ public:
 	void AddFields(std::vector<std::shared_ptr<Field>> fields);
 
 	// Accessors
-	std::future<__TypeKind> getKind(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::string>> getName(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> getFields(std::shared_ptr<service::RequestState> state, std::unique_ptr<bool>&& includeDeprecated) const override;
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> getInterfaces(std::shared_ptr<service::RequestState> state) const override;
+	std::future<__TypeKind> getKind(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::string>> getName(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> getFields(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<bool>&& includeDeprecated) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> getInterfaces(const std::shared_ptr<service::RequestState>& state) const override;
 
 private:
 	const std::string _name;
@@ -110,9 +110,9 @@ public:
 	void AddFields(std::vector<std::shared_ptr<Field>> fields);
 
 	// Accessors
-	std::future<__TypeKind> getKind(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::string>> getName(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> getFields(std::shared_ptr<service::RequestState> state, std::unique_ptr<bool>&& includeDeprecated) const override;
+	std::future<__TypeKind> getKind(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::string>> getName(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Field>>>> getFields(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<bool>&& includeDeprecated) const override;
 
 private:
 	const std::string _name;
@@ -128,9 +128,9 @@ public:
 	void AddPossibleTypes(std::vector<std::shared_ptr<object::__Type>> possibleTypes);
 
 	// Accessors
-	std::future<__TypeKind> getKind(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::string>> getName(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> getPossibleTypes(std::shared_ptr<service::RequestState> state) const override;
+	std::future<__TypeKind> getKind(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::string>> getName(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__Type>>>> getPossibleTypes(const std::shared_ptr<service::RequestState>& state) const override;
 
 private:
 	const std::string _name;
@@ -153,9 +153,9 @@ public:
 	void AddEnumValues(std::vector<EnumValueType> enumValues);
 
 	// Accessors
-	std::future<__TypeKind> getKind(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::string>> getName(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> getEnumValues(std::shared_ptr<service::RequestState> state, std::unique_ptr<bool>&& includeDeprecated) const override;
+	std::future<__TypeKind> getKind(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::string>> getName(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__EnumValue>>>> getEnumValues(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<bool>&& includeDeprecated) const override;
 
 private:
 	const std::string _name;
@@ -171,9 +171,9 @@ public:
 	void AddInputValues(std::vector<std::shared_ptr<InputValue>> inputValues);
 
 	// Accessors
-	std::future<__TypeKind> getKind(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::string>> getName(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> getInputFields(std::shared_ptr<service::RequestState> state) const override;
+	std::future<__TypeKind> getKind(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::string>> getName(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::vector<std::shared_ptr<object::__InputValue>>>> getInputFields(const std::shared_ptr<service::RequestState>& state) const override;
 
 private:
 	const std::string _name;
@@ -187,8 +187,8 @@ public:
 	explicit WrapperType(__TypeKind kind, std::shared_ptr<object::__Type> ofType);
 
 	// Accessors
-	std::future<__TypeKind> getKind(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::shared_ptr<object::__Type>> getOfType(std::shared_ptr<service::RequestState> state) const override;
+	std::future<__TypeKind> getKind(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::shared_ptr<object::__Type>> getOfType(const std::shared_ptr<service::RequestState>& state) const override;
 
 private:
 	const __TypeKind _kind;
@@ -201,12 +201,12 @@ public:
 	explicit Field(std::string name, std::string description, std::unique_ptr<std::string>&& deprecationReason, std::vector<std::shared_ptr<InputValue>> args, std::shared_ptr<object::__Type> type);
 
 	// Accessors
-	std::future<std::string> getName(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::string>> getDescription(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::vector<std::shared_ptr<object::__InputValue>>> getArgs(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::shared_ptr<object::__Type>> getType(std::shared_ptr<service::RequestState> state) const override;
-	std::future<bool> getIsDeprecated(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::string>> getDeprecationReason(std::shared_ptr<service::RequestState> state) const override;
+	std::future<std::string> getName(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::string>> getDescription(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::vector<std::shared_ptr<object::__InputValue>>> getArgs(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::shared_ptr<object::__Type>> getType(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<bool> getIsDeprecated(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::string>> getDeprecationReason(const std::shared_ptr<service::RequestState>& state) const override;
 
 private:
 	const std::string _name;
@@ -222,10 +222,10 @@ public:
 	explicit InputValue(std::string name, std::string description, std::shared_ptr<object::__Type> type, std::string defaultValue);
 
 	// Accessors
-	std::future<std::string> getName(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::string>> getDescription(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::shared_ptr<object::__Type>> getType(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::string>> getDefaultValue(std::shared_ptr<service::RequestState> state) const override;
+	std::future<std::string> getName(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::string>> getDescription(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::shared_ptr<object::__Type>> getType(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::string>> getDefaultValue(const std::shared_ptr<service::RequestState>& state) const override;
 
 private:
 	const std::string _name;
@@ -240,10 +240,10 @@ public:
 	explicit EnumValue(std::string name, std::string description, std::unique_ptr<std::string>&& deprecationReason);
 
 	// Accessors
-	std::future<std::string> getName(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::string>> getDescription(std::shared_ptr<service::RequestState> state) const override;
-	std::future<bool> getIsDeprecated(std::shared_ptr<service::RequestState> state) const override;
-	std::future<std::unique_ptr<std::string>> getDeprecationReason(std::shared_ptr<service::RequestState> state) const override;
+	std::future<std::string> getName(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::string>> getDescription(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<bool> getIsDeprecated(const std::shared_ptr<service::RequestState>& state) const override;
+	std::future<std::unique_ptr<std::string>> getDeprecationReason(const std::shared_ptr<service::RequestState>& state) const override;
 
 private:
 	const std::string _name;

--- a/samples/IntrospectionSchema.h
+++ b/samples/IntrospectionSchema.h
@@ -65,11 +65,11 @@ protected:
 	__Schema();
 
 public:
-	virtual std::future<std::vector<std::shared_ptr<__Type>>> getTypes(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::shared_ptr<__Type>> getQueryType(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::shared_ptr<__Type>> getMutationType(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::shared_ptr<__Type>> getSubscriptionType(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::vector<std::shared_ptr<__Directive>>> getDirectives(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<std::vector<std::shared_ptr<__Type>>> getTypes(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::shared_ptr<__Type>> getQueryType(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::shared_ptr<__Type>> getMutationType(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::shared_ptr<__Type>> getSubscriptionType(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::vector<std::shared_ptr<__Directive>>> getDirectives(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveTypes(service::ResolverParams&& params);
@@ -88,15 +88,15 @@ protected:
 	__Type();
 
 public:
-	virtual std::future<__TypeKind> getKind(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<response::StringType>> getName(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<response::StringType>> getDescription(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Field>>>> getFields(std::shared_ptr<service::RequestState> state, std::unique_ptr<response::BooleanType>&& includeDeprecated) const = 0;
-	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Type>>>> getInterfaces(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Type>>>> getPossibleTypes(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__EnumValue>>>> getEnumValues(std::shared_ptr<service::RequestState> state, std::unique_ptr<response::BooleanType>&& includeDeprecated) const = 0;
-	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__InputValue>>>> getInputFields(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::shared_ptr<__Type>> getOfType(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<__TypeKind> getKind(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getName(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDescription(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Field>>>> getFields(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<response::BooleanType>&& includeDeprecated) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Type>>>> getInterfaces(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__Type>>>> getPossibleTypes(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__EnumValue>>>> getEnumValues(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<response::BooleanType>&& includeDeprecated) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<__InputValue>>>> getInputFields(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::shared_ptr<__Type>> getOfType(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveKind(service::ResolverParams&& params);
@@ -119,12 +119,12 @@ protected:
 	__Field();
 
 public:
-	virtual std::future<response::StringType> getName(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<response::StringType>> getDescription(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::vector<std::shared_ptr<__InputValue>>> getArgs(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::shared_ptr<__Type>> getType(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<response::BooleanType> getIsDeprecated(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<response::StringType>> getDeprecationReason(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<response::StringType> getName(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDescription(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::vector<std::shared_ptr<__InputValue>>> getArgs(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::shared_ptr<__Type>> getType(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<response::BooleanType> getIsDeprecated(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDeprecationReason(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveName(service::ResolverParams&& params);
@@ -144,10 +144,10 @@ protected:
 	__InputValue();
 
 public:
-	virtual std::future<response::StringType> getName(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<response::StringType>> getDescription(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::shared_ptr<__Type>> getType(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<response::StringType>> getDefaultValue(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<response::StringType> getName(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDescription(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::shared_ptr<__Type>> getType(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDefaultValue(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveName(service::ResolverParams&& params);
@@ -165,10 +165,10 @@ protected:
 	__EnumValue();
 
 public:
-	virtual std::future<response::StringType> getName(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<response::StringType>> getDescription(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<response::BooleanType> getIsDeprecated(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<response::StringType>> getDeprecationReason(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<response::StringType> getName(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDescription(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<response::BooleanType> getIsDeprecated(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDeprecationReason(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveName(service::ResolverParams&& params);
@@ -186,10 +186,10 @@ protected:
 	__Directive();
 
 public:
-	virtual std::future<response::StringType> getName(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<response::StringType>> getDescription(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::vector<__DirectiveLocation>> getLocations(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::vector<std::shared_ptr<__InputValue>>> getArgs(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<response::StringType> getName(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getDescription(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::vector<__DirectiveLocation>> getLocations(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::vector<std::shared_ptr<__InputValue>>> getArgs(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveName(service::ResolverParams&& params);

--- a/samples/TodaySchema.h
+++ b/samples/TodaySchema.h
@@ -36,7 +36,7 @@ struct CompleteTaskInput
 
 struct Node
 {
-	virtual std::future<std::vector<uint8_t>> getId(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<std::vector<uint8_t>> getId(const std::shared_ptr<service::RequestState>& state) const = 0;
 };
 
 namespace object {
@@ -63,13 +63,13 @@ protected:
 	Query();
 
 public:
-	virtual std::future<std::shared_ptr<service::Object>> getNode(std::shared_ptr<service::RequestState> state, std::vector<uint8_t>&& id) const = 0;
-	virtual std::future<std::shared_ptr<AppointmentConnection>> getAppointments(std::shared_ptr<service::RequestState> state, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
-	virtual std::future<std::shared_ptr<TaskConnection>> getTasks(std::shared_ptr<service::RequestState> state, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
-	virtual std::future<std::shared_ptr<FolderConnection>> getUnreadCounts(std::shared_ptr<service::RequestState> state, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
-	virtual std::future<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(std::shared_ptr<service::RequestState> state, std::vector<std::vector<uint8_t>>&& ids) const = 0;
-	virtual std::future<std::vector<std::shared_ptr<Task>>> getTasksById(std::shared_ptr<service::RequestState> state, std::vector<std::vector<uint8_t>>&& ids) const = 0;
-	virtual std::future<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(std::shared_ptr<service::RequestState> state, std::vector<std::vector<uint8_t>>&& ids) const = 0;
+	virtual std::future<std::shared_ptr<service::Object>> getNode(const std::shared_ptr<service::RequestState>& state, std::vector<uint8_t>&& id) const = 0;
+	virtual std::future<std::shared_ptr<AppointmentConnection>> getAppointments(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
+	virtual std::future<std::shared_ptr<TaskConnection>> getTasks(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
+	virtual std::future<std::shared_ptr<FolderConnection>> getUnreadCounts(const std::shared_ptr<service::RequestState>& state, std::unique_ptr<response::IntType>&& first, std::unique_ptr<response::Value>&& after, std::unique_ptr<response::IntType>&& last, std::unique_ptr<response::Value>&& before) const = 0;
+	virtual std::future<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(const std::shared_ptr<service::RequestState>& state, std::vector<std::vector<uint8_t>>&& ids) const = 0;
+	virtual std::future<std::vector<std::shared_ptr<Task>>> getTasksById(const std::shared_ptr<service::RequestState>& state, std::vector<std::vector<uint8_t>>&& ids) const = 0;
+	virtual std::future<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(const std::shared_ptr<service::RequestState>& state, std::vector<std::vector<uint8_t>>&& ids) const = 0;
 
 private:
 	std::future<response::Value> resolveNode(service::ResolverParams&& params);
@@ -94,8 +94,8 @@ protected:
 	PageInfo();
 
 public:
-	virtual std::future<response::BooleanType> getHasNextPage(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<response::BooleanType> getHasPreviousPage(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<response::BooleanType> getHasNextPage(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<response::BooleanType> getHasPreviousPage(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveHasNextPage(service::ResolverParams&& params);
@@ -111,8 +111,8 @@ protected:
 	AppointmentEdge();
 
 public:
-	virtual std::future<std::shared_ptr<Appointment>> getNode(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<response::Value> getCursor(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<std::shared_ptr<Appointment>> getNode(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<response::Value> getCursor(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveNode(service::ResolverParams&& params);
@@ -128,8 +128,8 @@ protected:
 	AppointmentConnection();
 
 public:
-	virtual std::future<std::shared_ptr<PageInfo>> getPageInfo(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<std::shared_ptr<PageInfo>> getPageInfo(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
@@ -145,8 +145,8 @@ protected:
 	TaskEdge();
 
 public:
-	virtual std::future<std::shared_ptr<Task>> getNode(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<response::Value> getCursor(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<std::shared_ptr<Task>> getNode(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<response::Value> getCursor(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveNode(service::ResolverParams&& params);
@@ -162,8 +162,8 @@ protected:
 	TaskConnection();
 
 public:
-	virtual std::future<std::shared_ptr<PageInfo>> getPageInfo(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<std::shared_ptr<PageInfo>> getPageInfo(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
@@ -179,8 +179,8 @@ protected:
 	FolderEdge();
 
 public:
-	virtual std::future<std::shared_ptr<Folder>> getNode(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<response::Value> getCursor(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<std::shared_ptr<Folder>> getNode(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<response::Value> getCursor(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveNode(service::ResolverParams&& params);
@@ -196,8 +196,8 @@ protected:
 	FolderConnection();
 
 public:
-	virtual std::future<std::shared_ptr<PageInfo>> getPageInfo(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<std::shared_ptr<PageInfo>> getPageInfo(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
@@ -213,8 +213,8 @@ protected:
 	CompleteTaskPayload();
 
 public:
-	virtual std::future<std::shared_ptr<Task>> getTask(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<response::StringType>> getClientMutationId(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<std::shared_ptr<Task>> getTask(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getClientMutationId(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveTask(service::ResolverParams&& params);
@@ -230,7 +230,7 @@ protected:
 	Mutation();
 
 public:
-	virtual std::future<std::shared_ptr<CompleteTaskPayload>> getCompleteTask(std::shared_ptr<service::RequestState> state, CompleteTaskInput&& input) const = 0;
+	virtual std::future<std::shared_ptr<CompleteTaskPayload>> getCompleteTask(const std::shared_ptr<service::RequestState>& state, CompleteTaskInput&& input) const = 0;
 
 private:
 	std::future<response::Value> resolveCompleteTask(service::ResolverParams&& params);
@@ -245,7 +245,7 @@ protected:
 	Subscription();
 
 public:
-	virtual std::future<std::shared_ptr<Appointment>> getNextAppointmentChange(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<std::shared_ptr<Appointment>> getNextAppointmentChange(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveNextAppointmentChange(service::ResolverParams&& params);
@@ -261,9 +261,9 @@ protected:
 	Appointment();
 
 public:
-	virtual std::future<std::unique_ptr<response::Value>> getWhen(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<std::unique_ptr<response::StringType>> getSubject(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<response::BooleanType> getIsNow(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<std::unique_ptr<response::Value>> getWhen(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getSubject(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<response::BooleanType> getIsNow(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveId(service::ResolverParams&& params);
@@ -282,8 +282,8 @@ protected:
 	Task();
 
 public:
-	virtual std::future<std::unique_ptr<response::StringType>> getTitle(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<response::BooleanType> getIsComplete(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getTitle(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<response::BooleanType> getIsComplete(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveId(service::ResolverParams&& params);
@@ -301,8 +301,8 @@ protected:
 	Folder();
 
 public:
-	virtual std::future<std::unique_ptr<response::StringType>> getName(std::shared_ptr<service::RequestState> state) const = 0;
-	virtual std::future<response::IntType> getUnreadCount(std::shared_ptr<service::RequestState> state) const = 0;
+	virtual std::future<std::unique_ptr<response::StringType>> getName(const std::shared_ptr<service::RequestState>& state) const = 0;
+	virtual std::future<response::IntType> getUnreadCount(const std::shared_ptr<service::RequestState>& state) const = 0;
 
 private:
 	std::future<response::Value> resolveId(service::ResolverParams&& params);


### PR DESCRIPTION
There are a few places where we need to capture the `std::shared_ptr<service::RequestState>` and keep it alive in a member, a lambda capture, or `std::async` callback parameter, but most of the `service::Object::getField` accessors don't need to keep a copy of it. It's cheaper to go back to passing them by `const&` where possible.