### PR TITLE
Handle blank lines in the sample app and fix problems with schema_exception

### DIFF
--- a/samples/today/sample.cpp
+++ b/samples/today/sample.cpp
@@ -5,6 +5,7 @@
 
 #include <graphqlservice/JSONResponse.h>
 
+#include <iterator>
 #include <iostream>
 #include <stdexcept>
 #include <cstdio>
@@ -66,13 +67,8 @@ int main(int argc, char** argv)
 		}
 		else
 		{
-			std::string input;
-			std::string line;
-
-			while (std::getline(std::cin, line))
-			{
-				input.append(line);
-			}
+			std::istream_iterator<char> start{ std::cin >> std::noskipws }, end{};
+			std::string input{ start, end };
 
 			query = peg::parseString(std::move(input));
 		}

--- a/src/GraphQLResponse.cpp
+++ b/src/GraphQLResponse.cpp
@@ -69,37 +69,36 @@ struct TypedData : std::variant<
 	
 Value::Value(Type type /*= Type::Null*/)
 	: _type(type)
-	, _data(std::make_unique<TypedData>())
 {
 	switch (type)
 	{
 		case Type::Map:
-			*_data = { std::make_optional<MapData>() };
+			_data = std::make_unique<TypedData>(TypedData{ std::make_optional<MapData>() });
 			break;
 
 		case Type::List:
-			*_data = { std::make_optional<ListData>() };
+			_data = std::make_unique<TypedData>(TypedData{ std::make_optional<ListData>() });
 			break;
 
 		case Type::String:
 		case Type::EnumValue:
-			*_data = { std::make_optional<StringOrEnumData>() };
+			_data = std::make_unique<TypedData>(TypedData{ std::make_optional<StringOrEnumData>() });
 			break;
 
 		case Type::Scalar:
-			*_data = { std::make_optional<ScalarData>() };
+			_data = std::make_unique<TypedData>(TypedData{ std::make_optional<ScalarData>() });
 			break;
 
 		case Type::Boolean:
-			*_data = { BooleanType{ false } };
+			_data = std::make_unique<TypedData>(TypedData{ BooleanType{ false } });
 			break;
 
 		case Type::Int:
-			*_data = { IntType{ 0 } };
+			_data = std::make_unique<TypedData>(TypedData{ IntType{ 0 } });
 			break;
 
 		case Type::Float:
-			*_data = { FloatType{ 0.0 } };
+			_data = std::make_unique<TypedData>(TypedData{ FloatType{ 0.0 } });
 			break;
 
 		default:
@@ -158,8 +157,12 @@ Value::Value(const Value& other)
 
 Value& Value::operator=(Value&& rhs) noexcept
 {
-	const_cast<Type&>(_type) = rhs._type;
-	_data = std::move(rhs._data);
+	if (&rhs != this)
+	{
+		const_cast<Type&>(_type) = rhs._type;
+		_data = std::move(rhs._data);
+	}
+
 	return *this;
 }
 

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -1081,6 +1081,16 @@ std::future<response::Value> Object::resolve(const SelectionSetParams & selectio
 						}
 					}
 				}
+				catch (schema_exception & scx)
+				{
+					auto messages = scx.getErrors().release<response::ListType>();
+
+					errors.reserve(errors.size() + messages.size());
+					for (auto& error : messages)
+					{
+						errors.emplace_back(std::move(error));
+					}
+				}
 				catch (const std::exception & ex)
 				{
 					std::ostringstream message;


### PR DESCRIPTION
This turned into a bigger change than I expected. While testing the input for the sample app, I tried a bunch of queries that threw `schema_exception` and eventually crashed. Part of the problem was that I deleted the copy constructor on schema_exception, but that's part of the interface for `std::exception` which is used by `std::exception_ptr`, and it ended up dropping the `_errors` member in the copy operation.

Once that was fixed, I noticed that higher levels were eating `schema_exception` along with `std::exception` and turning more specific error messages into "Unknown error" messages at that level of the query. I added `catch (schema_exception &)` blocks to each of those spots, and instead of turning it into a single generic error message it will either propagate the schema_exception or append its error messages to the list of errors that will later be rethrown in a `schema_exception`.