### PR TITLE
Use explicit DLL exports on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 cmake_minimum_required(VERSION 3.8.2)
-project(cppgraphqlgen VERSION 3.0.0)
+project(cppgraphqlgen VERSION 3.2.0)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -11,11 +11,6 @@ set(GRAPHQL_INSTALL_TOOLS_DIR bin CACHE PATH "schemagen install directory")
 set(GRAPHQL_INSTALL_CMAKE_DIR lib/cmake CACHE PATH "CMake config files install directory")
 
 option(BUILD_SHARED_LIBS "Build shared libraries instead of static libs" OFF)
-
-if(WIN32 AND BUILD_SHARED_LIBS)
-  # Let CMake figure out the exports for the SHARED library (DLL) on Windows.
-  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-endif()
 
 function(add_bigobj_flag target)
   if(MSVC)

--- a/include/graphqlservice/GraphQLParse.h
+++ b/include/graphqlservice/GraphQLParse.h
@@ -6,6 +6,16 @@
 #ifndef GRAPHQLPARSE_H
 #define GRAPHQLPARSE_H
 
+#ifdef GRAPHQL_DLLEXPORTS
+	#ifdef IMPL_GRAPHQLPEG_DLL
+		#define GRAPHQLPEG_EXPORT __declspec(dllexport)
+	#else // !IMPL_GRAPHQLPEG_DLL
+		#define GRAPHQLPEG_EXPORT __declspec(dllimport)
+	#endif // !IMPL_GRAPHQLPEG_DLL
+#else // !GRAPHQL_DLLEXPORTS
+	#define GRAPHQLPEG_EXPORT
+#endif // !GRAPHQL_DLLEXPORTS
+
 #include <memory>
 #include <string_view>
 
@@ -22,12 +32,12 @@ struct ast
 	bool validated = false;
 };
 
-ast parseString(std::string_view input);
-ast parseFile(std::string_view filename);
+GRAPHQLPEG_EXPORT ast parseString(std::string_view input);
+GRAPHQLPEG_EXPORT ast parseFile(std::string_view filename);
 
 } /* namespace peg */
 
-peg::ast operator "" _graphql(const char* text, size_t size);
+GRAPHQLPEG_EXPORT peg::ast operator "" _graphql(const char* text, size_t size);
 
 } /* namespace graphql */
 

--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -6,6 +6,16 @@
 #ifndef GRAPHQLRESPONSE_H
 #define GRAPHQLRESPONSE_H
 
+#ifdef GRAPHQL_DLLEXPORTS
+	#ifdef IMPL_GRAPHQLRESPONSE_LIB
+		#define GRAPHQLRESPONSE_EXPORT __declspec(dllexport)
+	#else // !IMPL_GRAPHQLRESPONSE_LIB
+		#define GRAPHQLRESPONSE_EXPORT __declspec(dllimport)
+	#endif // !IMPL_GRAPHQLRESPONSE_LIB
+#else // !GRAPHQL_DLLEXPORTS
+	#define GRAPHQLRESPONSE_EXPORT
+#endif // !GRAPHQL_DLLEXPORTS
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -100,7 +110,7 @@ struct ValueTypeTraits<IdType>
 struct TypedData;
 
 // Represent a discriminated union of GraphQL response value types.
-struct Value
+struct GRAPHQLRESPONSE_EXPORT Value
 {
 	Value(Type type = Type::Null);
 	~Value();
@@ -177,6 +187,26 @@ private:
 	const Type _type;
 	std::unique_ptr<TypedData> _data;
 };
+
+#ifdef GRAPHQL_DLLEXPORTS
+// Export all of the specialized template methods
+template <> GRAPHQLRESPONSE_EXPORT void Value::set<StringType>(StringType&& value);
+template <> GRAPHQLRESPONSE_EXPORT void Value::set<BooleanType>(BooleanType value);
+template <> GRAPHQLRESPONSE_EXPORT void Value::set<IntType>(IntType value);
+template <> GRAPHQLRESPONSE_EXPORT void Value::set<FloatType>(FloatType value);
+template <> GRAPHQLRESPONSE_EXPORT void Value::set<ScalarType>(ScalarType&& value);
+template <> GRAPHQLRESPONSE_EXPORT const MapType& Value::get<MapType>() const;
+template <> GRAPHQLRESPONSE_EXPORT const ListType& Value::get<ListType>() const;
+template <> GRAPHQLRESPONSE_EXPORT const StringType& Value::get<StringType>() const;
+template <> GRAPHQLRESPONSE_EXPORT BooleanType Value::get<BooleanType>() const;
+template <> GRAPHQLRESPONSE_EXPORT IntType Value::get<IntType>() const;
+template <> GRAPHQLRESPONSE_EXPORT FloatType Value::get<FloatType>() const;
+template <> GRAPHQLRESPONSE_EXPORT const ScalarType& Value::get<ScalarType>() const;
+template <> GRAPHQLRESPONSE_EXPORT MapType Value::release<MapType>();
+template <> GRAPHQLRESPONSE_EXPORT ListType Value::release<ListType>();
+template <> GRAPHQLRESPONSE_EXPORT StringType Value::release<StringType>();
+template <> GRAPHQLRESPONSE_EXPORT ScalarType Value::release<ScalarType>();
+#endif // GRAPHQL_DLLEXPORTS
 
 } /* namespace graphql::response */
 

--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -7,11 +7,11 @@
 #define GRAPHQLRESPONSE_H
 
 #ifdef GRAPHQL_DLLEXPORTS
-	#ifdef IMPL_GRAPHQLRESPONSE_LIB
+	#ifdef IMPL_GRAPHQLRESPONSE_DLL
 		#define GRAPHQLRESPONSE_EXPORT __declspec(dllexport)
-	#else // !IMPL_GRAPHQLRESPONSE_LIB
+	#else // !IMPL_GRAPHQLRESPONSE_DLL
 		#define GRAPHQLRESPONSE_EXPORT __declspec(dllimport)
-	#endif // !IMPL_GRAPHQLRESPONSE_LIB
+	#endif // !IMPL_GRAPHQLRESPONSE_DLL
 #else // !GRAPHQL_DLLEXPORTS
 	#define GRAPHQLRESPONSE_EXPORT
 #endif // !GRAPHQL_DLLEXPORTS
@@ -110,49 +110,49 @@ struct ValueTypeTraits<IdType>
 struct TypedData;
 
 // Represent a discriminated union of GraphQL response value types.
-struct GRAPHQLRESPONSE_EXPORT Value
+struct Value
 {
-	Value(Type type = Type::Null);
-	~Value();
+	GRAPHQLRESPONSE_EXPORT Value(Type type = Type::Null);
+	GRAPHQLRESPONSE_EXPORT ~Value();
 
-	explicit Value(const char* value);
-	explicit Value(StringType&& value);
-	explicit Value(BooleanType value);
-	explicit Value(IntType value);
-	explicit Value(FloatType value);
+	GRAPHQLRESPONSE_EXPORT explicit Value(const char* value);
+	GRAPHQLRESPONSE_EXPORT explicit Value(StringType&& value);
+	GRAPHQLRESPONSE_EXPORT explicit Value(BooleanType value);
+	GRAPHQLRESPONSE_EXPORT explicit Value(IntType value);
+	GRAPHQLRESPONSE_EXPORT explicit Value(FloatType value);
 
-	Value(Value&& other) noexcept;
-	explicit Value(const Value& other);
+	GRAPHQLRESPONSE_EXPORT Value(Value&& other) noexcept;
+	GRAPHQLRESPONSE_EXPORT explicit Value(const Value& other);
 
-	Value& operator=(Value&& rhs) noexcept;
-	Value& operator=(const Value& rhs) = delete;
+	GRAPHQLRESPONSE_EXPORT Value& operator=(Value&& rhs) noexcept;
+	GRAPHQLRESPONSE_EXPORT Value& operator=(const Value& rhs) = delete;
 
 	// Comparison
-	bool operator==(const Value& rhs) const noexcept;
-	bool operator!=(const Value& rhs) const noexcept;
+	GRAPHQLRESPONSE_EXPORT bool operator==(const Value& rhs) const noexcept;
+	GRAPHQLRESPONSE_EXPORT bool operator!=(const Value& rhs) const noexcept;
 
 	// Check the Type
-	Type type() const noexcept;
+	GRAPHQLRESPONSE_EXPORT Type type() const noexcept;
 
 	// JSON doesn't distinguish between Type::String and Type::EnumValue, so if this value comes
 	// from JSON and it's a string we need to track the fact that it can be interpreted as either.
-	Value&& from_json() noexcept;
-	bool maybe_enum() const noexcept;
+	GRAPHQLRESPONSE_EXPORT Value&& from_json() noexcept;
+	GRAPHQLRESPONSE_EXPORT bool maybe_enum() const noexcept;
 
 	// Valid for Type::Map or Type::List
-	void reserve(size_t count);
-	size_t size() const;
+	GRAPHQLRESPONSE_EXPORT void reserve(size_t count);
+	GRAPHQLRESPONSE_EXPORT size_t size() const;
 
 	// Valid for Type::Map
-	void emplace_back(std::string&& name, Value&& value);
-	MapType::const_iterator find(const std::string& name) const;
-	MapType::const_iterator begin() const;
-	MapType::const_iterator end() const;
-	const Value& operator[](const std::string& name) const;
+	GRAPHQLRESPONSE_EXPORT void emplace_back(std::string&& name, Value&& value);
+	GRAPHQLRESPONSE_EXPORT MapType::const_iterator find(const std::string& name) const;
+	GRAPHQLRESPONSE_EXPORT MapType::const_iterator begin() const;
+	GRAPHQLRESPONSE_EXPORT MapType::const_iterator end() const;
+	GRAPHQLRESPONSE_EXPORT const Value& operator[](const std::string& name) const;
 
 	// Valid for Type::List
-	void emplace_back(Value&& value);
-	const Value& operator[](size_t index) const;
+	GRAPHQLRESPONSE_EXPORT void emplace_back(Value&& value);
+	GRAPHQLRESPONSE_EXPORT const Value& operator[](size_t index) const;
 
 	// Specialized for all single-value Types.
 	template <typename ValueType>

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -55,7 +55,7 @@ using field_path = std::queue<path_segment>;
 
 GRAPHQLSERVICE_EXPORT void addErrorPath(field_path&& path, response::Value& error);
 
-struct GRAPHQLSERVICE_EXPORT schema_error
+struct schema_error
 {
 	std::string message;
 	schema_location location;
@@ -65,21 +65,21 @@ struct GRAPHQLSERVICE_EXPORT schema_error
 GRAPHQLSERVICE_EXPORT response::Value buildErrorValues(const std::vector<schema_error>& structuredErrors);
 
 // This exception bubbles up 1 or more error messages to the JSON results.
-class GRAPHQLSERVICE_EXPORT schema_exception : public std::exception
+class schema_exception : public std::exception
 {
 public:
-	explicit schema_exception(std::vector<schema_error>&& structuredErrors);
-	explicit schema_exception(std::vector<std::string>&& messages);
+	GRAPHQLSERVICE_EXPORT explicit schema_exception(std::vector<schema_error>&& structuredErrors);
+	GRAPHQLSERVICE_EXPORT explicit schema_exception(std::vector<std::string>&& messages);
 
 	schema_exception() = delete;
 
-	const char* what() const noexcept override;
+	GRAPHQLSERVICE_EXPORT const char* what() const noexcept override;
 
-	const std::vector<schema_error>& getStructuredErrors() const noexcept;
-	std::vector<schema_error> getStructuredErrors() noexcept;
+	GRAPHQLSERVICE_EXPORT const std::vector<schema_error>& getStructuredErrors() const noexcept;
+	GRAPHQLSERVICE_EXPORT std::vector<schema_error> getStructuredErrors() noexcept;
 
-	const response::Value& getErrors() const noexcept;
-	response::Value getErrors() noexcept;
+	GRAPHQLSERVICE_EXPORT const response::Value& getErrors() const noexcept;
+	GRAPHQLSERVICE_EXPORT response::Value getErrors() noexcept;
 
 private:
 	static std::vector<schema_error> convertMessages(std::vector<std::string>&& messages) noexcept;
@@ -92,7 +92,7 @@ private:
 // per-request state that you want to maintain throughout the request (e.g. optimizing or batching
 // backend requests), you can inherit from RequestState and pass it to Request::resolve to correlate the
 // asynchronous/recursive callbacks and accumulate state in it.
-struct GRAPHQLSERVICE_EXPORT RequestState : std::enable_shared_from_this<RequestState>
+struct RequestState : std::enable_shared_from_this<RequestState>
 {
 };
 
@@ -114,7 +114,7 @@ constexpr std::string_view strSubscription { "subscription"sv };
 }
 
 // Pass a common bundle of parameters to all of the generated Object::getField accessors in a SelectionSet
-struct GRAPHQLSERVICE_EXPORT SelectionSetParams
+struct SelectionSetParams
 {
 	// The lifetime of each of these borrowed references is guaranteed until the future returned
 	// by the accessor is resolved or destroyed. They are owned by the OperationData shared pointer. 
@@ -136,9 +136,9 @@ struct GRAPHQLSERVICE_EXPORT SelectionSetParams
 };
 
 // Pass a common bundle of parameters to all of the generated Object::getField accessors.
-struct GRAPHQLSERVICE_EXPORT FieldParams : SelectionSetParams
+struct FieldParams : SelectionSetParams
 {
-	explicit FieldParams(const SelectionSetParams& selectionSetParams, response::Value&& directives);
+	GRAPHQLSERVICE_EXPORT explicit FieldParams(const SelectionSetParams& selectionSetParams, response::Value&& directives);
 
 	// Each field owns its own field-specific directives. Once the accessor returns it will be destroyed,
 	// but you can move it into another instance of response::Value to keep it alive longer.
@@ -174,7 +174,7 @@ private:
 // Fragments are referenced by name and have a single type condition (except for inline
 // fragments, where the type condition is common but optional). They contain a set of fields
 // (with optional aliases and sub-selections) and potentially references to other fragments.
-class GRAPHQLSERVICE_EXPORT Fragment
+class Fragment
 {
 public:
 	explicit Fragment(const peg::ast_node& fragmentDefinition, const response::Value& variables);
@@ -197,13 +197,13 @@ using FragmentMap = std::unordered_map<std::string, Fragment>;
 // Resolver functors take a set of arguments encoded as members on a JSON object
 // with an optional selection set for complex types and return a JSON value for
 // a single field.
-struct GRAPHQLSERVICE_EXPORT ResolverParams : SelectionSetParams
+struct ResolverParams : SelectionSetParams
 {
-	explicit ResolverParams(const SelectionSetParams& selectionSetParams, const peg::ast_node& field,
+	GRAPHQLSERVICE_EXPORT explicit ResolverParams(const SelectionSetParams& selectionSetParams, const peg::ast_node& field,
 		std::string&& fieldName, response::Value&& arguments, response::Value&& fieldDirectives,
 		const peg::ast_node* selection, const FragmentMap& fragments, const response::Value& variables);
 
-	schema_location getLocation() const;
+	GRAPHQLSERVICE_EXPORT schema_location getLocation() const;
 
 	// These values are different for each resolver.
 	const peg::ast_node& field;
@@ -222,7 +222,7 @@ using Resolver = std::function<std::future<response::Value>(ResolverParams&&)>;
 using ResolverMap = std::unordered_map<std::string, Resolver>;
 
 // Binary data and opaque strings like IDs are encoded in Base64.
-class GRAPHQLSERVICE_EXPORT Base64
+class Base64
 {
 public:
 	// Map a single Base64-encoded character to its 6-bit integer value.
@@ -236,7 +236,7 @@ public:
 	}
 
 	// Convert a Base64-encoded string to a vector of bytes.
-	static std::vector<uint8_t> fromBase64(const char* encoded, size_t count);
+	GRAPHQLSERVICE_EXPORT static std::vector<uint8_t> fromBase64(const char* encoded, size_t count);
 
 	// Map a single 6-bit integer value to its Base64-encoded character.
 	static constexpr char toBase64(uint8_t i) noexcept
@@ -249,7 +249,7 @@ public:
 	}
 
 	// Convert a set of bytes to Base64.
-	static std::string toBase64(const std::vector<uint8_t>& bytes);
+	GRAPHQLSERVICE_EXPORT static std::string toBase64(const std::vector<uint8_t>& bytes);
 
 private:
 	static constexpr char padding = '=';
@@ -430,15 +430,15 @@ using TypeNames = std::unordered_set<std::string>;
 // and @skip directives, and calls through to the resolver functor for each selected field with
 // its arguments. This may be a recursive process for fields which return another complex type,
 // in which case it requires its own selection set.
-class GRAPHQLSERVICE_EXPORT Object : public std::enable_shared_from_this<Object>
+class Object : public std::enable_shared_from_this<Object>
 {
 public:
-	explicit Object(TypeNames&& typeNames, ResolverMap&& resolvers);
-	virtual ~Object() = default;
+	GRAPHQLSERVICE_EXPORT explicit Object(TypeNames&& typeNames, ResolverMap&& resolvers);
+	GRAPHQLSERVICE_EXPORT virtual ~Object() = default;
 
-	std::future<response::Value> resolve(const SelectionSetParams& selectionSetParams, const peg::ast_node& selection, const FragmentMap& fragments, const response::Value& variables) const;
+	GRAPHQLSERVICE_EXPORT std::future<response::Value> resolve(const SelectionSetParams& selectionSetParams, const peg::ast_node& selection, const FragmentMap& fragments, const response::Value& variables) const;
 
-	bool matchesType(const std::string& typeName) const;
+	GRAPHQLSERVICE_EXPORT bool matchesType(const std::string& typeName) const;
 
 protected:
 	// These callbacks are optional, you may override either, both, or neither of them. The implementer
@@ -446,8 +446,8 @@ protected:
 	// testing directives which were included at the operation or fragment level. It's up to sub-classes
 	// to decide if they want to use const_cast, mutable members, or separate storage in the RequestState
 	// to accumulate state. By default these callbacks should treat the Object itself as const.
-	virtual void beginSelectionSet(const SelectionSetParams& params) const;
-	virtual void endSelectionSet(const SelectionSetParams& params) const;
+	GRAPHQLSERVICE_EXPORT virtual void beginSelectionSet(const SelectionSetParams& params) const;
+	GRAPHQLSERVICE_EXPORT virtual void endSelectionSet(const SelectionSetParams& params) const;
 
 	std::mutex _resolverMutex {};
 
@@ -783,7 +783,7 @@ using TypeMap = std::unordered_map<std::string, std::shared_ptr<Object>>;
 // You can still sub-class RequestState and use that in the state parameter to Request::subscribe
 // to add your own state to the service callbacks that you receive while executing the subscription
 // query.
-struct GRAPHQLSERVICE_EXPORT SubscriptionParams
+struct SubscriptionParams
 {
 	std::shared_ptr<RequestState> state;
 	peg::ast query;
@@ -838,35 +838,35 @@ struct SubscriptionData : std::enable_shared_from_this<SubscriptionData>
 // Request scans the fragment definitions and finds the right operation definition to interpret
 // depending on the operation name (which might be empty for a single-operation document). It
 // also needs the values of the request variables.
-class GRAPHQLSERVICE_EXPORT Request : public std::enable_shared_from_this<Request>
+class Request : public std::enable_shared_from_this<Request>
 {
 protected:
-	explicit Request(TypeMap&& operationTypes);
-	virtual ~Request() = default;
+	GRAPHQLSERVICE_EXPORT explicit Request(TypeMap&& operationTypes);
+	GRAPHQLSERVICE_EXPORT virtual ~Request() = default;
 
 public:
-	std::vector<schema_error> validate(peg::ast& query) const;
+	GRAPHQLSERVICE_EXPORT std::vector<schema_error> validate(peg::ast& query) const;
 
-	std::pair<std::string, const peg::ast_node*> findOperationDefinition(const peg::ast_node& root, const std::string& operationName) const;
+	GRAPHQLSERVICE_EXPORT std::pair<std::string, const peg::ast_node*> findOperationDefinition(const peg::ast_node& root, const std::string& operationName) const;
 
-	std::future<response::Value> resolve(const std::shared_ptr<RequestState>& state, peg::ast& query, const std::string& operationName, response::Value&& variables) const;
-	std::future<response::Value> resolve(std::launch launch, const std::shared_ptr<RequestState>& state, peg::ast& query, const std::string& operationName, response::Value&& variables) const;
+	GRAPHQLSERVICE_EXPORT std::future<response::Value> resolve(const std::shared_ptr<RequestState>& state, peg::ast& query, const std::string& operationName, response::Value&& variables) const;
+	GRAPHQLSERVICE_EXPORT std::future<response::Value> resolve(std::launch launch, const std::shared_ptr<RequestState>& state, peg::ast& query, const std::string& operationName, response::Value&& variables) const;
 
-	SubscriptionKey subscribe(SubscriptionParams&& params, SubscriptionCallback&& callback);
-	void unsubscribe(SubscriptionKey key);
+	GRAPHQLSERVICE_EXPORT SubscriptionKey subscribe(SubscriptionParams&& params, SubscriptionCallback&& callback);
+	GRAPHQLSERVICE_EXPORT void unsubscribe(SubscriptionKey key);
 
-	void deliver(const SubscriptionName& name, const std::shared_ptr<Object>& subscriptionObject) const;
-	void deliver(const SubscriptionName& name, const SubscriptionArguments& arguments, const std::shared_ptr<Object>& subscriptionObject) const;
-	void deliver(const SubscriptionName& name, const SubscriptionFilterCallback& apply, const std::shared_ptr<Object>& subscriptionObject) const;
+	GRAPHQLSERVICE_EXPORT void deliver(const SubscriptionName& name, const std::shared_ptr<Object>& subscriptionObject) const;
+	GRAPHQLSERVICE_EXPORT void deliver(const SubscriptionName& name, const SubscriptionArguments& arguments, const std::shared_ptr<Object>& subscriptionObject) const;
+	GRAPHQLSERVICE_EXPORT void deliver(const SubscriptionName& name, const SubscriptionFilterCallback& apply, const std::shared_ptr<Object>& subscriptionObject) const;
 
-	void deliver(std::launch launch, const SubscriptionName& name, const std::shared_ptr<Object>& subscriptionObject) const;
-	void deliver(std::launch launch, const SubscriptionName& name, const SubscriptionArguments& arguments, const std::shared_ptr<Object>& subscriptionObject) const;
-	void deliver(std::launch launch, const SubscriptionName& name, const SubscriptionFilterCallback& apply, const std::shared_ptr<Object>& subscriptionObject) const;
+	GRAPHQLSERVICE_EXPORT void deliver(std::launch launch, const SubscriptionName& name, const std::shared_ptr<Object>& subscriptionObject) const;
+	GRAPHQLSERVICE_EXPORT void deliver(std::launch launch, const SubscriptionName& name, const SubscriptionArguments& arguments, const std::shared_ptr<Object>& subscriptionObject) const;
+	GRAPHQLSERVICE_EXPORT void deliver(std::launch launch, const SubscriptionName& name, const SubscriptionFilterCallback& apply, const std::shared_ptr<Object>& subscriptionObject) const;
 
 	[[deprecated("Use the Request::resolve overload which takes a peg::ast reference instead.")]]
-	std::future<response::Value> resolve(const std::shared_ptr<RequestState>& state, const peg::ast_node& root, const std::string& operationName, response::Value&& variables) const;
+	GRAPHQLSERVICE_EXPORT std::future<response::Value> resolve(const std::shared_ptr<RequestState>& state, const peg::ast_node& root, const std::string& operationName, response::Value&& variables) const;
 	[[deprecated("Use the Request::resolve overload which takes a peg::ast reference instead.")]]
-	std::future<response::Value> resolve(std::launch launch, const std::shared_ptr<RequestState>& state, const peg::ast_node& root, const std::string& operationName, response::Value&& variables) const;
+	GRAPHQLSERVICE_EXPORT std::future<response::Value> resolve(std::launch launch, const std::shared_ptr<RequestState>& state, const peg::ast_node& root, const std::string& operationName, response::Value&& variables) const;
 
 private:
 	std::future<response::Value> resolveValidated(std::launch launch, const std::shared_ptr<RequestState>& state, const peg::ast_node& root, const std::string& operationName, response::Value&& variables) const;

--- a/include/graphqlservice/Introspection.h
+++ b/include/graphqlservice/Introspection.h
@@ -23,18 +23,18 @@ class Field;
 class InputValue;
 class EnumValue;
 
-class GRAPHQLSERVICE_EXPORT Schema : public object::Schema
+class Schema : public object::Schema
 {
 public:
-	explicit Schema();
+	GRAPHQLSERVICE_EXPORT explicit Schema();
 
-	void AddQueryType(std::shared_ptr<ObjectType> query);
-	void AddMutationType(std::shared_ptr<ObjectType> mutation);
-	void AddSubscriptionType(std::shared_ptr<ObjectType> subscription);
-	void AddType(response::StringType&& name, std::shared_ptr<object::Type> type);
-	const std::shared_ptr<object::Type>& LookupType(const response::StringType& name) const;
-	const std::shared_ptr<object::Type>& WrapType(TypeKind kind, const std::shared_ptr<object::Type>& ofType);
-	void AddDirective(std::shared_ptr<object::Directive> directive);
+	GRAPHQLSERVICE_EXPORT void AddQueryType(std::shared_ptr<ObjectType> query);
+	GRAPHQLSERVICE_EXPORT void AddMutationType(std::shared_ptr<ObjectType> mutation);
+	GRAPHQLSERVICE_EXPORT void AddSubscriptionType(std::shared_ptr<ObjectType> subscription);
+	GRAPHQLSERVICE_EXPORT void AddType(response::StringType&& name, std::shared_ptr<object::Type> type);
+	GRAPHQLSERVICE_EXPORT const std::shared_ptr<object::Type>& LookupType(const response::StringType& name) const;
+	GRAPHQLSERVICE_EXPORT const std::shared_ptr<object::Type>& WrapType(TypeKind kind, const std::shared_ptr<object::Type>& ofType);
+	GRAPHQLSERVICE_EXPORT void AddDirective(std::shared_ptr<object::Directive> directive);
 
 	// Accessors
 	service::FieldResult<std::vector<std::shared_ptr<object::Type>>> getTypes(service::FieldParams&& params) const override;
@@ -54,7 +54,7 @@ private:
 	std::unordered_map<std::shared_ptr<object::Type>, std::shared_ptr<object::Type>> _listWrappers;
 };
 
-class GRAPHQLSERVICE_EXPORT BaseType : public object::Type
+class BaseType : public object::Type
 {
 public:
 	// Accessors
@@ -74,10 +74,10 @@ private:
 	const response::StringType _description;
 };
 
-class GRAPHQLSERVICE_EXPORT ScalarType : public BaseType
+class ScalarType : public BaseType
 {
 public:
-	explicit ScalarType(response::StringType&& name, response::StringType&& description);
+	GRAPHQLSERVICE_EXPORT explicit ScalarType(response::StringType&& name, response::StringType&& description);
 
 	// Accessors
 	service::FieldResult<TypeKind> getKind(service::FieldParams&& params) const override;
@@ -87,13 +87,13 @@ private:
 	const response::StringType _name;
 };
 
-class GRAPHQLSERVICE_EXPORT ObjectType : public BaseType
+class ObjectType : public BaseType
 {
 public:
-	explicit ObjectType(response::StringType&& name, response::StringType&& description);
+	GRAPHQLSERVICE_EXPORT explicit ObjectType(response::StringType&& name, response::StringType&& description);
 
-	void AddInterfaces(std::vector<std::shared_ptr<InterfaceType>> interfaces);
-	void AddFields(std::vector<std::shared_ptr<Field>> fields);
+	GRAPHQLSERVICE_EXPORT void AddInterfaces(std::vector<std::shared_ptr<InterfaceType>> interfaces);
+	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<Field>> fields);
 
 	// Accessors
 	service::FieldResult<TypeKind> getKind(service::FieldParams&& params) const override;
@@ -108,13 +108,13 @@ private:
 	std::vector<std::shared_ptr<Field>> _fields;
 };
 
-class GRAPHQLSERVICE_EXPORT InterfaceType : public BaseType
+class InterfaceType : public BaseType
 {
 public:
-	explicit InterfaceType(response::StringType&& name, response::StringType&& description);
+	GRAPHQLSERVICE_EXPORT explicit InterfaceType(response::StringType&& name, response::StringType&& description);
 
-	void AddPossibleType(std::weak_ptr<ObjectType> possibleType);
-	void AddFields(std::vector<std::shared_ptr<Field>> fields);
+	GRAPHQLSERVICE_EXPORT void AddPossibleType(std::weak_ptr<ObjectType> possibleType);
+	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<Field>> fields);
 
 	// Accessors
 	service::FieldResult<TypeKind> getKind(service::FieldParams&& params) const override;
@@ -129,12 +129,12 @@ private:
 	std::vector<std::weak_ptr<ObjectType>> _possibleTypes;
 };
 
-class GRAPHQLSERVICE_EXPORT UnionType : public BaseType
+class UnionType : public BaseType
 {
 public:
-	explicit UnionType(response::StringType&& name, response::StringType&& description);
+	GRAPHQLSERVICE_EXPORT explicit UnionType(response::StringType&& name, response::StringType&& description);
 
-	void AddPossibleTypes(std::vector<std::weak_ptr<object::Type>> possibleTypes);
+	GRAPHQLSERVICE_EXPORT void AddPossibleTypes(std::vector<std::weak_ptr<object::Type>> possibleTypes);
 
 	// Accessors
 	service::FieldResult<TypeKind> getKind(service::FieldParams&& params) const override;
@@ -147,19 +147,19 @@ private:
 	std::vector<std::weak_ptr<object::Type>> _possibleTypes;
 };
 
-struct GRAPHQLSERVICE_EXPORT EnumValueType
+struct EnumValueType
 {
 	response::StringType value;
 	response::StringType description;
 	std::optional<response::StringType> deprecationReason;
 };
 
-class GRAPHQLSERVICE_EXPORT EnumType : public BaseType
+class EnumType : public BaseType
 {
 public:
-	explicit EnumType(response::StringType&& name, response::StringType&& description);
+	GRAPHQLSERVICE_EXPORT explicit EnumType(response::StringType&& name, response::StringType&& description);
 
-	void AddEnumValues(std::vector<EnumValueType> enumValues);
+	GRAPHQLSERVICE_EXPORT void AddEnumValues(std::vector<EnumValueType> enumValues);
 
 	// Accessors
 	service::FieldResult<TypeKind> getKind(service::FieldParams&& params) const override;
@@ -172,12 +172,12 @@ private:
 	std::vector<std::shared_ptr<object::EnumValue>> _enumValues;
 };
 
-class GRAPHQLSERVICE_EXPORT InputObjectType : public BaseType
+class InputObjectType : public BaseType
 {
 public:
-	explicit InputObjectType(response::StringType&& name, response::StringType&& description);
+	GRAPHQLSERVICE_EXPORT explicit InputObjectType(response::StringType&& name, response::StringType&& description);
 
-	void AddInputValues(std::vector<std::shared_ptr<InputValue>> inputValues);
+	GRAPHQLSERVICE_EXPORT void AddInputValues(std::vector<std::shared_ptr<InputValue>> inputValues);
 
 	// Accessors
 	service::FieldResult<TypeKind> getKind(service::FieldParams&& params) const override;
@@ -190,10 +190,10 @@ private:
 	std::vector<std::shared_ptr<InputValue>> _inputValues;
 };
 
-class GRAPHQLSERVICE_EXPORT WrapperType : public BaseType
+class WrapperType : public BaseType
 {
 public:
-	explicit WrapperType(TypeKind kind, const std::shared_ptr<object::Type>& ofType);
+	GRAPHQLSERVICE_EXPORT explicit WrapperType(TypeKind kind, const std::shared_ptr<object::Type>& ofType);
 
 	// Accessors
 	service::FieldResult<TypeKind> getKind(service::FieldParams&& params) const override;
@@ -204,10 +204,10 @@ private:
 	const std::weak_ptr<object::Type> _ofType;
 };
 
-class GRAPHQLSERVICE_EXPORT Field : public object::Field
+class Field : public object::Field
 {
 public:
-	explicit Field(response::StringType&& name, response::StringType&& description, std::optional<response::StringType>&& deprecationReason, std::vector<std::shared_ptr<InputValue>>&& args, const std::shared_ptr<object::Type>& type);
+	GRAPHQLSERVICE_EXPORT explicit Field(response::StringType&& name, response::StringType&& description, std::optional<response::StringType>&& deprecationReason, std::vector<std::shared_ptr<InputValue>>&& args, const std::shared_ptr<object::Type>& type);
 
 	// Accessors
 	service::FieldResult<response::StringType> getName(service::FieldParams&& params) const override;
@@ -225,10 +225,10 @@ private:
 	const std::weak_ptr<object::Type> _type;
 };
 
-class GRAPHQLSERVICE_EXPORT InputValue : public object::InputValue
+class InputValue : public object::InputValue
 {
 public:
-	explicit InputValue(response::StringType&& name, response::StringType&& description, const std::shared_ptr<object::Type>& type, response::StringType&& defaultValue);
+	GRAPHQLSERVICE_EXPORT explicit InputValue(response::StringType&& name, response::StringType&& description, const std::shared_ptr<object::Type>& type, response::StringType&& defaultValue);
 
 	// Accessors
 	service::FieldResult<response::StringType> getName(service::FieldParams&& params) const override;
@@ -243,10 +243,10 @@ private:
 	const response::StringType _defaultValue;
 };
 
-class GRAPHQLSERVICE_EXPORT EnumValue : public object::EnumValue
+class EnumValue : public object::EnumValue
 {
 public:
-	explicit EnumValue(response::StringType&& name, response::StringType&& description, std::optional<response::StringType>&& deprecationReason);
+	GRAPHQLSERVICE_EXPORT explicit EnumValue(response::StringType&& name, response::StringType&& description, std::optional<response::StringType>&& deprecationReason);
 
 	// Accessors
 	service::FieldResult<response::StringType> getName(service::FieldParams&& params) const override;
@@ -260,10 +260,10 @@ private:
 	const std::optional<response::StringType> _deprecationReason;
 };
 
-class GRAPHQLSERVICE_EXPORT Directive : public object::Directive
+class Directive : public object::Directive
 {
 public:
-	explicit Directive(response::StringType&& name, response::StringType&& description, std::vector<response::StringType>&& locations, std::vector<std::shared_ptr<InputValue>>&& args);
+	GRAPHQLSERVICE_EXPORT explicit Directive(response::StringType&& name, response::StringType&& description, std::vector<response::StringType>&& locations, std::vector<std::shared_ptr<InputValue>>&& args);
 
 	// Accessors
 	service::FieldResult<response::StringType> getName(service::FieldParams&& params) const override;

--- a/include/graphqlservice/Introspection.h
+++ b/include/graphqlservice/Introspection.h
@@ -23,7 +23,7 @@ class Field;
 class InputValue;
 class EnumValue;
 
-class Schema : public object::Schema
+class GRAPHQLSERVICE_EXPORT Schema : public object::Schema
 {
 public:
 	explicit Schema();
@@ -54,7 +54,7 @@ private:
 	std::unordered_map<std::shared_ptr<object::Type>, std::shared_ptr<object::Type>> _listWrappers;
 };
 
-class BaseType : public object::Type
+class GRAPHQLSERVICE_EXPORT BaseType : public object::Type
 {
 public:
 	// Accessors
@@ -74,7 +74,7 @@ private:
 	const response::StringType _description;
 };
 
-class ScalarType : public BaseType
+class GRAPHQLSERVICE_EXPORT ScalarType : public BaseType
 {
 public:
 	explicit ScalarType(response::StringType&& name, response::StringType&& description);
@@ -87,7 +87,7 @@ private:
 	const response::StringType _name;
 };
 
-class ObjectType : public BaseType
+class GRAPHQLSERVICE_EXPORT ObjectType : public BaseType
 {
 public:
 	explicit ObjectType(response::StringType&& name, response::StringType&& description);
@@ -108,7 +108,7 @@ private:
 	std::vector<std::shared_ptr<Field>> _fields;
 };
 
-class InterfaceType : public BaseType
+class GRAPHQLSERVICE_EXPORT InterfaceType : public BaseType
 {
 public:
 	explicit InterfaceType(response::StringType&& name, response::StringType&& description);
@@ -129,7 +129,7 @@ private:
 	std::vector<std::weak_ptr<ObjectType>> _possibleTypes;
 };
 
-class UnionType : public BaseType
+class GRAPHQLSERVICE_EXPORT UnionType : public BaseType
 {
 public:
 	explicit UnionType(response::StringType&& name, response::StringType&& description);
@@ -147,14 +147,14 @@ private:
 	std::vector<std::weak_ptr<object::Type>> _possibleTypes;
 };
 
-struct EnumValueType
+struct GRAPHQLSERVICE_EXPORT EnumValueType
 {
 	response::StringType value;
 	response::StringType description;
 	std::optional<response::StringType> deprecationReason;
 };
 
-class EnumType : public BaseType
+class GRAPHQLSERVICE_EXPORT EnumType : public BaseType
 {
 public:
 	explicit EnumType(response::StringType&& name, response::StringType&& description);
@@ -172,7 +172,7 @@ private:
 	std::vector<std::shared_ptr<object::EnumValue>> _enumValues;
 };
 
-class InputObjectType : public BaseType
+class GRAPHQLSERVICE_EXPORT InputObjectType : public BaseType
 {
 public:
 	explicit InputObjectType(response::StringType&& name, response::StringType&& description);
@@ -190,7 +190,7 @@ private:
 	std::vector<std::shared_ptr<InputValue>> _inputValues;
 };
 
-class WrapperType : public BaseType
+class GRAPHQLSERVICE_EXPORT WrapperType : public BaseType
 {
 public:
 	explicit WrapperType(TypeKind kind, const std::shared_ptr<object::Type>& ofType);
@@ -204,7 +204,7 @@ private:
 	const std::weak_ptr<object::Type> _ofType;
 };
 
-class Field : public object::Field
+class GRAPHQLSERVICE_EXPORT Field : public object::Field
 {
 public:
 	explicit Field(response::StringType&& name, response::StringType&& description, std::optional<response::StringType>&& deprecationReason, std::vector<std::shared_ptr<InputValue>>&& args, const std::shared_ptr<object::Type>& type);
@@ -225,7 +225,7 @@ private:
 	const std::weak_ptr<object::Type> _type;
 };
 
-class InputValue : public object::InputValue
+class GRAPHQLSERVICE_EXPORT InputValue : public object::InputValue
 {
 public:
 	explicit InputValue(response::StringType&& name, response::StringType&& description, const std::shared_ptr<object::Type>& type, response::StringType&& defaultValue);
@@ -243,7 +243,7 @@ private:
 	const response::StringType _defaultValue;
 };
 
-class EnumValue : public object::EnumValue
+class GRAPHQLSERVICE_EXPORT EnumValue : public object::EnumValue
 {
 public:
 	explicit EnumValue(response::StringType&& name, response::StringType&& description, std::optional<response::StringType>&& deprecationReason);
@@ -260,7 +260,7 @@ private:
 	const std::optional<response::StringType> _deprecationReason;
 };
 
-class Directive : public object::Directive
+class GRAPHQLSERVICE_EXPORT Directive : public object::Directive
 {
 public:
 	explicit Directive(response::StringType&& name, response::StringType&& description, std::vector<response::StringType>&& locations, std::vector<std::shared_ptr<InputValue>>&& args);

--- a/include/graphqlservice/JSONResponse.h
+++ b/include/graphqlservice/JSONResponse.h
@@ -6,13 +6,23 @@
 #ifndef JSONRESPONSE_H
 #define JSONRESPONSE_H
 
+#ifdef GRAPHQL_DLLEXPORTS
+	#ifdef IMPL_JSONRESPONSE_DLL
+		#define JSONRESPONSE_EXPORT __declspec(dllexport)
+	#else // !IMPL_JSONRESPONSE_DLL
+		#define JSONRESPONSE_EXPORT __declspec(dllimport)
+	#endif // !IMPL_JSONRESPONSE_DLL
+#else // !GRAPHQL_DLLEXPORTS
+	#define JSONRESPONSE_EXPORT
+#endif // !GRAPHQL_DLLEXPORTS
+
 #include "graphqlservice/GraphQLResponse.h"
 
 namespace graphql::response {
 
-std::string toJSON(Value&& response);
+JSONRESPONSE_EXPORT std::string toJSON(Value&& response);
 
-Value parseJSON(const std::string& json);
+JSONRESPONSE_EXPORT Value parseJSON(const std::string& json);
 
 } /* namespace graphql::response */
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -83,8 +83,8 @@ foreach(CPP_FILE IN LISTS SEPARATE_SCHEMA_FILES)
   list(APPEND SEPARATE_SCHEMA_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/separate/${CPP_FILE}")
 endforeach(CPP_FILE)
 
-add_library(separateschema OBJECT ${SEPARATE_SCHEMA_PATHS})
-add_dependencies(separateschema graphqlservice)
+add_library(separateschema STATIC ${SEPARATE_SCHEMA_PATHS})
+target_link_libraries(separateschema PUBLIC graphqlservice)
 target_compile_definitions(separateschema PUBLIC IMPL_SEPARATE_TODAY)
 target_include_directories(separateschema PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/../include
@@ -97,15 +97,10 @@ if(GRAPHQL_UPDATE_SAMPLES)
   add_dependencies(separateschema update_samples)
 endif()
 
-add_library(separategraphql
-  today/TodayMock.cpp
-  $<TARGET_OBJECTS:separateschema>)
-add_dependencies(separategraphql separateschema)
-target_link_libraries(separategraphql PUBLIC graphqlservice)
+add_library(separategraphql STATIC today/TodayMock.cpp)
+target_link_libraries(separategraphql PUBLIC separateschema)
 target_compile_definitions(separategraphql PUBLIC IMPL_SEPARATE_TODAY)
-target_include_directories(separategraphql PUBLIC
-  $<TARGET_PROPERTY:separateschema,INCLUDE_DIRECTORIES>
-  today)
+target_include_directories(separategraphql PUBLIC today)
 
 add_executable(sample today/sample.cpp)
 target_link_libraries(sample PRIVATE
@@ -116,10 +111,23 @@ target_include_directories(sample PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../include
   ${CMAKE_CURRENT_SOURCE_DIR}/../PEGTL/include)
 
+if(WIN32 AND BUILD_SHARED_LIBS)
+  add_custom_target(copy_sample_dlls ${CMAKE_COMMAND} -E copy graphqlservice.dll ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy graphqlservice.pdb ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy graphqljson.dll ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy graphqljson.pdb ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy graphqlpeg.dll ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy graphqlpeg.pdb ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS graphqlservice graphqljson graphqlpeg
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../src)
+
+  add_dependencies(sample copy_sample_dlls)
+endif()
+
 if(GRAPHQL_BUILD_TESTS)
   # tests
-  add_library(unifiedschema OBJECT unified/TodaySchema.cpp)
-  add_dependencies(unifiedschema graphqlservice)
+  add_library(unifiedschema STATIC unified/TodaySchema.cpp)
+  target_link_libraries(unifiedschema PUBLIC graphqlservice)
   target_include_directories(unifiedschema PUBLIC
     ${CMAKE_CURRENT_BINARY_DIR}/../include
     ${CMAKE_CURRENT_SOURCE_DIR}/../include
@@ -131,17 +139,12 @@ if(GRAPHQL_BUILD_TESTS)
     add_dependencies(unifiedschema update_samples)
   endif()
 
-  add_library(unifiedgraphql
-    today/TodayMock.cpp
-    $<TARGET_OBJECTS:unifiedschema>)
-  add_dependencies(unifiedgraphql unifiedschema)
-  target_link_libraries(unifiedgraphql PUBLIC graphqlservice)
-  target_include_directories(unifiedgraphql PUBLIC
-    $<TARGET_PROPERTY:unifiedschema,INCLUDE_DIRECTORIES>
-    today)
+  add_library(unifiedgraphql STATIC today/TodayMock.cpp)
+  target_link_libraries(unifiedgraphql PUBLIC unifiedschema)
+  target_include_directories(unifiedgraphql PUBLIC today)
   add_bigobj_flag(unifiedgraphql)
 
-  add_library(validationgraphql
+  add_library(validationgraphql STATIC
     validation/ValidationMock.cpp
     validation/ValidationSchema.cpp)
   target_link_libraries(validationgraphql PUBLIC graphqlservice)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -112,14 +112,11 @@ target_include_directories(sample PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../PEGTL/include)
 
 if(WIN32 AND BUILD_SHARED_LIBS)
-  add_custom_target(copy_sample_dlls ${CMAKE_COMMAND} -E copy graphqlservice.dll ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy graphqlservice.pdb ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy graphqljson.dll ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy graphqljson.pdb ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy graphqlpeg.dll ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy graphqlpeg.pdb ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS graphqlservice graphqljson graphqlpeg
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../src)
+  add_custom_target(copy_sample_dlls ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlservice> ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqljson> ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlpeg> ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlresponse> ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS graphqlservice graphqljson graphqlpeg graphqlresponse)
 
   add_dependencies(sample copy_sample_dlls)
 endif()

--- a/samples/introspection/IntrospectionSchema.h
+++ b/samples/introspection/IntrospectionSchema.h
@@ -60,7 +60,7 @@ class InputValue;
 class EnumValue;
 class Directive;
 
-class Schema
+class GRAPHQLSERVICE_EXPORT Schema
 	: public service::Object
 {
 protected:
@@ -83,7 +83,7 @@ private:
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };
 
-class Type
+class GRAPHQLSERVICE_EXPORT Type
 	: public service::Object
 {
 protected:
@@ -114,7 +114,7 @@ private:
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };
 
-class Field
+class GRAPHQLSERVICE_EXPORT Field
 	: public service::Object
 {
 protected:
@@ -139,7 +139,7 @@ private:
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };
 
-class InputValue
+class GRAPHQLSERVICE_EXPORT InputValue
 	: public service::Object
 {
 protected:
@@ -160,7 +160,7 @@ private:
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };
 
-class EnumValue
+class GRAPHQLSERVICE_EXPORT EnumValue
 	: public service::Object
 {
 protected:
@@ -181,7 +181,7 @@ private:
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };
 
-class Directive
+class GRAPHQLSERVICE_EXPORT Directive
 	: public service::Object
 {
 protected:
@@ -204,7 +204,7 @@ private:
 
 } /* namespace object */
 
-void AddTypesToSchema(const std::shared_ptr<introspection::Schema>& schema);
+GRAPHQLSERVICE_EXPORT void AddTypesToSchema(const std::shared_ptr<introspection::Schema>& schema);
 
 } /* namespace introspection */
 } /* namespace graphql */

--- a/samples/introspection/IntrospectionSchema.h
+++ b/samples/introspection/IntrospectionSchema.h
@@ -60,7 +60,7 @@ class InputValue;
 class EnumValue;
 class Directive;
 
-class GRAPHQLSERVICE_EXPORT Schema
+class Schema
 	: public service::Object
 {
 protected:
@@ -83,7 +83,7 @@ private:
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };
 
-class GRAPHQLSERVICE_EXPORT Type
+class Type
 	: public service::Object
 {
 protected:
@@ -114,7 +114,7 @@ private:
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };
 
-class GRAPHQLSERVICE_EXPORT Field
+class Field
 	: public service::Object
 {
 protected:
@@ -139,7 +139,7 @@ private:
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };
 
-class GRAPHQLSERVICE_EXPORT InputValue
+class InputValue
 	: public service::Object
 {
 protected:
@@ -160,7 +160,7 @@ private:
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };
 
-class GRAPHQLSERVICE_EXPORT EnumValue
+class EnumValue
 	: public service::Object
 {
 protected:
@@ -181,7 +181,7 @@ private:
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };
 
-class GRAPHQLSERVICE_EXPORT Directive
+class Directive
 	: public service::Object
 {
 protected:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,16 +19,32 @@ target_include_directories(graphqlpeg PUBLIC
   $<INSTALL_INTERFACE:${GRAPHQL_INSTALL_INCLUDE_DIR}>)
 add_bigobj_flag(graphqlpeg)
 
+if(WIN32 AND BUILD_SHARED_LIBS)
+  target_compile_definitions(graphqlpeg
+    PUBLIC GRAPHQL_DLLEXPORTS
+    PRIVATE IMPL_GRAPHQLPEG_DLL)
+endif()
+
 # graphqlresponse
-add_library(graphqlresponse OBJECT GraphQLResponse.cpp)
+add_library(graphqlresponse STATIC GraphQLResponse.cpp)
 target_include_directories(graphqlresponse PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
+if(WIN32 AND BUILD_SHARED_LIBS)
+  target_compile_definitions(graphqlresponse PUBLIC
+    GRAPHQL_DLLEXPORTS
+    IMPL_GRAPHQLRESPONSE_LIB)
+endif()
+
 # schemagen
 add_executable(schemagen
-  $<TARGET_OBJECTS:graphqlresponse>
-  SchemaGenerator.cpp)
-target_link_libraries(schemagen PRIVATE graphqlpeg)
+  SchemaGenerator.cpp
+  $<TARGET_PROPERTY:graphqlpeg,SOURCES>
+  $<TARGET_PROPERTY:graphqlresponse,SOURCES>)
+target_include_directories(schemagen PRIVATE
+  $<TARGET_PROPERTY:graphqlpeg,INTERFACE_INCLUDE_DIRECTORIES>
+  $<TARGET_PROPERTY:graphqlresponse,INTERFACE_INCLUDE_DIRECTORIES>)
+add_bigobj_flag(schemagen)
 
 set(BOOST_COMPONENTS program_options)
 set(BOOST_LIBRARIES Boost::program_options)
@@ -87,16 +103,22 @@ endif()
 
 # graphqlservice
 add_library(graphqlservice
-  $<TARGET_OBJECTS:graphqlresponse>
   GraphQLService.cpp
   Introspection.cpp
   Validation.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/../IntrospectionSchema.cpp)
 target_link_libraries(graphqlservice PUBLIC
-  graphqlpeg
-  Threads::Threads)
+    graphqlpeg
+    Threads::Threads)
+target_link_libraries(graphqlservice PRIVATE graphqlresponse)
 target_include_directories(graphqlservice SYSTEM PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}/../include)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+  target_compile_definitions(graphqlservice
+    PUBLIC GRAPHQL_DLLEXPORTS
+    PRIVATE IMPL_GRAPHQLSERVICE_DLL)
+endif()
 
 # RapidJSON is the only option for JSON serialization used in this project, but if you want
 # to use another JSON library you can implement an alternate version of the functions in
@@ -111,7 +133,14 @@ if(GRAPHQL_USE_RAPIDJSON)
 
   set(BUILD_GRAPHQLJSON ON)
   add_library(graphqljson JSONResponse.cpp)
+  target_link_libraries(graphqljson PRIVATE graphqlresponse)
   target_include_directories(graphqljson SYSTEM PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
+
+  if(WIN32 AND BUILD_SHARED_LIBS)
+    target_compile_definitions(graphqljson
+      PUBLIC GRAPHQL_DLLEXPORTS
+      PRIVATE IMPL_JSONRESPONSE_DLL)
+  endif()
 endif()
 
 # graphqljson
@@ -134,6 +163,7 @@ endif()
 
 install(TARGETS
     graphqlpeg
+    graphqlresponse
     graphqlservice
   EXPORT cppgraphqlgen-targets
   RUNTIME DESTINATION bin

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,24 +26,22 @@ if(WIN32 AND BUILD_SHARED_LIBS)
 endif()
 
 # graphqlresponse
-add_library(graphqlresponse STATIC GraphQLResponse.cpp)
-target_include_directories(graphqlresponse PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_library(graphqlresponse GraphQLResponse.cpp)
+target_include_directories(graphqlresponse PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  $<INSTALL_INTERFACE:${GRAPHQL_INSTALL_INCLUDE_DIR}>)
 
 if(WIN32 AND BUILD_SHARED_LIBS)
-  target_compile_definitions(graphqlresponse PUBLIC
-    GRAPHQL_DLLEXPORTS
-    IMPL_GRAPHQLRESPONSE_LIB)
+  target_compile_definitions(graphqlresponse
+    PUBLIC GRAPHQL_DLLEXPORTS
+    PRIVATE IMPL_GRAPHQLRESPONSE_DLL)
 endif()
 
 # schemagen
-add_executable(schemagen
-  SchemaGenerator.cpp
-  $<TARGET_PROPERTY:graphqlpeg,SOURCES>
-  $<TARGET_PROPERTY:graphqlresponse,SOURCES>)
-target_include_directories(schemagen PRIVATE
-  $<TARGET_PROPERTY:graphqlpeg,INTERFACE_INCLUDE_DIRECTORIES>
-  $<TARGET_PROPERTY:graphqlresponse,INTERFACE_INCLUDE_DIRECTORIES>)
+add_executable(schemagen SchemaGenerator.cpp)
+target_link_libraries(schemagen PRIVATE
+  graphqlpeg
+  graphqlresponse)
 add_bigobj_flag(schemagen)
 
 set(BOOST_COMPONENTS program_options)
@@ -110,7 +108,7 @@ add_library(graphqlservice
 target_link_libraries(graphqlservice PUBLIC
     graphqlpeg
     Threads::Threads)
-target_link_libraries(graphqlservice PRIVATE graphqlresponse)
+target_link_libraries(graphqlservice PUBLIC graphqlresponse)
 target_include_directories(graphqlservice SYSTEM PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}/../include)
 
@@ -133,7 +131,7 @@ if(GRAPHQL_USE_RAPIDJSON)
 
   set(BUILD_GRAPHQLJSON ON)
   add_library(graphqljson JSONResponse.cpp)
-  target_link_libraries(graphqljson PRIVATE graphqlresponse)
+  target_link_libraries(graphqljson PUBLIC graphqlresponse)
   target_include_directories(graphqljson SYSTEM PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
 
   if(WIN32 AND BUILD_SHARED_LIBS)

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -2217,6 +2217,7 @@ void Request::deliver(std::launch launch, const SubscriptionName& name, const Su
 
 			document.emplace_back(std::string { strData }, response::Value());
 			document.emplace_back(std::string { strErrors }, ex.getErrors());
+			promise.set_value(std::move(document));
 
 			result = promise.get_future();
 		}

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -1798,7 +1798,14 @@ class Schema;
 		// Output the full declarations
 		for (const auto& interfaceType : _interfaceTypes)
 		{
-			headerFile << R"cpp(struct )cpp" << interfaceType.cppType << R"cpp(
+			headerFile << R"cpp(struct )cpp";
+
+			if (_isIntrospection)
+			{
+				headerFile << R"cpp(GRAPHQLSERVICE_EXPORT )cpp";
+			}
+
+			headerFile << interfaceType.cppType << R"cpp(
 {
 )cpp";
 
@@ -1887,6 +1894,11 @@ private:
 		headerFile << std::endl;
 	}
 
+	if (_isIntrospection)
+	{
+		headerFile << R"cpp(GRAPHQLSERVICE_EXPORT )cpp";
+	}
+
 	headerFile << R"cpp(void AddTypesToSchema(const std::shared_ptr<)cpp" << s_introspectionNamespace << R"cpp(::Schema>& schema);
 
 )cpp";
@@ -1896,7 +1908,14 @@ private:
 
 void Generator::outputObjectDeclaration(std::ostream& headerFile, const ObjectType& objectType, bool isQueryType) const
 {
-	headerFile << R"cpp(class )cpp" << objectType.cppType << R"cpp(
+	headerFile << R"cpp(class )cpp";
+
+	if (_isIntrospection)
+	{
+		headerFile << R"cpp(GRAPHQLSERVICE_EXPORT )cpp";
+	}
+
+	headerFile << objectType.cppType << R"cpp(
 	: public service::Object)cpp";
 
 	for (const auto& interfaceName : objectType.interfaces)

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -1798,14 +1798,7 @@ class Schema;
 		// Output the full declarations
 		for (const auto& interfaceType : _interfaceTypes)
 		{
-			headerFile << R"cpp(struct )cpp";
-
-			if (_isIntrospection)
-			{
-				headerFile << R"cpp(GRAPHQLSERVICE_EXPORT )cpp";
-			}
-
-			headerFile << interfaceType.cppType << R"cpp(
+			headerFile << R"cpp(struct )cpp" << interfaceType.cppType << R"cpp(
 {
 )cpp";
 
@@ -1908,14 +1901,7 @@ private:
 
 void Generator::outputObjectDeclaration(std::ostream& headerFile, const ObjectType& objectType, bool isQueryType) const
 {
-	headerFile << R"cpp(class )cpp";
-
-	if (_isIntrospection)
-	{
-		headerFile << R"cpp(GRAPHQLSERVICE_EXPORT )cpp";
-	}
-
-	headerFile << objectType.cppType << R"cpp(
+	headerFile << R"cpp(class )cpp" << objectType.cppType << R"cpp(
 	: public service::Object)cpp";
 
 	for (const auto& interfaceName : objectType.interfaces)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,3 +51,20 @@ target_include_directories(response_tests PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/../include
   ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 gtest_add_tests(TARGET response_tests)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+  add_custom_target(copy_test_dlls ${CMAKE_COMMAND} -E copy graphqlservice.dll ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy graphqlservice.pdb ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy graphqljson.dll ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy graphqljson.pdb ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy graphqlpeg.dll ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy graphqlpeg.pdb ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS graphqlservice graphqljson graphqlpeg
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../src)
+
+  add_dependencies(validation_tests copy_test_dlls)
+  add_dependencies(today_tests copy_test_dlls)
+  add_dependencies(argument_tests copy_test_dlls)
+  add_dependencies(pegtl_tests copy_test_dlls)
+  add_dependencies(response_tests copy_test_dlls)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,13 +53,11 @@ target_include_directories(response_tests PUBLIC
 gtest_add_tests(TARGET response_tests)
 
 if(WIN32 AND BUILD_SHARED_LIBS)
-  add_custom_target(copy_test_dlls ${CMAKE_COMMAND} -E copy graphqlservice.dll ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy graphqlservice.pdb ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy graphqljson.dll ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy graphqljson.pdb ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy graphqlpeg.dll ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy graphqlpeg.pdb ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS graphqlservice graphqljson graphqlpeg
+  add_custom_target(copy_test_dlls ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlservice> ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqljson> ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlpeg> ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlresponse> ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS graphqlservice graphqljson graphqlpeg graphqlresponse
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../src)
 
   add_dependencies(validation_tests copy_test_dlls)


### PR DESCRIPTION
If you used `BUILD_SHARED_LIBS` on Windows (including building with `vcpkg` by default), it was setting `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` and letting `CMake` figure out all of the symbols in all of the DLLs and mark them as exported. That bloats the import libs which are used to consume them and increases the binary size considerably.

This PR undoes that and replaces it with explicit `__declspec(dllimport/dllimport)` attributes defined conditionally through macros on Windows for the methods which are actually referenced across modules.