### PR TITLE
Fixed generator to correctly add the namespace for input types

### DIFF
--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -3038,9 +3038,12 @@ std::string Generator::getArgumentAccessType(const InputField & argument) const 
 	switch (argument.fieldType)
 	{
 		case InputFieldType::Builtin:
+			argumentType << getCppType(argument.type);
+			break;
+
 		case InputFieldType::Enum:
 		case InputFieldType::Input:
-			argumentType << getCppType(argument.type);
+			argumentType << _schemaNamespace << R"cpp(::)cpp" << getCppType(argument.type);
 			break;
 
 		case InputFieldType::Scalar:


### PR DESCRIPTION
When parsing an `input` type as a parameter, the generator previously did not add the namespace, causing the name to not be resolved. This appears to fix that. Please let me know if there is some edge case where this breaks something.