### PR TITLE
Add a default template argument to ModifiedArgument<T>::find<...>

### DIFF
--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -423,7 +423,7 @@ struct ModifiedArgument
 	}
 
 	// Wrap require with modifiers in a try/catch block.
-	template <TypeModifier Modifier, TypeModifier... Other>
+	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
 	static std::pair<typename ArgumentTraits<Type, Modifier, Other...>::type, bool> find(
 		const std::string& name, const response::Value& arguments) noexcept
 	{

--- a/test/ArgumentTests.cpp
+++ b/test/ArgumentTests.cpp
@@ -291,3 +291,43 @@ TEST(ArgumentsCase, ScalarArgumentString)
 	ASSERT_EQ(response::Type::String, actual.type()) << "should parse the object";
 	ASSERT_EQ("foobar", actual.get<response::StringType>()) << "should match the value";
 }
+
+TEST(ArgumentsCase, FindArgumentNoTemplateArguments)
+{
+	response::Value response(response::Type::Map);
+	response.emplace_back("scalar", response::Value("foobar"));
+	std::pair<response::Value, bool> actual { {}, false };
+
+	try
+	{
+		actual = service::ModifiedArgument<response::Value>::find("scalar", response);
+	}
+	catch (service::schema_exception& ex)
+	{
+		FAIL() << response::toJSON(ex.getErrors());
+	}
+
+	ASSERT_TRUE(actual.second) << "should find the argument";
+	ASSERT_EQ(response::Type::String, actual.first.type()) << "should parse the object";
+	ASSERT_EQ("foobar", actual.first.get<response::StringType>()) << "should match the value";
+}
+
+TEST(ArgumentsCase, FindArgumentEmptyTemplateArgs)
+{
+	response::Value response(response::Type::Map);
+	response.emplace_back("scalar", response::Value("foobar"));
+	std::pair<response::Value, bool> actual { {}, false };
+
+	try
+	{
+		actual = service::ModifiedArgument<response::Value>::find<>("scalar", response);
+	}
+	catch (service::schema_exception& ex)
+	{
+		FAIL() << response::toJSON(ex.getErrors());
+	}
+
+	ASSERT_TRUE(actual.second) << "should find the argument";
+	ASSERT_EQ(response::Type::String, actual.first.type()) << "should parse the object";
+	ASSERT_EQ("foobar", actual.first.get<response::StringType>()) << "should match the value";
+}


### PR DESCRIPTION
`ModifiedArgument<T>::require<>` works without any default arguments, but `ModifiedArgument<T>::find<>` does not. This change adds a default `TypeModifier::None` template argument to the method declaration which gets forwarded to `require<>`.