### PR TITLE
Clean up graphqlpeg::parse_error exception messages

### DIFF
--- a/GraphQLTree.cpp
+++ b/GraphQLTree.cpp
@@ -561,6 +561,134 @@ struct ast_selector<input_object_type_extension>
 {
 };
 
+template <typename _Rule>
+struct ast_control
+	: normal<_Rule>
+{
+	static const std::string error_message;
+
+	template <typename _Input, typename... _States>
+	static void raise(const _Input& in, _States&&...)
+	{
+		throw parse_error(error_message, in);
+	}
+};
+
+template <> const std::string ast_control<bof>::error_message = "Expected beginning of file";
+template <> const std::string ast_control<opt<utf8::bom>>::error_message = "Expected optional UTF8 byte-order-mark";
+template <> const std::string ast_control<star<ignored>>::error_message = "Expected optional ignored characters";
+template <> const std::string ast_control<plus<ignored>>::error_message = "Expected ignored characters";
+template <> const std::string ast_control<until<ascii::eolf>>::error_message = "Expected Comment";
+template <> const std::string ast_control<eof>::error_message = "Expected end of file";
+template <> const std::string ast_control<list<definition, plus<ignored>>>::error_message = "Expected list of Definitions";
+template <> const std::string ast_control<selection_set>::error_message = "Expected SelectionSet";
+template <> const std::string ast_control<fragment_name>::error_message = "Expected FragmentName";
+template <> const std::string ast_control<type_condition>::error_message = "Expected TypeCondition";
+template <> const std::string ast_control<opt<seq<star<ignored>, directives>>>::error_message = "Expected optional Directives";
+template <> const std::string ast_control<one<'{'>>::error_message = "Expected {";
+template <> const std::string ast_control<list<root_operation_definition, plus<ignored>>>::error_message = "Expected RootOperationTypeDefinition";
+template <> const std::string ast_control<one<'}'>>::error_message = "Expected }";
+template <> const std::string ast_control<one<'@'>>::error_message = "Expected @";
+template <> const std::string ast_control<directive_name>::error_message = "Expected Directive Name";
+template <> const std::string ast_control<arguments_definition>::error_message = "Expected ArgumentsDefinition";
+template <> const std::string ast_control<on_keyword>::error_message = "Expected \"on\" keyword";
+template <> const std::string ast_control<directive_locations>::error_message = "Expected DirectiveLocations";
+template <> const std::string ast_control<schema_extension>::error_message = "Expected SchemaExtension";
+template <> const std::string ast_control<
+	seq<opt<seq<plus<ignored>, operation_name>>, opt<seq<star<ignored>, variable_definitions>>, opt<seq<star<ignored>, directives>>, star<ignored>, selection_set>>::error_message = "Expected OperationDefinition";
+template <> const std::string ast_control<list<selection, plus<ignored>>>::error_message = "Expected Selections";
+template <> const std::string ast_control<scalar_name>::error_message = "Expected ScalarType Name";
+template <> const std::string ast_control<object_name>::error_message = "Expected ObjectType Name";
+template <> const std::string ast_control<
+	sor<seq<opt<seq<plus<ignored>, implements_interfaces>>, opt<seq<star<ignored>, directives>>, seq<star<ignored>, fields_definition>>
+	, seq<opt<seq<plus<ignored>, implements_interfaces>>, seq<star<ignored>, directives>>
+	, opt<seq<plus<ignored>, implements_interfaces>>>>::error_message = "Expected ObjectTypeDefinition";
+template <> const std::string ast_control<interface_name>::error_message = "Expected InterfaceType Name";
+template <> const std::string ast_control<
+	sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, fields_definition>>
+	, opt<seq<star<ignored>, directives>>>>::error_message = "Expected InterfaceTypeDefinition";
+template <> const std::string ast_control<
+	sor<seq<opt<directives>, one<'{'>, star<ignored>, list<operation_type_definition, plus<ignored>>, star<ignored>, one<'}'>>
+	, directives>>::error_message = "Expected SchemaExtension";
+template <> const std::string ast_control<union_name>::error_message = "Expected UnionType Name";
+template <> const std::string ast_control<
+	sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, union_member_types>>
+	, opt<seq<star<ignored>, directives>>>>::error_message = "Expected UnionTypeDefinition";
+template <> const std::string ast_control<enum_name>::error_message = "Expected EnumType Name";
+template <> const std::string ast_control<
+	sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, enum_values_definition>>
+	, opt<seq<star<ignored>, directives>>>>::error_message = "Expected EnumTypeDefinition";
+template <> const std::string ast_control<
+	sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, input_fields_definition>>
+	, opt<seq<star<ignored>, directives>>>>::error_message = "Expected InputObjectTypeDefinition";
+template <> const std::string ast_control<directives>::error_message = "Expected list of Directives";
+template <> const std::string ast_control<
+	sor<seq<opt<seq<plus<ignored>, implements_interfaces>>, opt<seq<star<ignored>, directives>>, star<ignored>, fields_definition>
+	, seq<opt<seq<plus<ignored>, implements_interfaces>>, star<ignored>, directives>
+	, seq<plus<ignored>, implements_interfaces>>>::error_message = "Expected ObjectTypeExtension";
+template <> const std::string ast_control<
+	sor<seq<opt<seq<directives, star<ignored>>>, fields_definition>
+	, directives>>::error_message = "Expected InterfaceTypeExtension";
+template <> const std::string ast_control<
+	sor<seq<opt<seq<directives, star<ignored>>>, union_member_types>
+	, directives>>::error_message = "Expected UnionTypeExtension";
+template <> const std::string ast_control<
+	sor<seq<opt<seq<directives, star<ignored>>>, enum_values_definition>
+	, directives>>::error_message = "Expected EnumTypeExtension";
+template <> const std::string ast_control<
+	sor<seq<opt<seq<directives, star<ignored>>>, input_fields_definition>
+	, directives>>::error_message = "Expected InputObjectTypeExtension";
+template <> const std::string ast_control<name>::error_message = "Expected Name";
+template <> const std::string ast_control<named_type>::error_message = "Expected NamedType";
+template <> const std::string ast_control<list<input_field_definition, plus<ignored>>>::error_message = "Expected InputValueDefinitions";
+template <> const std::string ast_control<one<')'>>::error_message = "Expected )";
+template <> const std::string ast_control<one<':'>>::error_message = "Expected :";
+template <> const std::string ast_control<
+	sor<executable_directive_location
+	, type_system_directive_location>>::error_message = "Expected DirectiveLocation";
+template <> const std::string ast_control<opt<seq<star<ignored>, arguments>>>::error_message = "Expected optional Arguments";
+template <> const std::string ast_control<block_quote_token>::error_message = "Expected \"\"\"";
+template <> const std::string ast_control<quote_token>::error_message = "Expected \"";
+template <> const std::string ast_control<
+	sor<seq<opt<seq<star<ignored>, arguments>>, opt<seq<star<ignored>, directives>>, seq<star<ignored>, selection_set>>
+	, seq<opt<seq<star<ignored>, arguments>>, seq<star<ignored>, directives>>
+	, opt<seq<star<ignored>, arguments>>>>::error_message = "Expected Field";
+template <> const std::string ast_control<type_name>::error_message = "Expected Type";
+template <> const std::string ast_control<
+	sor<seq<opt<seq<star<ignored>, default_value>>, seq<star<ignored>, directives>>
+	, opt<seq<star<ignored>, default_value>>>>::error_message = "Expected InputValueDefinition";
+template <> const std::string ast_control<list<field_definition, plus<ignored>>>::error_message = "Expected FieldsDefinitions";
+template <> const std::string ast_control<opt<seq<star<ignored>, one<'&'>>>>::error_message = "Expected optional '&'";
+template <> const std::string ast_control<list<interface_type, seq<star<ignored>, one<'&'>, star<ignored>>>>::error_message = "Expected ImplementsInterfaces";
+template <> const std::string ast_control<opt<seq<star<ignored>, one<'|'>>>>::error_message = "Expected optional '|'";
+template <> const std::string ast_control<list<union_type, seq<star<ignored>, one<'|'>, star<ignored>>>>::error_message = "Expected UnionMemberTypes";
+template <> const std::string ast_control<list<enum_value_definition, plus<ignored>>>::error_message = "Expected EnumValuesDefinition";
+template <> const std::string ast_control<star<sor<block_escape_sequence, block_quote_character>>>::error_message = "Expected optional BlockStringCharacters";
+template <> const std::string ast_control<star<sor<string_escape_sequence, string_quote_character>>>::error_message = "Expected optional StringCharacters";
+template <> const std::string ast_control<sor<nonnull_type, list_type, named_type>>::error_message = "Expected Type";
+template <> const std::string ast_control<opt<seq<star<ignored>, default_value>>>::error_message = "Expected optional DefaultValue";
+template <> const std::string ast_control<list<variable, plus<ignored>>>::error_message = "Expected VariableDefinitions";
+template <> const std::string ast_control<opt<seq<star<ignored>, arguments_definition>>>::error_message = "Expected optional ArgumentsDefinition";
+template <> const std::string ast_control<list<argument, plus<ignored>>>::error_message = "Expected Arguments";
+template <> const std::string ast_control<one<']'>>::error_message = "Expected ]";
+template <> const std::string ast_control<sor<escaped_unicode, escaped_char>>::error_message = "Expected EscapeSequence";
+template <> const std::string ast_control<input_value>::error_message = "Expected Value";
+template <> const std::string ast_control<
+	sor<list_value
+	, object_value
+	, variable_value
+	, integer_value
+	, float_value
+	, string_value
+	, bool_value
+	, null_keyword
+	, enum_value>>::error_message = "Expected Value";
+template <> const std::string ast_control<rep<4, xdigit>>::error_message = "Expected EscapedUnicode";
+template <> const std::string ast_control<opt<list<list_entry, plus<ignored>>>>::error_message = "Expected optional ListValues";
+template <> const std::string ast_control<opt<list<object_field, plus<ignored>>>>::error_message = "Expected optional ObjectValues";
+template <> const std::string ast_control<plus<digit>>::error_message = "Expected Digits";
+template <> const std::string ast_control<opt<sign>>::error_message = "Expected optional Sign";
+
 template <>
 ast<std::string>::~ast()
 {
@@ -589,7 +717,7 @@ ast<std::string> parseString(std::string&& input)
 {
 	memory_input<> in(input.c_str(), input.size(), "GraphQL");
 
-	return { std::move(input), parse_tree::parse<document, ast_node, ast_selector>(std::move(in)) };
+	return { std::move(input), parse_tree::parse<document, ast_node, ast_selector, ast_control>(std::move(in)) };
 }
 
 ast<std::unique_ptr<file_input<>>> parseFile(const char* filename)
@@ -597,7 +725,7 @@ ast<std::unique_ptr<file_input<>>> parseFile(const char* filename)
 	std::unique_ptr<file_input<>> in(new file_input<>(std::string(filename)));
 	ast<std::unique_ptr<file_input<>>> result { std::move(in), nullptr };
 
-	result.root = parse_tree::parse<document, ast_node, ast_selector>(std::move(*result.input));
+	result.root = parse_tree::parse<document, ast_node, ast_selector, ast_control>(std::move(*result.input));
 
 	return result;
 }
@@ -608,7 +736,7 @@ peg::ast<const char*> operator "" _graphql(const char* text, size_t size)
 {
 	peg::memory_input<> in(text, size, "GraphQL");
 
-	return { text, peg::parse_tree::parse<peg::document, peg::ast_node, peg::ast_selector>(std::move(in)) };
+	return { text, peg::parse_tree::parse<peg::document, peg::ast_node, peg::ast_selector, peg::ast_control>(std::move(in)) };
 }
 
 } /* namespace graphql */

--- a/GraphQLTree.cpp
+++ b/GraphQLTree.cpp
@@ -574,120 +574,63 @@ struct ast_control
 	}
 };
 
-template <> const std::string ast_control<bof>::error_message = "Expected beginning of file";
-template <> const std::string ast_control<opt<utf8::bom>>::error_message = "Expected optional UTF8 byte-order-mark";
-template <> const std::string ast_control<star<ignored>>::error_message = "Expected optional ignored characters";
-template <> const std::string ast_control<plus<ignored>>::error_message = "Expected ignored characters";
-template <> const std::string ast_control<until<ascii::eolf>>::error_message = "Expected Comment";
-template <> const std::string ast_control<eof>::error_message = "Expected end of file";
-template <> const std::string ast_control<list<definition, plus<ignored>>>::error_message = "Expected list of Definitions";
-template <> const std::string ast_control<selection_set>::error_message = "Expected SelectionSet";
-template <> const std::string ast_control<fragment_name>::error_message = "Expected FragmentName";
-template <> const std::string ast_control<type_condition>::error_message = "Expected TypeCondition";
-template <> const std::string ast_control<opt<seq<star<ignored>, directives>>>::error_message = "Expected optional Directives";
-template <> const std::string ast_control<one<'{'>>::error_message = "Expected {";
-template <> const std::string ast_control<list<root_operation_definition, plus<ignored>>>::error_message = "Expected RootOperationTypeDefinition";
 template <> const std::string ast_control<one<'}'>>::error_message = "Expected }";
-template <> const std::string ast_control<one<'@'>>::error_message = "Expected @";
-template <> const std::string ast_control<directive_name>::error_message = "Expected Directive Name";
-template <> const std::string ast_control<arguments_definition>::error_message = "Expected ArgumentsDefinition";
-template <> const std::string ast_control<on_keyword>::error_message = "Expected \"on\" keyword";
-template <> const std::string ast_control<directive_locations>::error_message = "Expected DirectiveLocations";
-template <> const std::string ast_control<schema_extension>::error_message = "Expected SchemaExtension";
-template <> const std::string ast_control<
-	seq<opt<seq<plus<ignored>, operation_name>>, opt<seq<star<ignored>, variable_definitions>>, opt<seq<star<ignored>, directives>>, star<ignored>, selection_set>>::error_message = "Expected OperationDefinition";
-template <> const std::string ast_control<list<selection, plus<ignored>>>::error_message = "Expected Selections";
-template <> const std::string ast_control<scalar_name>::error_message = "Expected ScalarType Name";
-template <> const std::string ast_control<object_name>::error_message = "Expected ObjectType Name";
-template <> const std::string ast_control<
-	sor<seq<opt<seq<plus<ignored>, implements_interfaces>>, opt<seq<star<ignored>, directives>>, seq<star<ignored>, fields_definition>>
-	, seq<opt<seq<plus<ignored>, implements_interfaces>>, seq<star<ignored>, directives>>
-	, opt<seq<plus<ignored>, implements_interfaces>>>>::error_message = "Expected ObjectTypeDefinition";
-template <> const std::string ast_control<interface_name>::error_message = "Expected InterfaceType Name";
-template <> const std::string ast_control<
-	sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, fields_definition>>
-	, opt<seq<star<ignored>, directives>>>>::error_message = "Expected InterfaceTypeDefinition";
-template <> const std::string ast_control<
-	sor<seq<opt<directives>, one<'{'>, star<ignored>, list<operation_type_definition, plus<ignored>>, star<ignored>, one<'}'>>
-	, directives>>::error_message = "Expected SchemaExtension";
-template <> const std::string ast_control<union_name>::error_message = "Expected UnionType Name";
-template <> const std::string ast_control<
-	sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, union_member_types>>
-	, opt<seq<star<ignored>, directives>>>>::error_message = "Expected UnionTypeDefinition";
-template <> const std::string ast_control<enum_name>::error_message = "Expected EnumType Name";
-template <> const std::string ast_control<
-	sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, enum_values_definition>>
-	, opt<seq<star<ignored>, directives>>>>::error_message = "Expected EnumTypeDefinition";
-template <> const std::string ast_control<
-	sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, input_fields_definition>>
-	, opt<seq<star<ignored>, directives>>>>::error_message = "Expected InputObjectTypeDefinition";
-template <> const std::string ast_control<directives>::error_message = "Expected list of Directives";
-template <> const std::string ast_control<
-	sor<seq<opt<seq<plus<ignored>, implements_interfaces>>, opt<seq<star<ignored>, directives>>, star<ignored>, fields_definition>
-	, seq<opt<seq<plus<ignored>, implements_interfaces>>, star<ignored>, directives>
-	, seq<plus<ignored>, implements_interfaces>>>::error_message = "Expected ObjectTypeExtension";
-template <> const std::string ast_control<
-	sor<seq<opt<seq<directives, star<ignored>>>, fields_definition>
-	, directives>>::error_message = "Expected InterfaceTypeExtension";
-template <> const std::string ast_control<
-	sor<seq<opt<seq<directives, star<ignored>>>, union_member_types>
-	, directives>>::error_message = "Expected UnionTypeExtension";
-template <> const std::string ast_control<
-	sor<seq<opt<seq<directives, star<ignored>>>, enum_values_definition>
-	, directives>>::error_message = "Expected EnumTypeExtension";
-template <> const std::string ast_control<
-	sor<seq<opt<seq<directives, star<ignored>>>, input_fields_definition>
-	, directives>>::error_message = "Expected InputObjectTypeExtension";
-template <> const std::string ast_control<name>::error_message = "Expected Name";
-template <> const std::string ast_control<named_type>::error_message = "Expected NamedType";
-template <> const std::string ast_control<list<input_field_definition, plus<ignored>>>::error_message = "Expected InputValueDefinitions";
-template <> const std::string ast_control<one<')'>>::error_message = "Expected )";
-template <> const std::string ast_control<one<':'>>::error_message = "Expected :";
-template <> const std::string ast_control<
-	sor<executable_directive_location
-	, type_system_directive_location>>::error_message = "Expected DirectiveLocation";
-template <> const std::string ast_control<opt<seq<star<ignored>, arguments>>>::error_message = "Expected optional Arguments";
-template <> const std::string ast_control<block_quote_token>::error_message = "Expected \"\"\"";
-template <> const std::string ast_control<quote_token>::error_message = "Expected \"";
-template <> const std::string ast_control<
-	sor<seq<opt<seq<star<ignored>, arguments>>, opt<seq<star<ignored>, directives>>, seq<star<ignored>, selection_set>>
-	, seq<opt<seq<star<ignored>, arguments>>, seq<star<ignored>, directives>>
-	, opt<seq<star<ignored>, arguments>>>>::error_message = "Expected Field";
-template <> const std::string ast_control<type_name>::error_message = "Expected Type";
-template <> const std::string ast_control<
-	sor<seq<opt<seq<star<ignored>, default_value>>, seq<star<ignored>, directives>>
-	, opt<seq<star<ignored>, default_value>>>>::error_message = "Expected InputValueDefinition";
-template <> const std::string ast_control<list<field_definition, plus<ignored>>>::error_message = "Expected FieldsDefinitions";
-template <> const std::string ast_control<opt<seq<star<ignored>, one<'&'>>>>::error_message = "Expected optional '&'";
-template <> const std::string ast_control<list<interface_type, seq<star<ignored>, one<'&'>, star<ignored>>>>::error_message = "Expected ImplementsInterfaces";
-template <> const std::string ast_control<opt<seq<star<ignored>, one<'|'>>>>::error_message = "Expected optional '|'";
-template <> const std::string ast_control<list<union_type, seq<star<ignored>, one<'|'>, star<ignored>>>>::error_message = "Expected UnionMemberTypes";
-template <> const std::string ast_control<list<enum_value_definition, plus<ignored>>>::error_message = "Expected EnumValuesDefinition";
-template <> const std::string ast_control<star<sor<block_escape_sequence, block_quote_character>>>::error_message = "Expected optional BlockStringCharacters";
-template <> const std::string ast_control<star<sor<string_escape_sequence, string_quote_character>>>::error_message = "Expected optional StringCharacters";
-template <> const std::string ast_control<sor<nonnull_type, list_type, named_type>>::error_message = "Expected Type";
-template <> const std::string ast_control<opt<seq<star<ignored>, default_value>>>::error_message = "Expected optional DefaultValue";
-template <> const std::string ast_control<list<variable, plus<ignored>>>::error_message = "Expected VariableDefinitions";
-template <> const std::string ast_control<opt<seq<star<ignored>, arguments_definition>>>::error_message = "Expected optional ArgumentsDefinition";
-template <> const std::string ast_control<list<argument, plus<ignored>>>::error_message = "Expected Arguments";
 template <> const std::string ast_control<one<']'>>::error_message = "Expected ]";
-template <> const std::string ast_control<sor<escaped_unicode, escaped_char>>::error_message = "Expected EscapeSequence";
-template <> const std::string ast_control<input_value>::error_message = "Expected Value";
-template <> const std::string ast_control<
-	sor<list_value
-	, object_value
-	, variable_value
-	, integer_value
-	, float_value
-	, string_value
-	, bool_value
-	, null_keyword
-	, enum_value>>::error_message = "Expected Value";
-template <> const std::string ast_control<rep<4, xdigit>>::error_message = "Expected EscapedUnicode";
-template <> const std::string ast_control<opt<list<list_entry, plus<ignored>>>>::error_message = "Expected optional ListValues";
-template <> const std::string ast_control<opt<list<object_field, plus<ignored>>>>::error_message = "Expected optional ObjectValues";
-template <> const std::string ast_control<plus<digit>>::error_message = "Expected Digits";
-template <> const std::string ast_control<opt<sign>>::error_message = "Expected optional Sign";
+template <> const std::string ast_control<one<')'>>::error_message = "Expected )";
+template <> const std::string ast_control<quote_token>::error_message = "Expected \"";
+template <> const std::string ast_control<block_quote_token>::error_message = "Expected \"\"\"";
+
+template <> const std::string ast_control<variable_name_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#Variable";
+template <> const std::string ast_control<escaped_unicode_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#EscapedUnicode";
+template <> const std::string ast_control<string_escape_sequence_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#EscapedCharacter";
+template <> const std::string ast_control<string_quote_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#StringCharacter";
+template <> const std::string ast_control<block_quote_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#BlockStringCharacter";
+template <> const std::string ast_control<fractional_part_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#FractionalPart";
+template <> const std::string ast_control<exponent_part_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#ExponentPart";
+template <> const std::string ast_control<argument_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#Argument";
+template <> const std::string ast_control<arguments_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#Arguments";
+template <> const std::string ast_control<list_value_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#ListValue";
+template <> const std::string ast_control<object_field_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#ObjectField";
+template <> const std::string ast_control<object_value_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#ObjectValue";
+template <> const std::string ast_control<input_value_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#Value";
+template <> const std::string ast_control<default_value_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#DefaultValue";
+template <> const std::string ast_control<list_type_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#ListType";
+template <> const std::string ast_control<type_name_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#Type";
+template <> const std::string ast_control<variable_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#VariableDefinition";
+template <> const std::string ast_control<variable_definitions_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#VariableDefinitions";
+template <> const std::string ast_control<directive_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#Directive";
+template <> const std::string ast_control<field_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#Field";
+template <> const std::string ast_control<type_condition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#TypeCondition";
+template <> const std::string ast_control<fragement_spread_or_inline_fragment_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#FragmentSpread or https://facebook.github.io/graphql/June2018/#InlineFragment";
+template <> const std::string ast_control<selection_set_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#SelectionSet";
+template <> const std::string ast_control<operation_definition_operation_type_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#OperationDefinition";
+template <> const std::string ast_control<fragment_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#FragmentDefinition";
+template <> const std::string ast_control<root_operation_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#RootOperationTypeDefinition";
+template <> const std::string ast_control<schema_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#SchemaDefinition";
+template <> const std::string ast_control<scalar_type_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#ScalarTypeDefinition";
+template <> const std::string ast_control<arguments_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#ArgumentsDefinition";
+template <> const std::string ast_control<field_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#FieldDefinition";
+template <> const std::string ast_control<fields_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#FieldsDefinition";
+template <> const std::string ast_control<implements_interfaces_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#ImplementsInterfaces";
+template <> const std::string ast_control<object_type_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#ObjectTypeDefinition";
+template <> const std::string ast_control<interface_type_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#InterfaceTypeDefinition";
+template <> const std::string ast_control<union_member_types_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#UnionMemberTypes";
+template <> const std::string ast_control<union_type_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#UnionTypeDefinition";
+template <> const std::string ast_control<enum_value_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#EnumValueDefinition";
+template <> const std::string ast_control<enum_values_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#EnumValuesDefinition";
+template <> const std::string ast_control<enum_type_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#EnumTypeDefinition";
+template <> const std::string ast_control<input_field_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#InputValueDefinition";
+template <> const std::string ast_control<input_fields_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#InputFieldsDefinition";
+template <> const std::string ast_control<input_object_type_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#InputObjectTypeDefinition";
+template <> const std::string ast_control<directive_definition_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#DirectiveDefinition";
+template <> const std::string ast_control<schema_extension_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#SchemaExtension";
+template <> const std::string ast_control<scalar_type_extension_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#ScalarTypeExtension";
+template <> const std::string ast_control<object_type_extension_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#ObjectTypeExtension";
+template <> const std::string ast_control<interface_type_extension_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#InterfaceTypeExtension";
+template <> const std::string ast_control<union_type_extension_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#UnionTypeExtension";
+template <> const std::string ast_control<enum_type_extension_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#EnumTypeExtension";
+template <> const std::string ast_control<input_object_type_extension_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#InputObjectTypeExtension";
+template <> const std::string ast_control<document_content>::error_message = "Expected https://facebook.github.io/graphql/June2018/#Document";
 
 template <>
 ast<std::string>::~ast()

--- a/GraphQLTree.cpp
+++ b/GraphQLTree.cpp
@@ -717,7 +717,7 @@ ast<std::string> parseString(std::string&& input)
 {
 	memory_input<> in(input.c_str(), input.size(), "GraphQL");
 
-	return { std::move(input), parse_tree::parse<document, ast_node, ast_selector, ast_control>(std::move(in)) };
+	return { std::move(input), parse_tree::parse<document, ast_node, ast_selector, nothing, ast_control>(std::move(in)) };
 }
 
 ast<std::unique_ptr<file_input<>>> parseFile(const char* filename)
@@ -725,7 +725,7 @@ ast<std::unique_ptr<file_input<>>> parseFile(const char* filename)
 	std::unique_ptr<file_input<>> in(new file_input<>(std::string(filename)));
 	ast<std::unique_ptr<file_input<>>> result { std::move(in), nullptr };
 
-	result.root = parse_tree::parse<document, ast_node, ast_selector, ast_control>(std::move(*result.input));
+	result.root = parse_tree::parse<document, ast_node, ast_selector, nothing, ast_control>(std::move(*result.input));
 
 	return result;
 }
@@ -736,7 +736,7 @@ peg::ast<const char*> operator "" _graphql(const char* text, size_t size)
 {
 	peg::memory_input<> in(text, size, "GraphQL");
 
-	return { text, peg::parse_tree::parse<peg::document, peg::ast_node, peg::ast_selector, peg::ast_control>(std::move(in)) };
+	return { text, peg::parse_tree::parse<peg::document, peg::ast_node, peg::ast_selector, peg::nothing, peg::ast_control>(std::move(in)) };
 }
 
 } /* namespace graphql */

--- a/GraphQLTree.cpp
+++ b/GraphQLTree.cpp
@@ -658,9 +658,12 @@ ast<const char*>::~ast()
 
 ast<std::string> parseString(std::string&& input)
 {
-	memory_input<> in(input.c_str(), input.size(), "GraphQL");
+	ast<std::string> result { std::move(input), nullptr };
+	memory_input<> in(result.input.c_str(), result.input.size(), "GraphQL");
 
-	return { std::move(input), parse_tree::parse<document, ast_node, ast_selector, nothing, ast_control>(std::move(in)) };
+	result.root = parse_tree::parse<document, ast_node, ast_selector, nothing, ast_control>(std::move(in));
+
+	return result;
 }
 
 ast<std::unique_ptr<file_input<>>> parseFile(const char* filename)

--- a/include/GraphQLGrammar.h
+++ b/include/GraphQLGrammar.h
@@ -594,8 +594,8 @@ struct union_member_types
 // https://facebook.github.io/graphql/June2018/#UnionTypeDefinition
 struct union_type_definition
 	: if_must<seq<opt<seq<description, star<ignored>>>, union_keyword>, plus<ignored>, union_name,
-		sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, union_member_types>>,
-		opt<seq<star<ignored>, directives>>>>
+		sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, union_member_types>>
+		, opt<seq<star<ignored>, directives>>>>
 {
 };
 

--- a/include/GraphQLGrammar.h
+++ b/include/GraphQLGrammar.h
@@ -48,7 +48,7 @@ struct source_character
 
 // https://facebook.github.io/graphql/June2018/#sec-Comments
 struct comment
-	: if_must<one<'#'>, until<eolf>>
+	: seq<one<'#'>, until<eolf>>
 {
 };
 
@@ -66,9 +66,14 @@ struct name
 {
 };
 
+struct variable_name_content
+	: name
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#Variable
 struct variable_name
-	: if_must<one<'$'>, name>
+	: if_must<one<'$'>, variable_name_content>
 {
 };
 
@@ -88,9 +93,14 @@ struct backslash_token
 {
 };
 
+struct escaped_unicode_content
+	: rep<4, xdigit>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#EscapedUnicode
 struct escaped_unicode
-	: if_must<one<'u'>, rep<4, xdigit>>
+	: if_must<one<'u'>, escaped_unicode_content>
 {
 };
 
@@ -100,8 +110,13 @@ struct escaped_char
 {
 };
 
+struct string_escape_sequence_content
+	: sor<escaped_unicode, escaped_char>
+{
+};
+
 struct string_escape_sequence
-	: if_must<backslash_token, sor<escaped_unicode, escaped_char>>
+	: if_must<backslash_token, string_escape_sequence_content>
 {
 };
 
@@ -110,9 +125,14 @@ struct string_quote_character
 {
 };
 
+struct string_quote_content
+	: seq<star<sor<string_escape_sequence, string_quote_character>>, must<quote_token>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#StringCharacter
 struct string_quote
-	: if_must<quote_token, star<sor<string_escape_sequence, string_quote_character>>, quote_token>
+	: if_must<quote_token, string_quote_content>
 {
 };
 
@@ -131,9 +151,14 @@ struct block_quote_character
 {
 };
 
+struct block_quote_content
+	: seq<star<sor<block_escape_sequence, block_quote_character>>, must<block_quote_token>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#BlockStringCharacter
 struct block_quote
-	: if_must<block_quote_token, star<sor<block_escape_sequence, block_quote_character>>, block_quote_token>
+	: if_must<block_quote_token, block_quote_content>
 {
 };
 
@@ -173,9 +198,14 @@ struct integer_value
 {
 };
 
+struct fractional_part_content
+	: plus<digit>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#FractionalPart
 struct fractional_part
-	: if_must<one<'.'>, plus<digit>>
+	: if_must<one<'.'>, fractional_part_content>
 {
 };
 
@@ -191,9 +221,14 @@ struct sign
 {
 };
 
+struct exponent_part_content
+	: seq<opt<sign>, plus<digit>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#ExponentPart
 struct exponent_part
-	: if_must<exponent_indicator, opt<sign>, plus<digit>>
+	: if_must<exponent_indicator, exponent_part_content>
 {
 };
 
@@ -252,23 +287,38 @@ struct argument_name
 
 struct input_value;
 
+struct argument_content
+	: seq<star<ignored>, one<':'>, star<ignored>, input_value>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#Argument
 struct argument
-	: if_must<argument_name, star<ignored>, one<':'>, star<ignored>, input_value>
+	: if_must<argument_name, argument_content>
+{
+};
+
+struct arguments_content
+	: seq<star<ignored>, list<argument, plus<ignored>>, star<ignored>, must<one<')'>>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Arguments
 struct arguments
-	: if_must<one<'('>, star<ignored>, list<argument, plus<ignored>>, star<ignored>, one<')'>>
+	: if_must<one<'('>, arguments_content>
 {
 };
 
 struct list_entry;
 
+struct list_value_content
+	: seq<star<ignored>, opt<list<list_entry, plus<ignored>>>, star<ignored>, must<one<']'>>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#ListValue
 struct list_value
-	: if_must<one<'['>, star<ignored>, opt<list<list_entry, plus<ignored>>>, star<ignored>, one<']'>>
+	: if_must<one<'['>, list_value_content>
 {
 };
 
@@ -277,15 +327,25 @@ struct object_field_name
 {
 };
 
+struct object_field_content
+	: seq<star<ignored>, one<':'>, star<ignored>, input_value>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#ObjectField
 struct object_field
-	: if_must<object_field_name, star<ignored>, one<':'>, star<ignored>, input_value>
+	: if_must<object_field_name, object_field_content>
+{
+};
+
+struct object_value_content
+	: seq<star<ignored>, opt<list<object_field, plus<ignored>>>, star<ignored>, must<one<'}'>>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#ObjectValue
 struct object_value
-	: if_must<one<'{'>, star<ignored>, opt<list<object_field, plus<ignored>>>, star<ignored>, one<'}'>>
+	: if_must<one<'{'>, object_value_content>
 {
 };
 
@@ -294,9 +354,8 @@ struct variable_value
 {
 };
 
-// https://facebook.github.io/graphql/June2018/#Value
-struct input_value
-	: must<sor<list_value
+struct input_value_content
+	: sor<list_value
 	, object_value
 	, variable_value
 	, integer_value
@@ -304,7 +363,13 @@ struct input_value
 	, string_value
 	, bool_value
 	, null_keyword
-	, enum_value>>
+	, enum_value>
+{
+};
+
+// https://facebook.github.io/graphql/June2018/#Value
+struct input_value
+	: must<input_value_content>
 {
 };
 
@@ -313,9 +378,14 @@ struct list_entry
 {
 };
 
+struct default_value_content
+	: seq<star<ignored>, input_value>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#DefaultValue
 struct default_value
-	: if_must<one<'='>, star<ignored>, input_value>
+	: if_must<one<'='>, default_value_content>
 {
 };
 
@@ -325,11 +395,17 @@ struct named_type
 {
 };
 
+struct list_type;
 struct nonnull_type;
+
+struct list_type_content
+	: seq<star<ignored>, sor<nonnull_type, list_type, named_type>, star<ignored>, must<one<']'>>>
+{
+};
 
 // https://facebook.github.io/graphql/June2018/#ListType
 struct list_type
-	: if_must<one<'['>, star<ignored>, sor<nonnull_type, list_type, named_type>, star<ignored>, one<']'>>
+	: if_must<one<'['>, list_type_content>
 {
 };
 
@@ -339,21 +415,36 @@ struct nonnull_type
 {
 };
 
+struct type_name_content
+	: sor<nonnull_type, list_type, named_type>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#Type
 struct type_name
-	: must<sor<nonnull_type, list_type, named_type>>
+	: must<type_name_content>
+{
+};
+
+struct variable_content
+	: seq<star<ignored>, one<':'>, star<ignored>, type_name, opt<seq<star<ignored>, default_value>>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#VariableDefinition
 struct variable
-	: if_must<variable_name, star<ignored>, one<':'>, star<ignored>, type_name, opt<seq<star<ignored>, default_value>>>
+	: if_must<variable_name, variable_content>
+{
+};
+
+struct variable_definitions_content
+	: seq<star<ignored>, list<variable, plus<ignored>>, star<ignored>, must<one<')'>>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#VariableDefinitions
 struct variable_definitions
-	: if_must<one<'('>, star<ignored>, list<variable, plus<ignored>>, star<ignored>, one<')'>>
+	: if_must<one<'('>, variable_definitions_content>
 {
 };
 
@@ -362,9 +453,14 @@ struct directive_name
 {
 };
 
+struct directive_content
+	: seq<directive_name, opt<seq<star<ignored>, arguments>>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#Directive
 struct directive
-	: if_must<one<'@'>, directive_name, opt<seq<star<ignored>, arguments>>>
+	: if_must<one<'@'>, directive_content>
 {
 };
 
@@ -381,12 +477,36 @@ struct field_name
 {
 };
 
+struct field_start
+	: seq<opt<seq<alias, star<ignored>>>, field_name>
+{
+};
+
+struct field_arguments
+	: opt<seq<star<ignored>, arguments>>
+{
+};
+
+struct field_directives
+	: seq<star<ignored>, directives>
+{
+};
+
+struct field_selection_set
+	: seq<star<ignored>, selection_set>
+{
+};
+
+struct field_content
+	: sor<seq<field_arguments, opt<field_directives>, field_selection_set>
+	, seq<field_arguments, field_directives>
+	, field_arguments>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#Field
 struct field
-	: if_must<seq<opt<seq<alias, star<ignored>>>, field_name>,
-		sor<seq<opt<seq<star<ignored>, arguments>>, opt<seq<star<ignored>, directives>>, seq<star<ignored>, selection_set>>
-		, seq<opt<seq<star<ignored>, arguments>>, seq<star<ignored>, directives>>
-		, opt<seq<star<ignored>, arguments>>>>
+	: if_must<field_start, field_content>
 {
 };
 
@@ -408,33 +528,53 @@ struct fragment_token
 
 // https://facebook.github.io/graphql/June2018/#FragmentSpread
 struct fragment_spread
-	: seq<fragment_token, star<ignored>, fragment_name, opt<seq<star<ignored>, directives>>>
+	: seq<star<ignored>, fragment_name, opt<seq<star<ignored>, directives>>>
+{
+};
+
+struct type_condition_content
+	: seq<plus<ignored>, named_type>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#TypeCondition
 struct type_condition
-	: seq<on_keyword, plus<ignored>, named_type>
+	: if_must<on_keyword, type_condition_content>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#InlineFragment
 struct inline_fragment
-	: seq<fragment_token, opt<star<ignored>, type_condition>, opt<seq<star<ignored>, directives>>, star<ignored>, selection_set>
+	: seq<opt<star<ignored>, type_condition>, opt<seq<star<ignored>, directives>>, star<ignored>, selection_set>
+{
+};
+
+struct fragement_spread_or_inline_fragment_content
+	: sor<fragment_spread
+	, inline_fragment>
+{
+};
+
+struct fragement_spread_or_inline_fragment
+	: if_must<fragment_token, fragement_spread_or_inline_fragment_content>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Selection
 struct selection
 	: sor<field
-	, fragment_spread
-	, inline_fragment>
+	, fragement_spread_or_inline_fragment>
+{
+};
+
+struct selection_set_content
+	: seq<star<ignored>, list<selection, plus<ignored>>, star<ignored>, must<one<'}'>>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#SelectionSet
 struct selection_set
-	: if_must<one<'{'>, star<ignored>, list<selection, plus<ignored>>, star<ignored>, one<'}'>>
+	: if_must<one<'{'>, selection_set_content>
 {
 };
 
@@ -443,16 +583,26 @@ struct operation_name
 {
 };
 
+struct operation_definition_operation_type_content
+	: seq<opt<seq<plus<ignored>, operation_name>>, opt<seq<star<ignored>, variable_definitions>>, opt<seq<star<ignored>, directives>>, star<ignored>, selection_set>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#OperationDefinition
 struct operation_definition
-	: sor<if_must<operation_type, seq<opt<seq<plus<ignored>, operation_name>>, opt<seq<star<ignored>, variable_definitions>>, opt<seq<star<ignored>, directives>>, star<ignored>, selection_set>>
+	: sor<if_must<operation_type, operation_definition_operation_type_content>
 	, selection_set>
+{
+};
+
+struct fragment_definition_content
+	: seq<plus<ignored>, fragment_name, plus<ignored>, type_condition, opt<seq<star<ignored>, directives>>, star<ignored>, selection_set>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#FragmentDefinition
 struct fragment_definition
-	: if_must<TAO_PEGTL_KEYWORD("fragment"), plus<ignored>, fragment_name, plus<ignored>, type_condition, opt<seq<star<ignored>, directives>>, star<ignored>, selection_set>
+	: if_must<TAO_PEGTL_KEYWORD("fragment"), fragment_definition_content>
 {
 };
 
@@ -468,15 +618,25 @@ struct schema_keyword
 {
 };
 
+struct root_operation_definition_content
+	: seq<star<ignored>, one<':'>, star<ignored>, named_type>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#RootOperationTypeDefinition
 struct root_operation_definition
-	: if_must<operation_type, star<ignored>, one<':'>, star<ignored>, named_type>
+	: if_must<operation_type, root_operation_definition_content>
+{
+};
+
+struct schema_definition_content
+	: seq<opt<seq<star<ignored>, directives>>, star<ignored>, one<'{'>, star<ignored>, list<root_operation_definition, plus<ignored>>, star<ignored>, must<one<'}'>>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#SchemaDefinition
 struct schema_definition
-	: if_must<schema_keyword, opt<seq<star<ignored>, directives>>, star<ignored>, one<'{'>, star<ignored>, list<root_operation_definition, plus<ignored>>, star<ignored>, one<'}'>>
+	: if_must<schema_keyword, schema_definition_content>
 {
 };
 
@@ -496,9 +656,19 @@ struct scalar_name
 {
 };
 
+struct scalar_type_definition_start
+	: seq<opt<seq<description, star<ignored>>>, scalar_keyword>
+{
+};
+
+struct scalar_type_definition_content
+	: seq<plus<ignored>, scalar_name, opt<seq<star<ignored>, directives>>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#ScalarTypeDefinition
 struct scalar_type_definition
-	: if_must<seq<opt<seq<description, star<ignored>>>, scalar_keyword>, plus<ignored>, scalar_name, opt<seq<star<ignored>, directives>>>
+	: if_must<scalar_type_definition_start, scalar_type_definition_content>
 {
 };
 
@@ -509,21 +679,46 @@ struct type_keyword
 
 struct input_field_definition;
 
+struct arguments_definition_start
+	: one<'('>
+{
+};
+
+struct arguments_definition_content
+	: seq<star<ignored>, list<input_field_definition, plus<ignored>>, star<ignored>, must<one<')'>>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#ArgumentsDefinition
 struct arguments_definition
-	: if_must<one<'('>, star<ignored>, list<input_field_definition, plus<ignored>>, star<ignored>, one<')'>>
+	: if_must<arguments_definition_start, arguments_definition_content>
+{
+};
+
+struct field_definition_start
+	: seq<opt<seq<description, star<ignored>>>, field_name>
+{
+};
+
+struct field_definition_content
+	: seq<opt<seq<star<ignored>, arguments_definition>>, star<ignored>, one<':'>, star<ignored>, type_name, opt<seq<star<ignored>, directives>>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#FieldDefinition
 struct field_definition
-	: if_must<seq<opt<seq<description, star<ignored>>>, field_name>, opt<seq<star<ignored>, arguments_definition>>, star<ignored>, one<':'>, star<ignored>, type_name, opt<seq<star<ignored>, directives>>>
+	: if_must<field_definition_start, field_definition_content>
+{
+};
+
+struct fields_definition_content
+	: seq<star<ignored>, list<field_definition, plus<ignored>>, star<ignored>, must<one<'}'>>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#FieldsDefinition
 struct fields_definition
-	: if_must<one<'{'>, star<ignored>, list<field_definition, plus<ignored>>, star<ignored>, one<'}'>>
+	: if_must<one<'{'>, fields_definition_content>
 {
 };
 
@@ -532,9 +727,14 @@ struct interface_type
 {
 };
 
+struct implements_interfaces_content
+	: seq<opt<seq<star<ignored>, one<'&'>>>, star<ignored>, list<interface_type, seq<star<ignored>, one<'&'>, star<ignored>>>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#ImplementsInterfaces
 struct implements_interfaces
-	: if_must<TAO_PEGTL_KEYWORD("implements"), opt<seq<star<ignored>, one<'&'>>>, star<ignored>, list<interface_type, seq<star<ignored>, one<'&'>, star<ignored>>>>
+	: if_must<TAO_PEGTL_KEYWORD("implements"), implements_interfaces_content>
 {
 };
 
@@ -543,12 +743,42 @@ struct object_name
 {
 };
 
+struct object_type_definition_start
+	: seq<opt<seq<description, star<ignored>>>, type_keyword>
+{
+};
+
+struct object_type_definition_object_name
+	: seq<plus<ignored>, object_name>
+{
+};
+
+struct object_type_definition_implements_interfaces
+	: opt<seq<plus<ignored>, implements_interfaces>>
+{
+};
+
+struct object_type_definition_directives
+	: seq<star<ignored>, directives>
+{
+};
+
+struct object_type_definition_fields_definition
+	: seq<star<ignored>, fields_definition>
+{
+};
+
+struct object_type_definition_content
+	: seq<object_type_definition_object_name,
+		sor<seq<object_type_definition_implements_interfaces, opt<object_type_definition_directives>, object_type_definition_fields_definition>
+		, seq<object_type_definition_implements_interfaces, object_type_definition_directives>
+		, object_type_definition_implements_interfaces>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#ObjectTypeDefinition
 struct object_type_definition
-	: if_must<seq<opt<seq<description, star<ignored>>>, type_keyword>, plus<ignored>, object_name,
-		sor<seq<opt<seq<plus<ignored>, implements_interfaces>>, opt<seq<star<ignored>, directives>>, seq<star<ignored>, fields_definition>>
-		, seq<opt<seq<plus<ignored>, implements_interfaces>>, seq<star<ignored>, directives>>
-		, opt<seq<plus<ignored>, implements_interfaces>>>>
+	: if_must<object_type_definition_start, object_type_definition_content>
 {
 };
 
@@ -562,11 +792,36 @@ struct interface_name
 {
 };
 
+struct interface_type_definition_start
+	: seq<opt<seq<description, star<ignored>>>, interface_keyword>
+{
+};
+
+struct interface_type_definition_interface_name
+	: seq<plus<ignored>, interface_name>
+{
+};
+
+struct interface_type_definition_directives
+	: opt<seq<star<ignored>, directives>>
+{
+};
+
+struct interface_type_definition_fields_definition
+	: seq<star<ignored>, fields_definition>
+{
+};
+
+struct interface_type_definition_content
+	: seq<interface_type_definition_interface_name,
+		sor<seq<interface_type_definition_directives, interface_type_definition_fields_definition>
+		, interface_type_definition_directives>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#InterfaceTypeDefinition
 struct interface_type_definition
-	: if_must<seq<opt<seq<description, star<ignored>>>, interface_keyword>, plus<ignored>, interface_name,
-		sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, fields_definition>>
-		, opt<seq<star<ignored>, directives>>>>
+	: if_must<interface_type_definition_start, interface_type_definition_content>
 {
 };
 
@@ -585,17 +840,42 @@ struct union_type
 {
 };
 
+struct union_member_types_start
+	: one<'='>
+{
+};
+
+struct union_member_types_content
+	: seq<opt<seq<star<ignored>, one<'|'>>>, star<ignored>, list<union_type, seq<star<ignored>, one<'|'>, star<ignored>>>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#UnionMemberTypes
 struct union_member_types
-	: if_must<one<'='>, opt<seq<star<ignored>, one<'|'>>>, star<ignored>, list<union_type, seq<star<ignored>, one<'|'>, star<ignored>>>>
+	: if_must<union_member_types_start, union_member_types_content>
+{
+};
+
+struct union_type_definition_start
+	: seq<opt<seq<description, star<ignored>>>, union_keyword>
+{
+};
+
+struct union_type_definition_directives
+	: opt<seq<star<ignored>, directives>>
+{
+};
+
+struct union_type_definition_content
+	: seq<plus<ignored>, union_name,
+		sor<seq<union_type_definition_directives, seq<star<ignored>, union_member_types>>
+		, union_type_definition_directives>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#UnionTypeDefinition
 struct union_type_definition
-	: if_must<seq<opt<seq<description, star<ignored>>>, union_keyword>, plus<ignored>, union_name,
-		sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, union_member_types>>
-		, opt<seq<star<ignored>, directives>>>>
+	: if_must<union_type_definition_start, union_type_definition_content>
 {
 };
 
@@ -609,23 +889,68 @@ struct enum_name
 {
 };
 
+struct enum_value_definition_start
+	: seq<opt<seq<description, star<ignored>>>, enum_value>
+{
+};
+
+struct enum_value_definition_content
+	: opt<seq<star<ignored>, directives>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#EnumValueDefinition
 struct enum_value_definition
-	: seq<opt<seq<description, star<ignored>>>, enum_value, opt<seq<star<ignored>, directives>>>
+	: if_must<enum_value_definition_start, enum_value_definition_content>
+{
+};
+
+struct enum_values_definition_start
+	: one<'{'>
+{
+};
+
+struct enum_values_definition_content
+	: seq<star<ignored>, list<enum_value_definition, plus<ignored>>, star<ignored>, must<one<'}'>>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#EnumValuesDefinition
 struct enum_values_definition
-	: if_must<one<'{'>, star<ignored>, list<enum_value_definition, plus<ignored>>, star<ignored>, one<'}'>>
+	: if_must<enum_values_definition_start, enum_values_definition_content>
+{
+};
+
+struct enum_type_definition_start
+	: seq<opt<seq<description, star<ignored>>>, enum_keyword>
+{
+};
+
+struct enum_type_definition_name
+	: seq<plus<ignored>, enum_name>
+{
+};
+
+struct enum_type_definition_directives
+	: opt<seq<star<ignored>, directives>>
+{
+};
+
+struct enum_type_definition_enum_values_definition
+	: seq<star<ignored>, enum_values_definition>
+{
+};
+
+struct enum_type_definition_content
+	: seq<enum_type_definition_name,
+		sor<seq<enum_type_definition_directives, enum_type_definition_enum_values_definition>
+		, enum_type_definition_directives>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#EnumTypeDefinition
 struct enum_type_definition
-	: if_must<seq<opt<seq<description, star<ignored>>>, enum_keyword>, plus<ignored>, enum_name,
-		sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, enum_values_definition>>
-		, opt<seq<star<ignored>, directives>>>>
+	: if_must<enum_type_definition_start, enum_type_definition_content>
 {
 };
 
@@ -634,25 +959,85 @@ struct input_keyword
 {
 };
 
+struct input_field_definition_start
+	: seq<opt<seq<description, star<ignored>>>, argument_name>
+{
+};
+
+struct input_field_definition_type_name
+	: seq<star<ignored>, one<':'>, star<ignored>, type_name>
+{
+};
+
+struct input_field_definition_default_value
+	: opt<seq<star<ignored>, default_value>>
+{
+};
+
+struct input_field_definition_directives
+	: seq<star<ignored>, directives>
+{
+};
+
+struct input_field_definition_content
+	: seq<input_field_definition_type_name,
+		sor<seq<input_field_definition_default_value, input_field_definition_directives>
+		, input_field_definition_default_value>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#InputValueDefinition
 struct input_field_definition
-	: if_must<seq<opt<seq<description, star<ignored>>>, argument_name>, star<ignored>, one<':'>, star<ignored>, type_name,
-		sor<seq<opt<seq<star<ignored>, default_value>>, seq<star<ignored>, directives>>
-		, opt<seq<star<ignored>, default_value>>>>
+	: if_must<input_field_definition_start, input_field_definition_content>
+{
+};
+
+struct input_fields_definition_start
+	: one<'{'>
+{
+};
+
+struct input_fields_definition_content
+	: seq<star<ignored>, list<input_field_definition, plus<ignored>>, star<ignored>, must<one<'}'>>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#InputFieldsDefinition
 struct input_fields_definition
-	: if_must<one<'{'>, star<ignored>, list<input_field_definition, plus<ignored>>, star<ignored>, one<'}'>>
+	: if_must<input_fields_definition_start, input_fields_definition_content>
+{
+};
+
+struct input_object_type_definition_start
+	: seq<opt<seq<description, star<ignored>>>, input_keyword>
+{
+};
+
+struct input_object_type_definition_object_name
+	: seq<plus<ignored>, object_name>
+{
+};
+
+struct input_object_type_definition_directives
+	: opt<seq<star<ignored>, directives>>
+{
+};
+
+struct input_object_type_definition_fields_definition
+	: seq<star<ignored>, input_fields_definition>
+{
+};
+
+struct input_object_type_definition_content
+	: seq<input_object_type_definition_object_name,
+		sor<seq<input_object_type_definition_directives, input_object_type_definition_fields_definition>
+		, input_object_type_definition_directives>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#InputObjectTypeDefinition
 struct input_object_type_definition
-	: if_must<seq<opt<seq<description, star<ignored>>>, input_keyword>, plus<ignored>, object_name,
-		sor<seq<opt<seq<star<ignored>, directives>>, seq<star<ignored>, input_fields_definition>>
-		, opt<seq<star<ignored>, directives>>>>
+	: if_must<input_object_type_definition_start, input_object_type_definition_content>
 {
 };
 
@@ -697,8 +1082,8 @@ struct type_system_directive_location
 
 // https://facebook.github.io/graphql/June2018/#DirectiveLocation
 struct directive_location
-	: must<sor<executable_directive_location
-	, type_system_directive_location>>
+	: sor<executable_directive_location
+	, type_system_directive_location>
 {
 };
 
@@ -708,9 +1093,19 @@ struct directive_locations
 {
 };
 
+struct directive_definition_start
+	: seq<opt<seq<description, star<ignored>>>, TAO_PEGTL_KEYWORD("directive")>
+{
+};
+
+struct directive_definition_content
+	: seq<star<ignored>, one<'@'>, directive_name, arguments_definition, plus<ignored>, on_keyword, plus<ignored>, directive_locations>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#DirectiveDefinition
 struct directive_definition
-	: if_must<seq<opt<seq<description, star<ignored>>>, TAO_PEGTL_KEYWORD("directive")>, star<ignored>, one<'@'>, directive_name, arguments_definition, plus<ignored>, on_keyword, plus<ignored>, directive_locations>
+	: if_must<directive_definition_start, directive_definition_content>
 {
 };
 
@@ -733,58 +1128,148 @@ struct operation_type_definition
 {
 };
 
+struct schema_extension_start
+	: seq<extend_keyword, plus<ignored>, schema_keyword>
+{
+};
+
+struct schema_extension_operation_type_definitions
+	: seq<one<'{'>, star<ignored>, list<operation_type_definition, plus<ignored>>, star<ignored>, must<one<'}'>>>
+{
+};
+
+struct schema_extension_content
+	: seq<star<ignored>,
+		sor<seq<opt<directives>, schema_extension_operation_type_definitions>
+		, directives>>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#SchemaExtension
 struct schema_extension
-	: if_must<seq<extend_keyword, plus<ignored>, schema_keyword>, star<ignored>,
-		sor<seq<opt<directives>, one<'{'>, star<ignored>, list<operation_type_definition, plus<ignored>>, star<ignored>, one<'}'>>
-		, directives>>
+	: if_must<schema_extension_start, schema_extension_content>
+{
+};
+
+struct scalar_type_extension_start
+	: seq<extend_keyword, plus<ignored>, scalar_keyword>
+{
+};
+
+struct scalar_type_extension_content
+	: seq<star<ignored>, scalar_name, star<ignored>, directives>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#ScalarTypeExtension
 struct scalar_type_extension
-	: if_must<seq<extend_keyword, plus<ignored>, scalar_keyword>, star<ignored>, scalar_name, star<ignored>, directives>
+	: if_must<scalar_type_extension_start, scalar_type_extension_content>
+{
+};
+
+struct object_type_extension_start
+	: seq<extend_keyword, plus<ignored>, type_keyword>
+{
+};
+
+struct object_type_extension_implements_interfaces
+	: seq<plus<ignored>, implements_interfaces>
+{
+};
+
+struct object_type_extension_directives
+	: seq<star<ignored>, directives>
+{
+};
+
+struct object_type_extension_fields_definition
+	: seq<star<ignored>, fields_definition>
+{
+};
+
+struct object_type_extension_content
+	: seq<plus<ignored>, object_name,
+		sor<seq<opt<object_type_extension_implements_interfaces>, opt<object_type_extension_directives>, object_type_extension_fields_definition>
+		, seq<opt<object_type_extension_implements_interfaces>, object_type_extension_directives>
+		, object_type_extension_implements_interfaces>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#ObjectTypeExtension
 struct object_type_extension
-	: if_must<seq<extend_keyword, plus<ignored>, type_keyword>, plus<ignored>, object_name,
-		sor<seq<opt<seq<plus<ignored>, implements_interfaces>>, opt<seq<star<ignored>, directives>>, star<ignored>, fields_definition>
-		, seq<opt<seq<plus<ignored>, implements_interfaces>>, star<ignored>, directives>
-		, seq<plus<ignored>, implements_interfaces>>>
+	: if_must<object_type_extension_start, object_type_extension_content>
+{
+};
+
+struct interface_type_extension_start
+	: seq<extend_keyword, plus<ignored>, interface_keyword>
+{
+};
+
+struct interface_type_extension_content
+	: seq<plus<ignored>, interface_name, star<ignored>,
+		sor<seq<opt<seq<directives, star<ignored>>>, fields_definition>
+		, directives>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#InterfaceTypeExtension
 struct interface_type_extension
-	: if_must<seq<extend_keyword, plus<ignored>, interface_keyword>, plus<ignored>, interface_name, star<ignored>,
-		sor<seq<opt<seq<directives, star<ignored>>>, fields_definition>
+	: if_must<interface_type_extension_start, interface_type_extension_content>
+{
+};
+
+struct union_type_extension_start
+	: seq<extend_keyword, plus<ignored>, union_keyword>
+{
+};
+
+struct union_type_extension_content
+	: seq<plus<ignored>, union_name, star<ignored>,
+		sor<seq<opt<seq<directives, star<ignored>>>, union_member_types>
 		, directives>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#UnionTypeExtension
 struct union_type_extension
-	: if_must<seq<extend_keyword, plus<ignored>, union_keyword>, plus<ignored>, union_name, star<ignored>,
-		sor<seq<opt<seq<directives, star<ignored>>>, union_member_types>
+	: if_must<union_type_extension_start, union_type_extension_content>
+{
+};
+
+struct enum_type_extension_start
+	: seq<extend_keyword, plus<ignored>, enum_keyword>
+{
+};
+
+struct enum_type_extension_content
+	: seq<plus<ignored>, enum_name, star<ignored>,
+		sor<seq<opt<seq<directives, star<ignored>>>, enum_values_definition>
 		, directives>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#EnumTypeExtension
 struct enum_type_extension
-	: if_must<seq<extend_keyword, plus<ignored>, enum_keyword>, plus<ignored>, enum_name, star<ignored>,
-		sor<seq<opt<seq<directives, star<ignored>>>, enum_values_definition>
+	: if_must<enum_type_extension_start, enum_type_extension_content>
+{
+};
+
+struct input_object_type_extension_start
+	: seq<extend_keyword, plus<ignored>, input_keyword>
+{
+};
+
+struct input_object_type_extension_content
+	: seq<plus<ignored>, object_name, star<ignored>,
+		sor<seq<opt<seq<directives, star<ignored>>>, input_fields_definition>
 		, directives>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#InputObjectTypeExtension
 struct input_object_type_extension
-	: if_must<seq<extend_keyword, plus<ignored>, input_keyword>, plus<ignored>, object_name, star<ignored>,
-		sor<seq<opt<seq<directives, star<ignored>>>, input_fields_definition>
-		, directives>>
+	: if_must<input_object_type_extension_start, input_object_type_extension_content>
 {
 };
 
@@ -814,9 +1299,14 @@ struct definition
 {
 };
 
+struct document_content
+	: seq<bof, opt<utf8::bom>, star<ignored>, list<definition, plus<ignored>>, star<ignored>, tao::graphqlpeg::eof>
+{
+};
+
 // https://facebook.github.io/graphql/June2018/#Document
 struct document
-	: must<bof, opt<utf8::bom>, star<ignored>, list<definition, plus<ignored>>, star<ignored>, tao::graphqlpeg::eof>
+	: must<document_content>
 {
 };
 


### PR DESCRIPTION
PEGTL has a default control template class (`normal`) which raises `parse_error` exceptions using the type name of the required rule that was not matched. Some of the types in my GraphQL grammar were ambiguous and hard to map to the grammar rule that expected them.

I refactored the grammar to use a custom control template and I encapsulated all of the `must` or `if_must` rules which are the only valid match in those locations with `*_content` rules that can be unambiguously specialized in the control template class.