### PR TITLE
Notify on subscribe

### DIFF
--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -879,10 +879,10 @@ public:
 	GRAPHQLSERVICE_EXPORT std::future<response::Value> resolve(std::launch launch, const std::shared_ptr<RequestState>& state, peg::ast& query, const std::string& operationName, response::Value&& variables) const;
 
 	GRAPHQLSERVICE_EXPORT SubscriptionKey subscribe(SubscriptionParams&& params, SubscriptionCallback&& callback);
-	GRAPHQLSERVICE_EXPORT SubscriptionKey subscribe(std::launch launch, SubscriptionParams&& params, SubscriptionCallback&& callback);
+	GRAPHQLSERVICE_EXPORT std::future<SubscriptionKey> subscribe(std::launch launch, SubscriptionParams&& params, SubscriptionCallback&& callback);
 
 	GRAPHQLSERVICE_EXPORT void unsubscribe(SubscriptionKey key);
-	GRAPHQLSERVICE_EXPORT void unsubscribe(std::launch launch, SubscriptionKey key);
+	GRAPHQLSERVICE_EXPORT std::future<void> unsubscribe(std::launch launch, SubscriptionKey key);
 
 	GRAPHQLSERVICE_EXPORT void deliver(const SubscriptionName& name, const std::shared_ptr<Object>& subscriptionObject) const;
 	GRAPHQLSERVICE_EXPORT void deliver(const SubscriptionName& name, const SubscriptionArguments& arguments, const std::shared_ptr<Object>& subscriptionObject) const;

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -113,9 +113,33 @@ constexpr std::string_view strSubscription { "subscription"sv };
 
 }
 
+// Resolvers may be called in multiple different Operation contexts.
+enum class ResolverContext
+{
+	// Resolving a Query operation.
+	Query,
+
+	// Resolving a Mutation operation.
+	Mutation,
+
+	// Adding a Subscription. If you need to prepare to send events for this Subsciption
+	// (e.g. registering an event sink of your own), this is a chance to do that.
+	NotifySubscribe,
+
+	// Resolving a Subscription event.
+	Subscription,
+
+	// Removing a Subscription. If there are no more Subscriptions registered this is an
+	// opportunity to release resources which are no longer needed.
+	NotifyUnsubscribe,
+};
+
 // Pass a common bundle of parameters to all of the generated Object::getField accessors in a SelectionSet
 struct SelectionSetParams
 {
+	// Context for this selection set.
+	const ResolverContext resolverContext;
+
 	// The lifetime of each of these borrowed references is guaranteed until the future returned
 	// by the accessor is resolved or destroyed. They are owned by the OperationData shared pointer. 
 	const std::shared_ptr<RequestState>& state;

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -879,7 +879,10 @@ public:
 	GRAPHQLSERVICE_EXPORT std::future<response::Value> resolve(std::launch launch, const std::shared_ptr<RequestState>& state, peg::ast& query, const std::string& operationName, response::Value&& variables) const;
 
 	GRAPHQLSERVICE_EXPORT SubscriptionKey subscribe(SubscriptionParams&& params, SubscriptionCallback&& callback);
+	GRAPHQLSERVICE_EXPORT SubscriptionKey subscribe(std::launch launch, SubscriptionParams&& params, SubscriptionCallback&& callback);
+
 	GRAPHQLSERVICE_EXPORT void unsubscribe(SubscriptionKey key);
+	GRAPHQLSERVICE_EXPORT void unsubscribe(std::launch launch, SubscriptionKey key);
 
 	GRAPHQLSERVICE_EXPORT void deliver(const SubscriptionName& name, const std::shared_ptr<Object>& subscriptionObject) const;
 	GRAPHQLSERVICE_EXPORT void deliver(const SubscriptionName& name, const SubscriptionArguments& arguments, const std::shared_ptr<Object>& subscriptionObject) const;

--- a/samples/today/TodayMock.h
+++ b/samples/today/TodayMock.h
@@ -434,8 +434,50 @@ public:
 	{
 	}
 
+	static size_t getCount(service::ResolverContext resolverContext)
+	{
+		switch (resolverContext)
+		{
+			case service::ResolverContext::NotifySubscribe:
+				return _notifySubscribeCount;
+
+			case service::ResolverContext::Subscription:
+				return _subscriptionCount;
+
+			case service::ResolverContext::NotifyUnsubscribe:
+				return _notifyUnsubscribeCount;
+
+			default:
+				throw std::runtime_error("Unexpected ResolverContext");
+		}
+	}
+
 	service::FieldResult<std::shared_ptr<object::Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
 	{
+		switch (params.resolverContext)
+		{
+			case service::ResolverContext::NotifySubscribe:
+			{
+				++_notifySubscribeCount;
+				break;
+			}
+
+			case service::ResolverContext::Subscription:
+			{
+				++_subscriptionCount;
+				break;
+			}
+
+			case service::ResolverContext::NotifyUnsubscribe:
+			{
+				++_notifyUnsubscribeCount;
+				break;
+			}
+
+			default:
+				throw std::runtime_error("Unexpected ResolverContext");
+		}
+
 		return std::static_pointer_cast<object::Appointment>(_changeNextAppointment(params.state));
 	}
 
@@ -446,6 +488,10 @@ public:
 
 private:
 	nextAppointmentChange _changeNextAppointment;
+
+	static size_t _notifySubscribeCount;
+	static size_t _subscriptionCount;
+	static size_t _notifyUnsubscribeCount;
 };
 
 class NodeChange : public object::Subscription


### PR DESCRIPTION
Fix #116 

I added overloads to `Request::subscribe` and `Request::unsubscribe` which take a `std::async` launch policy and return a `std::future<>`. If you use these overrides to subscribe and unsubscribe, and you provided a default `Subscription` operation implementation, then as a side effect of asynchronously adding or removing the subscription callback it will also resolve the subscription against the default operation and pass `params.resolverContext` with `ResolverContext::NotifySubscribe` or `ResolverContext::NotifyUnsubscribe`. The result of the resolver will be ignored, but exceptions will rethrow and should not alter the registration.

You can also use these overrides without a default `Subscription` operation implementation, but in that case all it does is make the subscribe/unsubscribe run asynchronously with the specified launch policy.