### PR TITLE
Fix samples build with make and separate build dir

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/unified)
+
 # todaygraphql
 add_custom_command(
   OUTPUT
@@ -17,6 +19,8 @@ add_custom_command(
 # separate
 file(STRINGS separate/today_schema_files SEPARATE_SCHEMA_CPP)
 list(TRANSFORM SEPARATE_SCHEMA_CPP PREPEND separate/)
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/separate)
 
 add_custom_command(
   OUTPUT


### PR DESCRIPTION
`MSBuild` and `Ninja` seem to handle creating the sub-directories under `CMAKE_CURRENT_BINARY_DIR` without explicitly creating them, but regular `make` does not. add a couple of lines to the `CMakeLists.txt` to create the directories there if they do not exist.