### PR TITLE
Fix VC++ Code Analysis and g++ warnings

### DIFF
--- a/GraphQLResponse.cpp
+++ b/GraphQLResponse.cpp
@@ -11,6 +11,9 @@ namespace response {
 
 Value::Value(Type type /*= Type::Null*/)
 	: _type(type)
+	, _boolean(false)
+	, _int(0)
+	, _float(0.0)
 {
 	switch (type)
 	{
@@ -28,18 +31,6 @@ Value::Value(Type type /*= Type::Null*/)
 			_string.reset(new StringType());
 			break;
 
-		case Type::Boolean:
-			_boolean = false;
-			break;
-
-		case Type::Int:
-			_int = 0;
-			break;
-
-		case Type::Float:
-			_float = 0;
-			break;
-
 		case Type::Scalar:
 			_scalar.reset(new Value());
 			break;
@@ -52,34 +43,49 @@ Value::Value(Type type /*= Type::Null*/)
 Value::Value(StringType&& value)
 	: _type(Type::String)
 	, _string(new StringType(std::move(value)))
+	, _boolean(false)
+	, _int(0)
+	, _float(0.0)
 {
 }
 
 Value::Value(BooleanType value)
 	: _type(Type::Boolean)
-	, _boolean(value)
+	, _boolean(false)
+	, _int(0)
+	, _float(0.0)
 {
+	_boolean = value;
 }
 
 Value::Value(IntType value)
 	: _type(Type::Int)
-	, _int(value)
+	, _boolean(false)
+	, _int(0)
+	, _float(0.0)
 {
+	_int = value;
 }
 
 Value::Value(FloatType value)
 	: _type(Type::Float)
-	, _float(value)
+	, _boolean(false)
+	, _int(0)
+	, _float(0.0)
 {
+	_float = value;
 }
 
-Value::Value(Value&& other)
+Value::Value(Value&& other) noexcept
 	: _type(other._type)
 	, _members(std::move(other._members))
 	, _map(std::move(other._map))
 	, _list(std::move(other._list))
 	, _string(std::move(other._string))
 	, _scalar(std::move(other._scalar))
+	, _boolean(false)
+	, _int(0)
+	, _float(0.0)
 {
 	switch (_type)
 	{
@@ -98,10 +104,18 @@ Value::Value(Value&& other)
 		default:
 			break;
 	}
+
+	const_cast<Type&>(other._type) = Type::Null;
+	other._boolean = false;
+	other._int = 0;
+	other._float = 0.0;
 }
 
 Value::Value(const Value& other)
 	: _type(other._type)
+	, _boolean(false)
+	, _int(0)
+	, _float(0.0)
 {
 	switch (_type)
 	{
@@ -140,7 +154,7 @@ Value::Value(const Value& other)
 	}
 }
 
-Value& Value::operator=(Value&& rhs)
+Value& Value::operator=(Value&& rhs) noexcept
 {
 	const_cast<Type&>(_type) = rhs._type;
 	const_cast<Type&>(rhs._type) = Type::Null;
@@ -150,19 +164,25 @@ Value& Value::operator=(Value&& rhs)
 	_list = std::move(rhs._list);
 	_string = std::move(rhs._string);
 	_scalar = std::move(rhs._scalar);
+	_boolean = false;
+	_int = 0;
+	_float = 0.0;
 
 	switch (_type)
 	{
 		case Type::Boolean:
 			_boolean = rhs._boolean;
+			rhs._boolean = false;
 			break;
 
 		case Type::Int:
 			_int = rhs._int;
+			rhs._int = 0;
 			break;
 
 		case Type::Float:
 			_float = rhs._float;
+			rhs._float = 0.0;
 			break;
 
 		default:

--- a/GraphQLResponse.cpp
+++ b/GraphQLResponse.cpp
@@ -11,9 +11,6 @@ namespace response {
 
 Value::Value(Type type /*= Type::Null*/)
 	: _type(type)
-	, _boolean(false)
-	, _int(0)
-	, _float(0.0)
 {
 	switch (type)
 	{
@@ -43,37 +40,25 @@ Value::Value(Type type /*= Type::Null*/)
 Value::Value(StringType&& value)
 	: _type(Type::String)
 	, _string(new StringType(std::move(value)))
-	, _boolean(false)
-	, _int(0)
-	, _float(0.0)
 {
 }
 
 Value::Value(BooleanType value)
 	: _type(Type::Boolean)
-	, _boolean(false)
-	, _int(0)
-	, _float(0.0)
+	, _boolean(value)
 {
-	_boolean = value;
 }
 
 Value::Value(IntType value)
 	: _type(Type::Int)
-	, _boolean(false)
-	, _int(0)
-	, _float(0.0)
+	, _int(value)
 {
-	_int = value;
 }
 
 Value::Value(FloatType value)
 	: _type(Type::Float)
-	, _boolean(false)
-	, _int(0)
-	, _float(0.0)
+	, _float(value)
 {
-	_float = value;
 }
 
 Value::Value(Value&& other) noexcept
@@ -83,28 +68,10 @@ Value::Value(Value&& other) noexcept
 	, _list(std::move(other._list))
 	, _string(std::move(other._string))
 	, _scalar(std::move(other._scalar))
-	, _boolean(false)
-	, _int(0)
-	, _float(0.0)
+	, _boolean(other._boolean)
+	, _int(other._int)
+	, _float(other._float)
 {
-	switch (_type)
-	{
-		case Type::Boolean:
-			_boolean = other._boolean;
-			break;
-
-		case Type::Int:
-			_int = other._int;
-			break;
-
-		case Type::Float:
-			_float = other._float;
-			break;
-
-		default:
-			break;
-	}
-
 	const_cast<Type&>(other._type) = Type::Null;
 	other._boolean = false;
 	other._int = 0;
@@ -113,9 +80,9 @@ Value::Value(Value&& other) noexcept
 
 Value::Value(const Value& other)
 	: _type(other._type)
-	, _boolean(false)
-	, _int(0)
-	, _float(0.0)
+	, _boolean(other._boolean)
+	, _int(other._int)
+	, _float(other._float)
 {
 	switch (_type)
 	{
@@ -131,18 +98,6 @@ Value::Value(const Value& other)
 		case Type::String:
 		case Type::EnumValue:
 			_string.reset(new StringType(*other._string));
-			break;
-
-		case Type::Boolean:
-			_boolean = other._boolean;
-			break;
-
-		case Type::Int:
-			_int = other._int;
-			break;
-
-		case Type::Float:
-			_float = other._float;
 			break;
 
 		case Type::Scalar:
@@ -164,30 +119,12 @@ Value& Value::operator=(Value&& rhs) noexcept
 	_list = std::move(rhs._list);
 	_string = std::move(rhs._string);
 	_scalar = std::move(rhs._scalar);
-	_boolean = false;
-	_int = 0;
-	_float = 0.0;
-
-	switch (_type)
-	{
-		case Type::Boolean:
-			_boolean = rhs._boolean;
-			rhs._boolean = false;
-			break;
-
-		case Type::Int:
-			_int = rhs._int;
-			rhs._int = 0;
-			break;
-
-		case Type::Float:
-			_float = rhs._float;
-			rhs._float = 0.0;
-			break;
-
-		default:
-			break;
-	}
+	_boolean = rhs._boolean;
+	rhs._boolean = false;
+	_int = rhs._int;
+	rhs._int = 0;
+	_float = rhs._float;
+	rhs._float = 0.0;
 
 	return *this;
 }

--- a/JSONResponse.cpp
+++ b/JSONResponse.cpp
@@ -13,6 +13,8 @@
 #include <rapidjson/reader.h>
 
 #include <stack>
+#include <limits>
+#include <stdexcept>
 
 namespace facebook {
 namespace graphql {
@@ -141,6 +143,8 @@ struct ResponseHandler
 
 	bool Int(int i)
 	{
+		// https://facebook.github.io/graphql/June2018/#sec-Int
+		static_assert(sizeof(i) == 4, "GraphQL only supports 32-bit signed integers");
 		auto value = Value(Type::Int);
 
 		value.set<IntType>(std::move(i));
@@ -150,17 +154,24 @@ struct ResponseHandler
 
 	bool Uint(unsigned int i)
 	{
+		if (i > static_cast<unsigned int>(std::numeric_limits<int>::max()))
+		{
+			// https://facebook.github.io/graphql/June2018/#sec-Int
+			throw std::overflow_error("GraphQL only supports 32-bit signed integers");
+		}
 		return Int(static_cast<int>(i));
 	}
 
-	bool Int64(int64_t i)
+	bool Int64(int64_t /*i*/)
 	{
-		return Int(static_cast<int>(i));
+		// https://facebook.github.io/graphql/June2018/#sec-Int
+		throw std::overflow_error("GraphQL only supports 32-bit signed integers");
 	}
 
-	bool Uint64(uint64_t i)
+	bool Uint64(uint64_t /*i*/)
 	{
-		return Int(static_cast<int>(i));
+		// https://facebook.github.io/graphql/June2018/#sec-Int
+		throw std::overflow_error("GraphQL only supports 32-bit signed integers");
 	}
 
 	bool Double(double d)

--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -48,10 +48,10 @@ struct Value
 	explicit Value(IntType value);
 	explicit Value(FloatType value);
 
-	Value(Value&& other);
+	Value(Value&& other) noexcept;
 	explicit Value(const Value& other);
 
-	Value& operator=(Value&& rhs);
+	Value& operator=(Value&& rhs) noexcept;
 	Value& operator=(const Value& rhs) = delete;
 
 	// Check the Type

--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -95,17 +95,14 @@ private:
 	// Type::String or Type::EnumValue
 	std::unique_ptr<StringType> _string;
 
-	union
-	{
-		// Type::Boolean
-		BooleanType _boolean;
+	// Type::Boolean
+	BooleanType _boolean = false;
 
-		// Type::Int
-		IntType _int;
+	// Type::Int
+	IntType _int = 0;
 
-		// Type::Float
-		FloatType _float;
-	};
+	// Type::Float
+	FloatType _float = 0.0;
 
 	// Type::Scalar
 	std::unique_ptr<ScalarType> _scalar;


### PR DESCRIPTION
I ran the Code Analysis tool on VC++, and aside from a bunch of warnings in RapidJSON and GoogleTest it found some issues in this code. Specifically, I split the union of GraphQLResponse's _boolean, _int, and _float members so they could be default initialized.