### PR TITLE
Float input values

### DIFF
--- a/include/graphqlservice/GraphQLGrammar.h
+++ b/include/graphqlservice/GraphQLGrammar.h
@@ -366,8 +366,8 @@ struct input_value_content
 	: sor<list_value
 	, object_value
 	, variable_value
-	, integer_value
 	, float_value
+	, integer_value
 	, string_value
 	, bool_value
 	, null_keyword

--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -125,7 +125,7 @@ struct Value
 	GRAPHQLRESPONSE_EXPORT explicit Value(const Value& other);
 
 	GRAPHQLRESPONSE_EXPORT Value& operator=(Value&& rhs) noexcept;
-	GRAPHQLRESPONSE_EXPORT Value& operator=(const Value& rhs) = delete;
+	Value& operator=(const Value& rhs) = delete;
 
 	// Comparison
 	GRAPHQLRESPONSE_EXPORT bool operator==(const Value& rhs) const noexcept;

--- a/samples/schema.today.graphql
+++ b/samples/schema.today.graphql
@@ -87,6 +87,7 @@ type CompleteTaskPayload {
 
 type Mutation {
     completeTask(input: CompleteTaskInput!) : CompleteTaskPayload!
+    setFloat(value: Float!): Float!
 }
 
 type Subscription {

--- a/samples/separate/MutationObject.h
+++ b/samples/separate/MutationObject.h
@@ -18,9 +18,11 @@ protected:
 
 public:
 	virtual service::FieldResult<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const;
+	virtual service::FieldResult<response::FloatType> applySetFloat(service::FieldParams&& params, response::FloatType&& valueArg) const;
 
 private:
 	std::future<response::Value> resolveCompleteTask(service::ResolverParams&& params);
+	std::future<response::Value> resolveSetFloat(service::ResolverParams&& params);
 
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };

--- a/samples/today/TodayMock.cpp
+++ b/samples/today/TodayMock.cpp
@@ -394,6 +394,19 @@ service::FieldResult<std::shared_ptr<object::CompleteTaskPayload>> Mutation::app
 	return promise.get_future();
 }
 
+std::optional<response::FloatType> Mutation::_setFloat = std::nullopt;
+
+double Mutation::getFloat() noexcept
+{
+	return *_setFloat;
+}
+
+service::FieldResult<response::FloatType> Mutation::applySetFloat(service::FieldParams&& params, response::FloatType&& valueArg) const
+{
+	_setFloat = std::make_optional(valueArg);
+	return valueArg;
+}
+
 std::stack<CapturedParams> NestedType::_capturedParams;
 
 NestedType::NestedType(service::FieldParams&& params, int depth)

--- a/samples/today/TodayMock.h
+++ b/samples/today/TodayMock.h
@@ -402,10 +402,14 @@ public:
 
 	explicit Mutation(completeTaskMutation&& mutateCompleteTask);
 
+	static double getFloat() noexcept;
+
 	service::FieldResult<std::shared_ptr<object::CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& input) const final;
+	service::FieldResult<response::FloatType> applySetFloat(service::FieldParams&& params, response::FloatType&& valueArg) const final;
 
 private:
 	completeTaskMutation _mutateCompleteTask;
+	static std::optional<response::FloatType> _setFloat;
 };
 
 class Subscription : public object::Subscription

--- a/samples/unified/TodaySchema.h
+++ b/samples/unified/TodaySchema.h
@@ -245,9 +245,11 @@ protected:
 
 public:
 	virtual service::FieldResult<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const;
+	virtual service::FieldResult<response::FloatType> applySetFloat(service::FieldParams&& params, response::FloatType&& valueArg) const;
 
 private:
 	std::future<response::Value> resolveCompleteTask(service::ResolverParams&& params);
+	std::future<response::Value> resolveSetFloat(service::ResolverParams&& params);
 
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };

--- a/src/GraphQLResponse.cpp
+++ b/src/GraphQLResponse.cpp
@@ -363,12 +363,20 @@ void Value::set<BooleanType>(BooleanType value)
 template <>
 void Value::set<IntType>(IntType value)
 {
-	if (type() != Type::Int)
+	if (type() == Type::Float)
 	{
-		throw std::logic_error("Invalid call to Value::set for IntType");
+		// Coerce IntType to FloatType
+		*_data = { static_cast<FloatType>(value) };
 	}
+	else
+	{
+		if (type() != Type::Int)
+		{
+			throw std::logic_error("Invalid call to Value::set for IntType");
+		}
 
-	*_data = { value };
+		*_data = { value };
+	}
 }
 
 template <>
@@ -452,6 +460,12 @@ IntType Value::get<IntType>() const
 template <>
 FloatType Value::get<FloatType>() const
 {
+	if (type() == Type::Int)
+	{
+		// Coerce IntType to FloatType
+		return static_cast<FloatType>(std::get<IntType>(*_data));
+	}
+
 	if (type() != Type::Float)
 	{
 		throw std::logic_error("Invalid call to Value::get for FloatType");

--- a/test/TodayTests.cpp
+++ b/test/TodayTests.cpp
@@ -1495,3 +1495,32 @@ TEST_F(TodayServiceCase, SubscribeUnsubscribeNotificationsDeferred)
 		FAIL() << response::toJSON(ex.getErrors());
 	}
 }
+
+TEST_F(TodayServiceCase, MutateSetFloat)
+{
+	auto query = R"(mutation {
+			setFloat(value: 0.1)
+		})"_graphql;
+	response::Value variables(response::Type::Map);
+	auto state = std::make_shared<today::RequestState>(22);
+	auto result = _service->resolve(state, query, "", std::move(variables)).get();
+
+	try
+	{
+		ASSERT_TRUE(result.type() == response::Type::Map);
+		auto errorsItr = result.find("errors");
+		if (errorsItr != result.get<response::MapType>().cend())
+		{
+			FAIL() << response::toJSON(response::Value(errorsItr->second));
+		}
+		const auto data = service::ScalarArgument::require("data", result);
+		ASSERT_TRUE(data.type() == response::Type::Map);
+		const auto setFloat = service::FloatArgument::require("setFloat", data);
+		ASSERT_EQ(0.1, setFloat) << "should return the value that was set";
+		ASSERT_EQ(0.1, today::Mutation::getFloat()) << "should save the value in the Mutation static member";
+	}
+	catch (service::schema_exception & ex)
+	{
+		FAIL() << response::toJSON(ex.getErrors());
+	}
+}

--- a/test/TodayTests.cpp
+++ b/test/TodayTests.cpp
@@ -1524,3 +1524,32 @@ TEST_F(TodayServiceCase, MutateSetFloat)
 		FAIL() << response::toJSON(ex.getErrors());
 	}
 }
+
+TEST_F(TodayServiceCase, MutateCoerceSetFloat)
+{
+	auto query = R"(mutation {
+			coerceFloat: setFloat(value: 1)
+		})"_graphql;
+	response::Value variables(response::Type::Map);
+	auto state = std::make_shared<today::RequestState>(22);
+	auto result = _service->resolve(state, query, "", std::move(variables)).get();
+
+	try
+	{
+		ASSERT_TRUE(result.type() == response::Type::Map);
+		auto errorsItr = result.find("errors");
+		if (errorsItr != result.get<response::MapType>().cend())
+		{
+			FAIL() << response::toJSON(response::Value(errorsItr->second));
+		}
+		const auto data = service::ScalarArgument::require("data", result);
+		ASSERT_TRUE(data.type() == response::Type::Map);
+		const auto coerceFloat = service::FloatArgument::require("coerceFloat", data);
+		ASSERT_EQ(1.0, coerceFloat) << "should return the value that was coerced from an int";
+		ASSERT_EQ(1.0, today::Mutation::getFloat()) << "should save the value in the Mutation static member";
+	}
+	catch (service::schema_exception & ex)
+	{
+		FAIL() << response::toJSON(ex.getErrors());
+	}
+}


### PR DESCRIPTION
Fix #120 

There were two bugs reported in this issue, the first is that whole numbers (`IntValue`) don't get coerced to floats (`FloatValue`). I added coercion handling to `ModifiedArgument` and `response::Value::get`/`set` to treat integers as valid inputs and automatically `static_cast` them to `FloatType` if that is the expected type. I added a unit test for this case. 

The second was that the grammar doesn't parse float input values. It rejects them as malformed integers. I swapped the order that `input_value_content` matches them so that the more specific `float_value` is tested first, and I added a unit test for this as well.