### PR TITLE
CMake tweaks to be compatible with earlier versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,6 @@ settings.json
 /test/pegtl_tests
 /test/response_tests
 /test/today_tests
-build
+build/
+install/
+isenseconfig/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,10 @@ if(NOT pegtl_FOUND)
   add_subdirectory(PEGTL)
 endif()
 
-add_subdirectory(src)
-
 option(GRAPHQL_UPDATE_SAMPLES "Regenerate the sample schema sources whether or not we're building the tests." ON)
+
+add_subdirectory(cmake)
+add_subdirectory(src)
 
 if(GRAPHQL_BUILD_TESTS OR GRAPHQL_UPDATE_SAMPLES)
   add_subdirectory(samples)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+cmake_minimum_required(VERSION 3.8.2)
+
+# Enable version checks in find_package
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(${PROJECT_NAME}-config-version.cmake COMPATIBILITY SameMajorVersion)
+
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+  DESTINATION ${GRAPHQL_INSTALL_CMAKE_DIR}/${PROJECT_NAME})

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -55,11 +55,13 @@ if(GRAPHQL_UPDATE_SAMPLES)
 endif()
 
 # sample
-file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/separate/today_schema_files SEPARATE_SCHEMA_CPP)
-list(TRANSFORM SEPARATE_SCHEMA_CPP PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/separate/)
+set(SEPARATE_SCHEMA_PATHS "")
+file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/separate/today_schema_files SEPARATE_SCHEMA_FILES)
+foreach(CPP_FILE IN LISTS SEPARATE_SCHEMA_FILES)
+  list(APPEND SEPARATE_SCHEMA_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/separate/${CPP_FILE}")
+endforeach(CPP_FILE)
 
-add_library(separateschema OBJECT ${SEPARATE_SCHEMA_CPP})
-target_link_libraries(separateschema PUBLIC graphqlservice)
+add_library(separateschema OBJECT ${SEPARATE_SCHEMA_PATHS})
 target_include_directories(separateschema PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/../include
   ${CMAKE_CURRENT_SOURCE_DIR}/../include
@@ -71,9 +73,13 @@ if(GRAPHQL_UPDATE_SAMPLES)
   add_dependencies(separateschema update_samples)
 endif()
 
-add_library(separategraphql today/SeparateToday.cpp)
-target_link_libraries(separategraphql PUBLIC separateschema)
-target_include_directories(separategraphql PUBLIC today)
+add_library(separategraphql
+  today/SeparateToday.cpp
+  $<TARGET_OBJECTS:separateschema>)
+target_link_libraries(separategraphql PUBLIC graphqlservice)
+target_include_directories(separategraphql PUBLIC
+  $<TARGET_PROPERTY:separateschema,INCLUDE_DIRECTORIES>
+  today)
 
 add_executable(sample today/sample.cpp)
 target_link_libraries(sample PRIVATE
@@ -87,7 +93,6 @@ target_include_directories(sample PRIVATE
 if(GRAPHQL_BUILD_TESTS)
   # tests
   add_library(unifiedschema OBJECT unified/TodaySchema.cpp)
-  target_link_libraries(unifiedschema PUBLIC graphqlservice)
   target_include_directories(unifiedschema PUBLIC
     ${CMAKE_CURRENT_BINARY_DIR}/../include
     ${CMAKE_CURRENT_SOURCE_DIR}/../include
@@ -100,7 +105,11 @@ if(GRAPHQL_BUILD_TESTS)
     add_dependencies(unifiedschema update_samples)
   endif()
 
-  add_library(unifiedgraphql today/UnifiedToday.cpp)
-  target_link_libraries(unifiedgraphql PUBLIC unifiedschema)
-  target_include_directories(unifiedgraphql PUBLIC today)
+  add_library(unifiedgraphql
+    today/UnifiedToday.cpp
+    $<TARGET_OBJECTS:unifiedschema>)
+  target_link_libraries(unifiedgraphql PUBLIC graphqlservice)
+  target_include_directories(unifiedgraphql PUBLIC
+    $<TARGET_PROPERTY:unifiedschema,INCLUDE_DIRECTORIES>
+    today)
 endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -62,6 +62,7 @@ foreach(CPP_FILE IN LISTS SEPARATE_SCHEMA_FILES)
 endforeach(CPP_FILE)
 
 add_library(separateschema OBJECT ${SEPARATE_SCHEMA_PATHS})
+add_dependencies(separateschema graphqlservice)
 target_include_directories(separateschema PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/../include
   ${CMAKE_CURRENT_SOURCE_DIR}/../include
@@ -94,6 +95,7 @@ target_include_directories(sample PRIVATE
 if(GRAPHQL_BUILD_TESTS)
   # tests
   add_library(unifiedschema OBJECT unified/TodaySchema.cpp)
+  add_dependencies(unifiedschema graphqlservice)
   target_include_directories(unifiedschema PUBLIC
     ${CMAKE_CURRENT_BINARY_DIR}/../include
     ${CMAKE_CURRENT_SOURCE_DIR}/../include

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -76,6 +76,7 @@ endif()
 add_library(separategraphql
   today/SeparateToday.cpp
   $<TARGET_OBJECTS:separateschema>)
+add_dependencies(separategraphql separateschema)
 target_link_libraries(separategraphql PUBLIC graphqlservice)
 target_include_directories(separategraphql PUBLIC
   $<TARGET_PROPERTY:separateschema,INCLUDE_DIRECTORIES>
@@ -98,7 +99,6 @@ if(GRAPHQL_BUILD_TESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/../include
     ${CMAKE_CURRENT_SOURCE_DIR}/../PEGTL/include
     unified)
-  add_bigobj_flag(unifiedschema)
 
   if(GRAPHQL_UPDATE_SAMPLES)
     # wait for the sample update to complete
@@ -108,8 +108,10 @@ if(GRAPHQL_BUILD_TESTS)
   add_library(unifiedgraphql
     today/UnifiedToday.cpp
     $<TARGET_OBJECTS:unifiedschema>)
+  add_dependencies(unifiedgraphql unifiedschema)
   target_link_libraries(unifiedgraphql PUBLIC graphqlservice)
   target_include_directories(unifiedgraphql PUBLIC
     $<TARGET_PROPERTY:unifiedschema,INCLUDE_DIRECTORIES>
     today)
+  add_bigobj_flag(unifiedgraphql)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ add_custom_command(
   OUTPUT
     ${CMAKE_CURRENT_BINARY_DIR}/../IntrospectionSchema.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/IntrospectionSchema.h
+  COMMAND ${CMAKE_COMMAND} -E make_directory include/graphqlservice
   COMMAND schemagen --introspection
   DEPENDS schemagen
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
@@ -84,7 +85,7 @@ add_library(graphqlservice
 target_link_libraries(graphqlservice PUBLIC
   graphqlpeg
   Threads::Threads)
-target_include_directories(graphqlservice PRIVATE
+target_include_directories(graphqlservice SYSTEM PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}/../include)
 
 # RapidJSON is the only option for JSON serialization used in this project, but if you want
@@ -139,15 +140,6 @@ install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/IntrospectionSchema.h
   DESTINATION ${GRAPHQL_INSTALL_INCLUDE_DIR}/graphqlservice
   CONFIGURATIONS Release)
-
-# Enable version checks in find_package
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(cmake/${PROJECT_NAME}-config-version.cmake COMPATIBILITY SameMajorVersion)
-
-install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/${PROJECT_NAME}-config.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
-  DESTINATION ${GRAPHQL_INSTALL_CMAKE_DIR}/${PROJECT_NAME})
 
 install(EXPORT cppgraphqlgen-targets
   NAMESPACE cppgraphqlgen::


### PR DESCRIPTION
I started building with Visual Studio on Windows Subsystem for Linux and found that when it tried to use CMake 3.10 which is the default on Ubuntu bionic, there were a few modern syntax options that didn't work, particularly with Unix Makefiles.

In particular, you can't link against an `OBJECT` library in CMake 3.10 (or 3.8.2, which is what I specified a long time ago in the `CMakeLists.txt` files). Switching to linking against the `TARGET_OBJECTS` and sorting out the `PUBLIC` include directories, dependencies, etc. was more complicated.

I also couldn't use `list(TRANSFORM ...)` to build the full paths to the generated schema files in one line, so I replaced that with a `foreach(... IN LISTS ...)` loop.