### PR TITLE
CMake fixes to skip regenerating IntrospectionSchema.* in vcpkg

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,17 +48,17 @@ install(TARGETS schemagen
   CONFIGURATIONS Release)
 
 # introspection
-add_custom_command(
-  OUTPUT
-    ${CMAKE_CURRENT_BINARY_DIR}/../IntrospectionSchema.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/IntrospectionSchema.h
-  COMMAND ${CMAKE_COMMAND} -E make_directory include/graphqlservice
-  COMMAND schemagen --introspection
-  DEPENDS schemagen
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
-  COMMENT "Generating IntrospectionSchema files")
-
 if(GRAPHQL_UPDATE_SAMPLES)
+  add_custom_command(
+    OUTPUT
+      ${CMAKE_CURRENT_BINARY_DIR}/../IntrospectionSchema.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/IntrospectionSchema.h
+    COMMAND ${CMAKE_COMMAND} -E make_directory include/graphqlservice
+    COMMAND schemagen --introspection
+    DEPENDS schemagen
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
+    COMMENT "Generating IntrospectionSchema files")
+
   file(GLOB OLD_INTROSPECTION_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../samples/introspection/*)
 
   add_custom_command(
@@ -74,6 +74,15 @@ if(GRAPHQL_UPDATE_SAMPLES)
 
   add_custom_target(update_introspection ALL
     DEPENDS updated_introspection)
+else()
+  add_custom_command(
+    OUTPUT
+      ${CMAKE_CURRENT_BINARY_DIR}/../IntrospectionSchema.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/IntrospectionSchema.h
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/../samples/introspection/IntrospectionSchema.cpp .
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/../samples/introspection/IntrospectionSchema.h include/graphqlservice
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
+    COMMENT "Copying IntrospectionSchema files")
 endif()
 
 # graphqlservice


### PR DESCRIPTION
Updating `vcpkg` to the v3.1.0 release uncovered a dependency in CMake on Windows. Generating the `IntrospectionSchema.*` files as part of the build depends on `schemagen`, and when `vcpkg` builds it it hasn't run `appLocal.ps1` to copy the runtime dependencies for `schemagen` to the build directory yet. So `schemagen.exe` fails to load `boost-program-options.dll` and breaks the build.

Workaround is to just copy the latest version of `IntrospectionSchema.*` from the `samples` directory to the build directory if `GRAPHQL_UPDATE_SAMPLES` is turned off, as it is in the `vcpkg` build.