### PR TITLE
BUG: Instrospection query with non-valid type name crashes

### DIFF
--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -32,6 +32,11 @@ void Schema::AddType(response::StringType&& name, std::shared_ptr<object::Type> 
 
 const std::shared_ptr<object::Type>& Schema::LookupType(const response::StringType& name) const
 {
+	if (_typeMap.find(name) == _typeMap.cend())
+	{
+		throw service::schema_exception { { "type not found" } };
+	}
+
 	return _types[_typeMap.find(name)->second].second;
 }
 


### PR DESCRIPTION
BUG: When I make an instrospection query with non-valid type name as parameter the program crashes.

I've see that the method 'Schema::LookupType' tries to find the name of
the type in the '_typeMap' map, but it assumes that always exists, and
this is not correct.

Result: Crash (Core dump).
Reproducible: Always.
O.S.: GNU/Linux (OpenSuse)
GCC version: 9.2.1

schema.graphql
```
schema {
    query: Query
}

"My description"
type Query {
    myData: String
}
```

valid_query_file.graphql
```
{
    __type(name: "Query") {
        description
    }
}
```

crash_query_file.graphql
```
{
    __type(name: "Other") {
        description
    }
}
```