### PR TITLE
Fix the CI build on Windows

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -54,6 +54,7 @@ if(GRAPHQL_UPDATE_SAMPLES)
       ${CMAKE_CURRENT_BINARY_DIR}/unified/TodaySchema.cpp
       ${CMAKE_CURRENT_BINARY_DIR}/unified/TodaySchema.h
       ${CMAKE_CURRENT_BINARY_DIR}/separate/today_schema_files
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Updating sample files")
 
   add_custom_target(update_samples ALL

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -34,27 +34,20 @@ if(GRAPHQL_UPDATE_SAMPLES)
   add_custom_target(separate_schema_files ALL
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/separate/today_schema_files)
 
-  file(GLOB OLD_INTROSPECTION_FILES ${CMAKE_CURRENT_SOURCE_DIR}/introspection/*)
   file(GLOB OLD_UNIFIED_FILES ${CMAKE_CURRENT_SOURCE_DIR}/unified/*)
   file(GLOB OLD_SEPARATE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/separate/*)
 
   add_custom_command(
     OUTPUT updated_samples
-    COMMAND ${CMAKE_COMMAND} -E remove -f ${OLD_INTROSPECTION_FILES}
-    COMMAND ${CMAKE_COMMAND} -E copy ../IntrospectionSchema.cpp ${CMAKE_CURRENT_SOURCE_DIR}/introspection/
-    COMMAND ${CMAKE_COMMAND} -E copy ../include/graphqlservice/IntrospectionSchema.h ${CMAKE_CURRENT_SOURCE_DIR}/introspection/
     COMMAND ${CMAKE_COMMAND} -E remove -f ${OLD_UNIFIED_FILES}
     COMMAND ${CMAKE_COMMAND} -E copy_directory unified/ ${CMAKE_CURRENT_SOURCE_DIR}/unified/
     COMMAND ${CMAKE_COMMAND} -E remove -f ${OLD_SEPARATE_FILES}
     COMMAND ${CMAKE_COMMAND} -E copy_directory separate/ ${CMAKE_CURRENT_SOURCE_DIR}/separate/
     COMMAND ${CMAKE_COMMAND} -E touch updated_samples
     DEPENDS 
-      ${CMAKE_CURRENT_BINARY_DIR}/../IntrospectionSchema.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/IntrospectionSchema.h
       ${CMAKE_CURRENT_BINARY_DIR}/unified/TodaySchema.cpp
       ${CMAKE_CURRENT_BINARY_DIR}/unified/TodaySchema.h
       ${CMAKE_CURRENT_BINARY_DIR}/separate/today_schema_files
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Updating sample files")
 
   add_custom_target(update_samples ALL

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,24 @@ add_custom_command(
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
   COMMENT "Generating IntrospectionSchema files")
 
+if(GRAPHQL_UPDATE_SAMPLES)
+  file(GLOB OLD_INTROSPECTION_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../samples/introspection/*)
+
+  add_custom_command(
+    OUTPUT updated_introspection
+    COMMAND ${CMAKE_COMMAND} -E remove -f ${OLD_INTROSPECTION_FILES}
+    COMMAND ${CMAKE_COMMAND} -E copy ../IntrospectionSchema.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../samples/introspection/
+    COMMAND ${CMAKE_COMMAND} -E copy ../include/graphqlservice/IntrospectionSchema.h ${CMAKE_CURRENT_SOURCE_DIR}/../samples/introspection/
+    COMMAND ${CMAKE_COMMAND} -E touch updated_introspection
+    DEPENDS 
+      ${CMAKE_CURRENT_BINARY_DIR}/../IntrospectionSchema.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/IntrospectionSchema.h
+    COMMENT "Updating introspection files")
+
+  add_custom_target(update_introspection ALL
+    DEPENDS updated_introspection)
+endif()
+
 # graphqlservice
 add_library(graphqlservice
   $<TARGET_OBJECTS:graphqlresponse>


### PR DESCRIPTION
There seems to be a dependency ordering issue on Windows with MSBuild where it's not generating the `IntrospectionSchema.*` files before it tries to update the samples, or maybe the relative paths are wrong.

This change separates the `update_samples` custom command/target into `update_samples` and `update_introspection`, so updating the `IntrospectionSchema.*` takes place in the same `src/CMakeLists.txt` and working directory as the code generator which creates them.