### PR TITLE
Update to PEGTL 3.0.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ exposes an instance of [GraphiQL](https://github.com/graphql/graphiql) on top of
 
 ## Installation process
 
-I've tested this on Windows with both Visual Studio 2017 and 2019, and on Linux using an Ubuntu 18.04 LTS instance running in
-WSL with both gcc 7.3.0 and clang 6.0.0. The key compiler requirement is support for C++17, earlier versions of gcc and clang
-may not have enough support for that.
+I've tested this on Windows with both Visual Studio 2017 and 2019, and on Linux using an Ubuntu 20.04 LTS instance running in
+WSL with both gcc 9.3.0 and clang 10.0.0. The key compiler requirement is support for C++17 including std::filesystem, earlier
+versions of gcc and clang may not have enough support for that.
 
 The easiest way to get all of these and to build `cppgraphqlgen` in one step is to use
 [microsoft/vcpkg](https://github.com/microsoft/vcpkg). To install with vcpkg, make sure you've pulled the latest version
@@ -68,7 +68,7 @@ means you need to include an acknowledgement along with the license text.
 - GraphQL parsing: [Parsing Expression Grammar Template Library (PEGTL)](https://github.com/taocpp/PEGTL) release 3.0.0,
 which is part of [The Art of C++](https://taocpp.github.io/) library collection. I've added this as a sub-module, so you
 do not need to install this separately. If you already have 3.0.0 installed where CMake can find it, it will use that
-instead of the sub-module and avoid installing another copy of PEGTL. _Note: PEGTL 3.0.0 is currently at pre-release._
+instead of the sub-module and avoid installing another copy of PEGTL.
 
 ### graphqlservice
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The easiest way to get all of these and to build `cppgraphqlgen` in one step is 
 [microsoft/vcpkg](https://github.com/microsoft/vcpkg). To install with vcpkg, make sure you've pulled the latest version
 and then run `vcpkg install cppgraphqlgen` (or `cppgraphqlgen:x64-windows`, `cppgraphqlgen:x86-windows-static`, etc.
 depending on your platform). To install just the dependencies and work in a clone of this repo, you'll need some subset
-of `vcpkg install pegtl boost-program-options boost-filesystem rapidjson gtest`. It works for Windows, Linux, and Mac,
+of `vcpkg install pegtl boost-program-options rapidjson gtest`. It works for Windows, Linux, and Mac,
 but if you want to try building for another platform (e.g. Android or iOS), you'll need to do more of this manually.
 
 Manual installation will work best if you clone the GitHub repos for each of the dependencies and follow the installation
@@ -85,11 +85,6 @@ do that.
 
 I'm using [Boost](https://www.boost.org/doc/libs/1_69_0/more/getting_started/index.html) for `schemagen`:
 
-- C++17 std::filesystem support on Unix:
-[Boost.Filesystem](https://www.boost.org/doc/libs/1_69_0/libs/filesystem/doc/index.htm). Most of the default C++
-compilers on Linux still have `std::filesystem` from C++17 in an experimental directory and require an extra
-library. The standard just adopted the Boost library, so on Unix systems I have an `#ifdef` which redirects back to
-it for the time being.
 - Command line handling: [Boost.Program_options](https://www.boost.org/doc/libs/1_69_0/doc/html/program_options.html).
 Run `schemagen -?` to get a list of options. Many of the files in the [samples](samples/) directory were generated
 with `schemagen`, you can look at [samples/CMakeLists.txt](samples/CMakeLists.txt) for a few examples of how to call it:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,12 +51,6 @@ if(GRAPHQL_BUILD_SCHEMAGEN)
   set(BOOST_COMPONENTS program_options)
   set(BOOST_LIBRARIES Boost::program_options)
   
-  if(NOT MSVC)
-    set(BOOST_COMPONENTS ${BOOST_COMPONENTS} filesystem)
-    set(BOOST_LIBRARIES ${BOOST_LIBRARIES} Boost::filesystem)
-    target_compile_options(schemagen PRIVATE -DUSE_BOOST_FILESYSTEM)
-  endif()
-  
   find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
   target_link_libraries(schemagen PRIVATE ${BOOST_LIBRARIES})
   

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -5,15 +5,8 @@
 
 #include <boost/program_options.hpp>
 
-#ifdef USE_BOOST_FILESYSTEM
-#include <boost/filesystem.hpp>
-namespace fs = boost::filesystem;
-#else
-#include <filesystem>
-namespace fs = std::filesystem;
-#endif
-
 #include <cctype>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <regex>
@@ -304,11 +297,11 @@ std::string Generator::getHeaderDir() const noexcept
 {
 	if (_isIntrospection)
 	{
-		return (fs::path { "include" } / "graphqlservice").string();
+		return (std::filesystem::path { "include" } / "graphqlservice").string();
 	}
 	else if (_options.paths)
 	{
-		return fs::path { _options.paths->headerPath }.string();
+		return std::filesystem::path { _options.paths->headerPath }.string();
 	}
 	else
 	{
@@ -324,13 +317,13 @@ std::string Generator::getSourceDir() const noexcept
 	}
 	else
 	{
-		return fs::path(_options.paths->sourcePath).string();
+		return std::filesystem::path(_options.paths->sourcePath).string();
 	}
 }
 
 std::string Generator::getHeaderPath() const noexcept
 {
-	fs::path fullPath { _headerDir };
+	std::filesystem::path fullPath { _headerDir };
 
 	if (_isIntrospection)
 	{
@@ -348,7 +341,7 @@ std::string Generator::getObjectHeaderPath() const noexcept
 {
 	if (_options.separateFiles)
 	{
-		fs::path fullPath { _headerDir };
+		std::filesystem::path fullPath { _headerDir };
 
 		fullPath /= (_options.customSchema->filenamePrefix + "Objects.h");
 		return fullPath.string();
@@ -359,7 +352,7 @@ std::string Generator::getObjectHeaderPath() const noexcept
 
 std::string Generator::getSourcePath() const noexcept
 {
-	fs::path fullPath { _sourceDir };
+	std::filesystem::path fullPath { _sourceDir };
 
 	if (_isIntrospection)
 	{
@@ -1666,7 +1659,8 @@ std::string Generator::getOutputCppType(const OutputField& field) const noexcept
 bool Generator::outputHeader() const noexcept
 {
 	std::ofstream headerFile(_headerPath, std::ios_base::trunc);
-	IncludeGuardScope includeGuard { headerFile, fs::path(_headerPath).filename().string() };
+	IncludeGuardScope includeGuard { headerFile,
+		std::filesystem::path(_headerPath).filename().string() };
 
 	headerFile << R"cpp(#include "graphqlservice/GraphQLService.h"
 
@@ -2048,8 +2042,8 @@ bool Generator::outputSource() const noexcept
 )cpp";
 	if (!_isIntrospection)
 	{
-		sourceFile << R"cpp(#include ")cpp" << fs::path(_objectHeaderPath).filename().string()
-				   << R"cpp("
+		sourceFile << R"cpp(#include ")cpp"
+				   << std::filesystem::path(_objectHeaderPath).filename().string() << R"cpp("
 
 )cpp";
 	}
@@ -3427,8 +3421,8 @@ std::string Generator::getIntrospectionType(
 std::vector<std::string> Generator::outputSeparateFiles() const noexcept
 {
 	std::vector<std::string> files;
-	const fs::path headerDir(_headerDir);
-	const fs::path sourceDir(_sourceDir);
+	const std::filesystem::path headerDir(_headerDir);
+	const std::filesystem::path sourceDir(_sourceDir);
 	std::string queryType;
 
 	for (const auto& operation : _operationTypes)
@@ -3443,10 +3437,10 @@ std::vector<std::string> Generator::outputSeparateFiles() const noexcept
 	// Output a convenience header
 	std::ofstream objectHeaderFile(_objectHeaderPath, std::ios_base::trunc);
 	IncludeGuardScope includeGuard { objectHeaderFile,
-		fs::path(_objectHeaderPath).filename().string() };
+		std::filesystem::path(_objectHeaderPath).filename().string() };
 
-	objectHeaderFile << R"cpp(#include ")cpp" << fs::path(_headerPath).filename().string()
-					 << R"cpp("
+	objectHeaderFile << R"cpp(#include ")cpp"
+					 << std::filesystem::path(_headerPath).filename().string() << R"cpp("
 
 )cpp";
 
@@ -3480,7 +3474,8 @@ std::vector<std::string> Generator::outputSeparateFiles() const noexcept
 		std::ofstream headerFile(headerPath, std::ios_base::trunc);
 		IncludeGuardScope includeGuard { headerFile, headerFilename };
 
-		headerFile << R"cpp(#include ")cpp" << fs::path(_headerPath).filename().string() << R"cpp("
+		headerFile << R"cpp(#include ")cpp"
+				   << std::filesystem::path(_headerPath).filename().string() << R"cpp("
 
 )cpp";
 
@@ -3503,7 +3498,7 @@ std::vector<std::string> Generator::outputSeparateFiles() const noexcept
 		sourceFile << R"cpp(// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include ")cpp" << fs::path(_objectHeaderPath).filename().string()
+#include ")cpp" << std::filesystem::path(_objectHeaderPath).filename().string()
 				   << R"cpp("
 
 #include "graphqlservice/Introspection.h"


### PR DESCRIPTION
Sync to the 3.0.0 tag on the `PEGTL` submodule and update all of the `std::filesystem` dependencies/docs to remove the `boost-filesystem` fallback now that `PEGTL` depends on `std::filesystem`. That means I also bumped the Linux compiler versions up in the "tested with" section, it may work with a lower version number of either `gcc` or `clang`, but I haven't tried to find a lower version number than the latest LTS versions.