### PR TITLE
Separate JSON serialization into its own library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,13 +55,31 @@ add_library(graphqlservice
   GraphQLService.cpp
   Introspection.cpp
   IntrospectionSchema.cpp)
-target_link_libraries(graphqlservice PRIVATE taocpp::pegtl)
-target_link_libraries(graphqlservice PUBLIC Threads::Threads)
+target_link_libraries(graphqlservice PUBLIC
+  taocpp::pegtl
+  Threads::Threads)
 target_include_directories(graphqlservice PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 cppgraphqlgen_target_set_cxx_standard(graphqlservice)
+
+# RapidJSON is the only option for JSON serialization used in this project, but if you want
+# to use another JSON library you can implement an alternate version of the functions in
+# JSONResponse.cpp to serialize to and from GraphQLResponse and build graphqljson from that.
+option(USE_RAPIDJSON "Use RapidJSON for JSON serialization." ON)
+
+if(USE_RAPIDJSON)
+  find_package(RapidJSON CONFIG REQUIRED)
+
+  add_library(graphqljson
+    JSONResponse.cpp)
+  target_link_libraries(graphqljson PUBLIC
+    graphqlservice)
+  target_include_directories(graphqljson SYSTEM PRIVATE
+    ${RAPIDJSON_INCLUDE_DIRS})
+  cppgraphqlgen_target_set_cxx_standard(graphqljson)
+endif()
 
 option(BUILD_TESTS "Build the tests and sample schema library." ON)
 option(UPDATE_SAMPLES "Regenerate the sample schema sources whether or not we're building the tests and the sample library." ON)
@@ -83,16 +101,12 @@ if(BUILD_TESTS OR UPDATE_SAMPLES)
   )
 
   if(BUILD_TESTS)
-    find_package(RapidJSON CONFIG REQUIRED)
-
     add_library(todaygraphql
-       Today.cpp
-       TodaySchema.cpp
-       JSONResponse.cpp)
+      Today.cpp
+      TodaySchema.cpp)
     target_link_libraries(todaygraphql PUBLIC
-      graphqlservice)
-    target_include_directories(todaygraphql SYSTEM PUBLIC
-      ${RAPIDJSON_INCLUDE_DIRS})
+      graphqlservice
+      graphqljson)
     target_include_directories(todaygraphql PUBLIC
       ${CMAKE_CURRENT_SOURCE_DIR}/include
       ${CMAKE_CURRENT_BINARY_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,9 @@ if(BUILD_TESTS OR UPDATE_SAMPLES)
   endif()
 endif()
 
-install(TARGETS graphqlservice
+install(TARGETS
+    graphqlservice
+    graphqljson
   EXPORT cppgraphqlgen-targets
   RUNTIME DESTINATION bin
   ARCHIVE DESTINATION lib

--- a/include/graphqlservice/JSONResponse.h
+++ b/include/graphqlservice/JSONResponse.h
@@ -5,19 +5,14 @@
 
 #include <graphqlservice/GraphQLResponse.h>
 
-#define RAPIDJSON_NAMESPACE facebook::graphql::rapidjson
-#define RAPIDJSON_NAMESPACE_BEGIN namespace facebook { namespace graphql { namespace rapidjson {
-#define RAPIDJSON_NAMESPACE_END } /* namespace rapidjson */ } /* namespace graphql */ } /* namespace facebook */
-#include <rapidjson/document.h>
-
 namespace facebook {
 namespace graphql {
-namespace rapidjson {
+namespace response {
 
-Document convertResponse(response::Value&& response);
+std::string toJSON(Value&& response);
 
-response::Value convertResponse(const Document& document);
+Value parseJSON(const std::string& json);
 
-} /* namespace rapidjson */
+} /* namespace response */
 } /* namespace graphql */
 } /* namespace facebook */

--- a/test_today.cpp
+++ b/test_today.cpp
@@ -2,14 +2,12 @@
 // Licensed under the MIT License.
 
 #include "Today.h"
-#include "graphqlservice/JSONResponse.h"
+
+#include <graphqlservice/JSONResponse.h>
 
 #include <iostream>
 #include <stdexcept>
 #include <cstdio>
-
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 
 using namespace facebook::graphql;
 
@@ -92,12 +90,10 @@ int main(int argc, char** argv)
 
 		std::cout << "Executing query..." << std::endl;
 
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 		response::Value variables(response::Type::Map);
-		
-		rapidjson::convertResponse(service->resolve(nullptr, *ast, ((argc > 2) ? argv[2] : ""), variables).get()).Accept(writer);
-		std::cout << buffer.GetString() << std::endl;
+
+		response::toJSON(service->resolve(nullptr, *ast, ((argc > 2) ? argv[2] : ""), variables).get());
+		std::cout << response::toJSON(service->resolve(nullptr, *ast, ((argc > 2) ? argv[2] : ""), variables).get()) << std::endl;
 	}
 	catch (const std::runtime_error& ex)
 	{

--- a/tests.cpp
+++ b/tests.cpp
@@ -10,9 +10,6 @@
 
 #include <tao/pegtl/analyze.hpp>
 
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
-
 using namespace facebook::graphql;
 using namespace facebook::graphql::peg;
 
@@ -143,12 +140,7 @@ TEST_F(TodayServiceCase, QueryEverything)
 		auto errorsItr = result.find("errors");
 		if (errorsItr != result.get<const response::MapType&>().cend())
 		{
-			rapidjson::StringBuffer buffer;
-			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-			rapidjson::convertResponse(response::Value(errorsItr->second)).Accept(writer);
-
-			FAIL() << buffer.GetString();
+			FAIL() << response::toJSON(response::Value(errorsItr->second));
 		}
 		const auto data = service::ScalarArgument::require("data", result);
 		
@@ -182,12 +174,7 @@ TEST_F(TodayServiceCase, QueryEverything)
 	}
 	catch (const service::schema_exception& ex)
 	{
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
-
-		FAIL() << buffer.GetString();
+		FAIL() << response::toJSON(response::Value(ex.getErrors()));
 	}
 }
 
@@ -224,12 +211,7 @@ TEST_F(TodayServiceCase, QueryAppointments)
 		auto errorsItr = result.find("errors");
 		if (errorsItr != result.get<const response::MapType&>().cend())
 		{
-			rapidjson::StringBuffer buffer;
-			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-			rapidjson::convertResponse(response::Value(errorsItr->second)).Accept(writer);
-
-			FAIL() << buffer.GetString();
+			FAIL() << response::toJSON(response::Value(errorsItr->second));
 		}
 		const auto data = service::ScalarArgument::require("data", result);
 
@@ -245,12 +227,7 @@ TEST_F(TodayServiceCase, QueryAppointments)
 	}
 	catch (const service::schema_exception& ex)
 	{
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
-
-		FAIL() << buffer.GetString();
+		FAIL() << response::toJSON(response::Value(ex.getErrors()));
 	}
 }
 
@@ -286,12 +263,7 @@ TEST_F(TodayServiceCase, QueryTasks)
 		auto errorsItr = result.find("errors");
 		if (errorsItr != result.get<const response::MapType&>().cend())
 		{
-			rapidjson::StringBuffer buffer;
-			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-			rapidjson::convertResponse(response::Value(errorsItr->second)).Accept(writer);
-
-			FAIL() << buffer.GetString();
+			FAIL() << response::toJSON(response::Value(errorsItr->second));
 		}
 		const auto data = service::ScalarArgument::require("data", result);
 
@@ -306,12 +278,7 @@ TEST_F(TodayServiceCase, QueryTasks)
 	}
 	catch (const service::schema_exception& ex)
 	{
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
-
-		FAIL() << buffer.GetString();
+		FAIL() << response::toJSON(response::Value(ex.getErrors()));
 	}
 }
 
@@ -347,12 +314,7 @@ TEST_F(TodayServiceCase, QueryUnreadCounts)
 		auto errorsItr = result.find("errors");
 		if (errorsItr != result.get<const response::MapType&>().cend())
 		{
-			rapidjson::StringBuffer buffer;
-			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-			rapidjson::convertResponse(response::Value(errorsItr->second)).Accept(writer);
-
-			FAIL() << buffer.GetString();
+			FAIL() << response::toJSON(response::Value(errorsItr->second));
 		}
 		const auto data = service::ScalarArgument::require("data", result);
 
@@ -367,12 +329,7 @@ TEST_F(TodayServiceCase, QueryUnreadCounts)
 	}
 	catch (const service::schema_exception& ex)
 	{
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
-
-		FAIL() << buffer.GetString();
+		FAIL() << response::toJSON(response::Value(ex.getErrors()));
 	}
 }
 
@@ -398,12 +355,7 @@ TEST_F(TodayServiceCase, MutateCompleteTask)
 		auto errorsItr = result.find("errors");
 		if (errorsItr != result.get<const response::MapType&>().cend())
 		{
-			rapidjson::StringBuffer buffer;
-			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-			rapidjson::convertResponse(response::Value(errorsItr->second)).Accept(writer);
-
-			FAIL() << buffer.GetString();
+			FAIL() << response::toJSON(response::Value(errorsItr->second));
 		}
 		const auto data = service::ScalarArgument::require("data", result);
 
@@ -421,12 +373,7 @@ TEST_F(TodayServiceCase, MutateCompleteTask)
 	}
 	catch (const service::schema_exception& ex)
 	{
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
-
-		FAIL() << buffer.GetString();
+		FAIL() << response::toJSON(response::Value(ex.getErrors()));
 	}
 }
 
@@ -474,12 +421,7 @@ TEST_F(TodayServiceCase, Introspection)
 		auto errorsItr = result.find("errors");
 		if (errorsItr != result.get<const response::MapType&>().cend())
 		{
-			rapidjson::StringBuffer buffer;
-			rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-			rapidjson::convertResponse(response::Value(errorsItr->second)).Accept(writer);
-
-			FAIL() << buffer.GetString();
+			FAIL() << response::toJSON(response::Value(errorsItr->second));
 		}
 		const auto data = service::ScalarArgument::require("data", result);
 		const auto schema = service::ScalarArgument::require("__schema", data);
@@ -493,19 +435,13 @@ TEST_F(TodayServiceCase, Introspection)
 	}
 	catch (const service::schema_exception& ex)
 	{
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
-
-		FAIL() << buffer.GetString();
+		FAIL() << response::toJSON(response::Value(ex.getErrors()));
 	}
 }
 
 TEST(ArgumentsCase, ListArgumentStrings)
 {
-	rapidjson::Document parsed;
-	parsed.Parse(R"js({"value":[
+	auto parsed = response::parseJSON(R"js({"value":[
 		"string1",
 		"string2",
 		"string3"
@@ -514,16 +450,11 @@ TEST(ArgumentsCase, ListArgumentStrings)
 
 	try
 	{
-		actual = service::StringArgument::require<service::TypeModifier::List>("value", rapidjson::convertResponse(parsed));
+		actual = service::StringArgument::require<service::TypeModifier::List>("value", parsed);
 	}
 	catch (const service::schema_exception& ex)
 	{
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
-
-		FAIL() << buffer.GetString();
+		FAIL() << response::toJSON(response::Value(ex.getErrors()));
 	}
 
 	ASSERT_EQ(3, actual.size()) << "should get 3 entries";
@@ -534,8 +465,7 @@ TEST(ArgumentsCase, ListArgumentStrings)
 
 TEST(ArgumentsCase, ListArgumentStringsNonNullable)
 {
-	rapidjson::Document parsed;
-	parsed.Parse(R"js({"value":[
+	auto parsed = response::parseJSON(R"js({"value":[
 		"string1",
 		null,
 		"string2",
@@ -546,16 +476,11 @@ TEST(ArgumentsCase, ListArgumentStringsNonNullable)
 
 	try
 	{
-		service::StringArgument::require<service::TypeModifier::List>("value", rapidjson::convertResponse(parsed));
+		service::StringArgument::require<service::TypeModifier::List>("value", parsed);
 	}
 	catch (const service::schema_exception& ex)
 	{
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
-
-		exceptionWhat = buffer.GetString();
+		exceptionWhat = response::toJSON(response::Value(ex.getErrors()));
 		caughtException = true;
 	}
 
@@ -565,8 +490,7 @@ TEST(ArgumentsCase, ListArgumentStringsNonNullable)
 
 TEST(ArgumentsCase, ListArgumentStringsNullable)
 {
-	rapidjson::Document parsed;
-	parsed.Parse(R"js({"value":[
+	auto parsed = response::parseJSON(R"js({"value":[
 		"string1",
 		"string2",
 		null,
@@ -579,16 +503,11 @@ TEST(ArgumentsCase, ListArgumentStringsNullable)
 		actual = service::StringArgument::require<
 			service::TypeModifier::List,
 			service::TypeModifier::Nullable
-		>("value", rapidjson::convertResponse(parsed));
+		>("value", parsed);
 	}
 	catch (const service::schema_exception& ex)
 	{
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
-
-		FAIL() << buffer.GetString();
+		FAIL() << response::toJSON(response::Value(ex.getErrors()));
 	}
 
 	ASSERT_EQ(4, actual.size()) << "should get 4 entries";
@@ -603,8 +522,7 @@ TEST(ArgumentsCase, ListArgumentStringsNullable)
 
 TEST(ArgumentsCase, ListArgumentListArgumentStrings)
 {
-	rapidjson::Document parsed;
-	parsed.Parse(R"js({"value":[
+	auto parsed = response::parseJSON(R"js({"value":[
 		["list1string1", "list1string2"],
 		["list2string1", "list2string2"]
 	]})js");
@@ -615,16 +533,11 @@ TEST(ArgumentsCase, ListArgumentListArgumentStrings)
 		actual = service::StringArgument::require<
 			service::TypeModifier::List,
 			service::TypeModifier::List
-		>("value", rapidjson::convertResponse(parsed));
+		>("value", parsed);
 	}
 	catch (const service::schema_exception& ex)
 	{
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
-
-		FAIL() << buffer.GetString();
+		FAIL() << response::toJSON(response::Value(ex.getErrors()));
 	}
 
 	ASSERT_EQ(2, actual.size()) << "should get 2 entries";
@@ -638,8 +551,7 @@ TEST(ArgumentsCase, ListArgumentListArgumentStrings)
 
 TEST(ArgumentsCase, ListArgumentNullableListArgumentStrings)
 {
-	rapidjson::Document parsed;
-	parsed.Parse(R"js({"value":[
+	auto parsed = response::parseJSON(R"js({"value":[
 		null,
 		["list2string1", "list2string2"]
 	]})js");
@@ -651,16 +563,11 @@ TEST(ArgumentsCase, ListArgumentNullableListArgumentStrings)
 			service::TypeModifier::List,
 			service::TypeModifier::Nullable,
 			service::TypeModifier::List
-		>("value", rapidjson::convertResponse(parsed));
+		>("value", parsed);
 	}
 	catch (const service::schema_exception& ex)
 	{
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
-
-		FAIL() << buffer.GetString();
+		FAIL() << response::toJSON(response::Value(ex.getErrors()));
 	}
 
 	ASSERT_EQ(2, actual.size()) << "should get 2 entries";
@@ -684,12 +591,7 @@ TEST(ArgumentsCase, TaskStateEnum)
 	}
 	catch (const service::schema_exception& ex)
 	{
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-
-		rapidjson::convertResponse(response::Value(ex.getErrors())).Accept(writer);
-
-		FAIL() << buffer.GetString();
+		FAIL() << response::toJSON(response::Value(ex.getErrors()));
 	}
 
 	EXPECT_EQ(today::TaskState::Started, actual) << "should parse the enum";


### PR DESCRIPTION
The serialization interface is pretty tiny (1 function/method in each direction), but the JSON library dependency is non-trivial. This refactor moves all of that dependency into a separate library so consumers can replace the JSON library as they see fit (e.g. they've already linked against something else and don't want to add RapidJSON to their project).