### PR TITLE
Simplify grammar

### DIFF
--- a/include/GraphQLGrammar.h
+++ b/include/GraphQLGrammar.h
@@ -121,7 +121,7 @@ struct string_escape_sequence
 };
 
 struct string_quote_character
-	: plus<seq<not_at<backslash_token>, not_at<quote_token>, not_at<ascii::eol>, source_character>>
+	: plus<not_at<backslash_token>, not_at<quote_token>, not_at<ascii::eol>, source_character>
 {
 };
 
@@ -147,7 +147,7 @@ struct block_escape_sequence
 };
 
 struct block_quote_character
-	: plus<seq<not_at<block_quote_token>, not_at<block_escape_sequence>, source_character>>
+	: plus<not_at<block_quote_token>, not_at<block_escape_sequence>, source_character>
 {
 };
 

--- a/include/GraphQLGrammar.h
+++ b/include/GraphQLGrammar.h
@@ -62,7 +62,7 @@ struct ignored
 
 // https://facebook.github.io/graphql/June2018/#sec-Names
 struct name
-	: seq<sor<alpha, one<'_'>>, star<sor<alnum, one<'_'>>>>
+	: identifier
 {
 };
 
@@ -522,7 +522,7 @@ struct fragment_name
 };
 
 struct fragment_token
-	: rep<3, one<'.'>>
+	: ellipsis
 {
 };
 

--- a/include/GraphQLGrammar.h
+++ b/include/GraphQLGrammar.h
@@ -427,7 +427,7 @@ struct type_name
 };
 
 struct variable_content
-	: seq<star<ignored>, one<':'>, star<ignored>, type_name, opt<seq<star<ignored>, default_value>>>
+	: seq<star<ignored>, one<':'>, star<ignored>, type_name, opt<star<ignored>, default_value>>
 {
 };
 
@@ -454,7 +454,7 @@ struct directive_name
 };
 
 struct directive_content
-	: seq<directive_name, opt<seq<star<ignored>, arguments>>>
+	: seq<directive_name, opt<star<ignored>, arguments>>
 {
 };
 
@@ -478,12 +478,12 @@ struct field_name
 };
 
 struct field_start
-	: seq<opt<seq<alias, star<ignored>>>, field_name>
+	: seq<opt<alias, star<ignored>>, field_name>
 {
 };
 
 struct field_arguments
-	: opt<seq<star<ignored>, arguments>>
+	: opt<star<ignored>, arguments>
 {
 };
 
@@ -528,7 +528,7 @@ struct fragment_token
 
 // https://facebook.github.io/graphql/June2018/#FragmentSpread
 struct fragment_spread
-	: seq<star<ignored>, fragment_name, opt<seq<star<ignored>, directives>>>
+	: seq<star<ignored>, fragment_name, opt<star<ignored>, directives>>
 {
 };
 
@@ -545,7 +545,7 @@ struct type_condition
 
 // https://facebook.github.io/graphql/June2018/#InlineFragment
 struct inline_fragment
-	: seq<opt<star<ignored>, type_condition>, opt<seq<star<ignored>, directives>>, star<ignored>, selection_set>
+	: seq<opt<star<ignored>, type_condition>, opt<star<ignored>, directives>, star<ignored>, selection_set>
 {
 };
 
@@ -584,7 +584,7 @@ struct operation_name
 };
 
 struct operation_definition_operation_type_content
-	: seq<opt<seq<plus<ignored>, operation_name>>, opt<seq<star<ignored>, variable_definitions>>, opt<seq<star<ignored>, directives>>, star<ignored>, selection_set>
+	: seq<opt<plus<ignored>, operation_name>, opt<star<ignored>, variable_definitions>, opt<star<ignored>, directives>, star<ignored>, selection_set>
 {
 };
 
@@ -596,7 +596,7 @@ struct operation_definition
 };
 
 struct fragment_definition_content
-	: seq<plus<ignored>, fragment_name, plus<ignored>, type_condition, opt<seq<star<ignored>, directives>>, star<ignored>, selection_set>
+	: seq<plus<ignored>, fragment_name, plus<ignored>, type_condition, opt<star<ignored>, directives>, star<ignored>, selection_set>
 {
 };
 
@@ -630,7 +630,7 @@ struct root_operation_definition
 };
 
 struct schema_definition_content
-	: seq<opt<seq<star<ignored>, directives>>, star<ignored>, one<'{'>, star<ignored>, list<root_operation_definition, plus<ignored>>, star<ignored>, must<one<'}'>>>
+	: seq<opt<star<ignored>, directives>, star<ignored>, one<'{'>, star<ignored>, list<root_operation_definition, plus<ignored>>, star<ignored>, must<one<'}'>>>
 {
 };
 
@@ -657,12 +657,12 @@ struct scalar_name
 };
 
 struct scalar_type_definition_start
-	: seq<opt<seq<description, star<ignored>>>, scalar_keyword>
+	: seq<opt<description, star<ignored>>, scalar_keyword>
 {
 };
 
 struct scalar_type_definition_content
-	: seq<plus<ignored>, scalar_name, opt<seq<star<ignored>, directives>>>
+	: seq<plus<ignored>, scalar_name, opt<star<ignored>, directives>>
 {
 };
 
@@ -696,12 +696,12 @@ struct arguments_definition
 };
 
 struct field_definition_start
-	: seq<opt<seq<description, star<ignored>>>, field_name>
+	: seq<opt<description, star<ignored>>, field_name>
 {
 };
 
 struct field_definition_content
-	: seq<opt<seq<star<ignored>, arguments_definition>>, star<ignored>, one<':'>, star<ignored>, type_name, opt<seq<star<ignored>, directives>>>
+	: seq<opt<star<ignored>, arguments_definition>, star<ignored>, one<':'>, star<ignored>, type_name, opt<star<ignored>, directives>>
 {
 };
 
@@ -728,7 +728,7 @@ struct interface_type
 };
 
 struct implements_interfaces_content
-	: seq<opt<seq<star<ignored>, one<'&'>>>, star<ignored>, list<interface_type, seq<star<ignored>, one<'&'>, star<ignored>>>>
+	: seq<opt<star<ignored>, one<'&'>>, star<ignored>, list<interface_type, seq<star<ignored>, one<'&'>, star<ignored>>>>
 {
 };
 
@@ -744,7 +744,7 @@ struct object_name
 };
 
 struct object_type_definition_start
-	: seq<opt<seq<description, star<ignored>>>, type_keyword>
+	: seq<opt<description, star<ignored>>, type_keyword>
 {
 };
 
@@ -754,7 +754,7 @@ struct object_type_definition_object_name
 };
 
 struct object_type_definition_implements_interfaces
-	: opt<seq<plus<ignored>, implements_interfaces>>
+	: opt<plus<ignored>, implements_interfaces>
 {
 };
 
@@ -793,7 +793,7 @@ struct interface_name
 };
 
 struct interface_type_definition_start
-	: seq<opt<seq<description, star<ignored>>>, interface_keyword>
+	: seq<opt<description, star<ignored>>, interface_keyword>
 {
 };
 
@@ -803,7 +803,7 @@ struct interface_type_definition_interface_name
 };
 
 struct interface_type_definition_directives
-	: opt<seq<star<ignored>, directives>>
+	: opt<star<ignored>, directives>
 {
 };
 
@@ -846,7 +846,7 @@ struct union_member_types_start
 };
 
 struct union_member_types_content
-	: seq<opt<seq<star<ignored>, one<'|'>>>, star<ignored>, list<union_type, seq<star<ignored>, one<'|'>, star<ignored>>>>
+	: seq<opt<star<ignored>, one<'|'>>, star<ignored>, list<union_type, seq<star<ignored>, one<'|'>, star<ignored>>>>
 {
 };
 
@@ -857,12 +857,12 @@ struct union_member_types
 };
 
 struct union_type_definition_start
-	: seq<opt<seq<description, star<ignored>>>, union_keyword>
+	: seq<opt<description, star<ignored>>, union_keyword>
 {
 };
 
 struct union_type_definition_directives
-	: opt<seq<star<ignored>, directives>>
+	: opt<star<ignored>, directives>
 {
 };
 
@@ -890,12 +890,12 @@ struct enum_name
 };
 
 struct enum_value_definition_start
-	: seq<opt<seq<description, star<ignored>>>, enum_value>
+	: seq<opt<description, star<ignored>>, enum_value>
 {
 };
 
 struct enum_value_definition_content
-	: opt<seq<star<ignored>, directives>>
+	: opt<star<ignored>, directives>
 {
 };
 
@@ -922,7 +922,7 @@ struct enum_values_definition
 };
 
 struct enum_type_definition_start
-	: seq<opt<seq<description, star<ignored>>>, enum_keyword>
+	: seq<opt<description, star<ignored>>, enum_keyword>
 {
 };
 
@@ -932,7 +932,7 @@ struct enum_type_definition_name
 };
 
 struct enum_type_definition_directives
-	: opt<seq<star<ignored>, directives>>
+	: opt<star<ignored>, directives>
 {
 };
 
@@ -960,7 +960,7 @@ struct input_keyword
 };
 
 struct input_field_definition_start
-	: seq<opt<seq<description, star<ignored>>>, argument_name>
+	: seq<opt<description, star<ignored>>, argument_name>
 {
 };
 
@@ -970,7 +970,7 @@ struct input_field_definition_type_name
 };
 
 struct input_field_definition_default_value
-	: opt<seq<star<ignored>, default_value>>
+	: opt<star<ignored>, default_value>
 {
 };
 
@@ -1009,7 +1009,7 @@ struct input_fields_definition
 };
 
 struct input_object_type_definition_start
-	: seq<opt<seq<description, star<ignored>>>, input_keyword>
+	: seq<opt<description, star<ignored>>, input_keyword>
 {
 };
 
@@ -1019,7 +1019,7 @@ struct input_object_type_definition_object_name
 };
 
 struct input_object_type_definition_directives
-	: opt<seq<star<ignored>, directives>>
+	: opt<star<ignored>, directives>
 {
 };
 
@@ -1089,12 +1089,12 @@ struct directive_location
 
 // https://facebook.github.io/graphql/June2018/#DirectiveLocations
 struct directive_locations
-	: seq<opt<seq<one<'|'>, star<ignored>>>, list<directive_location, seq<star<ignored>, one<'|'>, star<ignored>>>>
+	: seq<opt<one<'|'>, star<ignored>>, list<directive_location, seq<star<ignored>, one<'|'>, star<ignored>>>>
 {
 };
 
 struct directive_definition_start
-	: seq<opt<seq<description, star<ignored>>>, TAO_PEGTL_KEYWORD("directive")>
+	: seq<opt<description, star<ignored>>, TAO_PEGTL_KEYWORD("directive")>
 {
 };
 
@@ -1208,7 +1208,7 @@ struct interface_type_extension_start
 
 struct interface_type_extension_content
 	: seq<plus<ignored>, interface_name, star<ignored>,
-		sor<seq<opt<seq<directives, star<ignored>>>, fields_definition>
+		sor<seq<opt<directives, star<ignored>>, fields_definition>
 		, directives>>
 {
 };
@@ -1226,7 +1226,7 @@ struct union_type_extension_start
 
 struct union_type_extension_content
 	: seq<plus<ignored>, union_name, star<ignored>,
-		sor<seq<opt<seq<directives, star<ignored>>>, union_member_types>
+		sor<seq<opt<directives, star<ignored>>, union_member_types>
 		, directives>>
 {
 };
@@ -1244,7 +1244,7 @@ struct enum_type_extension_start
 
 struct enum_type_extension_content
 	: seq<plus<ignored>, enum_name, star<ignored>,
-		sor<seq<opt<seq<directives, star<ignored>>>, enum_values_definition>
+		sor<seq<opt<directives, star<ignored>>, enum_values_definition>
 		, directives>>
 {
 };
@@ -1262,7 +1262,7 @@ struct input_object_type_extension_start
 
 struct input_object_type_extension_content
 	: seq<plus<ignored>, object_name, star<ignored>,
-		sor<seq<opt<seq<directives, star<ignored>>>, input_fields_definition>
+		sor<seq<opt<directives, star<ignored>>, input_fields_definition>
 		, directives>>
 {
 };


### PR DESCRIPTION
The PEGTL rules `plus<...>` and `opt<...>` are variadic with an implicit `seq<...>`, hence `opt<seq<...>>` can always be replaced with `opt<...>`, likewise for `plus<seq<...>>`.