### PR TITLE
Fix #72

### DIFF
--- a/include/graphqlservice/GraphQLGrammar.h
+++ b/include/graphqlservice/GraphQLGrammar.h
@@ -1305,7 +1305,7 @@ struct definition
 };
 
 struct document_content
-	: seq<bof, opt<utf8::bom>, star<ignored>, list<definition, plus<ignored>>, star<ignored>, tao::graphqlpeg::eof>
+	: seq<bof, opt<utf8::bom>, star<ignored>, list<definition, star<ignored>>, star<ignored>, tao::graphqlpeg::eof>
 {
 };
 


### PR DESCRIPTION
If multiple sequential definitions have unambiguous adjacent tokens, they don't need to include any whitespace or ignored characters (e.g. commas) in between the definitions. The separator for the list of definitions in the document should look for 0 or more ignored characters (`star`) instead of at least 1 (`plus`).