### PR TITLE
Re-add the Boost.Filesystem fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endfunction()
 
 find_package(Threads MODULE REQUIRED)
 
-find_package(pegtl 3.0.0 QUIET CONFIG)
+find_package(pegtl 3.0.1 QUIET CONFIG)
 if(NOT pegtl_FOUND)
   # If a compatible version of PEGTL is not already installed, build and install it from the submodule directory.
   set(PEGTL_BUILD_TESTS OFF CACHE BOOL "Disable PEGTL tests")

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The easiest way to get all of these and to build `cppgraphqlgen` in one step is 
 [microsoft/vcpkg](https://github.com/microsoft/vcpkg). To install with vcpkg, make sure you've pulled the latest version
 and then run `vcpkg install cppgraphqlgen` (or `cppgraphqlgen:x64-windows`, `cppgraphqlgen:x86-windows-static`, etc.
 depending on your platform). To install just the dependencies and work in a clone of this repo, you'll need some subset
-of `vcpkg install pegtl boost-program-options rapidjson gtest`. It works for Windows, Linux, and Mac,
+of `vcpkg install pegtl boost-program-options boost-filesystem rapidjson gtest`. It works for Windows, Linux, and Mac,
 but if you want to try building for another platform (e.g. Android or iOS), you'll need to do more of this manually.
 
 Manual installation will work best if you clone the GitHub repos for each of the dependencies and follow the installation
@@ -85,6 +85,11 @@ do that.
 
 I'm using [Boost](https://www.boost.org/doc/libs/1_69_0/more/getting_started/index.html) for `schemagen`:
 
+- C++17 std::filesystem support on Unix:
+[Boost.Filesystem](https://www.boost.org/doc/libs/1_69_0/libs/filesystem/doc/index.htm). Most of the default C++
+compilers on Linux still have `std::filesystem` from C++17 in an experimental directory and require an extra
+library. The standard just adopted the Boost library, so on Unix systems I have an `#ifdef` which redirects back to
+it for the time being.
 - Command line handling: [Boost.Program_options](https://www.boost.org/doc/libs/1_69_0/doc/html/program_options.html).
 Run `schemagen -?` to get a list of options. Many of the files in the [samples](samples/) directory were generated
 with `schemagen`, you can look at [samples/CMakeLists.txt](samples/CMakeLists.txt) for a few examples of how to call it:

--- a/cmake/test_filesystem.cpp.in
+++ b/cmake/test_filesystem.cpp.in
@@ -1,0 +1,22 @@
+// This is a dummy program that just needs to compile and link to tell us if
+// the C++17 std::filesystem API is available. Use CMake's configure_file
+// command to replace the FILESYSTEM_HEADER and FILESYSTEM_NAMESPACE tokens
+// for each combination of headers and namespaces which we want to pass to the
+// CMake try_compile command.
+
+#include <@FILESYSTEM_HEADER@>
+
+int main()
+{
+    try
+    {
+        throw @FILESYSTEM_NAMESPACE@::filesystem_error("instantiate one to make sure it links",
+            std::make_error_code(std::errc::function_not_supported));
+    }
+    catch (const @FILESYSTEM_NAMESPACE@::filesystem_error& error)
+    {
+        return -1;
+    }
+
+    return !@FILESYSTEM_NAMESPACE@::temp_directory_path().is_absolute();
+}

--- a/include/Validation.h
+++ b/include/Validation.h
@@ -227,6 +227,7 @@ private:
 	using OperationVariables = std::optional<VariableTypes>;
 	using VariableSet = std::set<std::string>;
 
+	// These members store Introspection schema information which does not change between queries.
 	OperationTypes _operationTypes;
 	ValidateTypeKinds _typeKinds;
 	MatchingTypes _matchingTypes;
@@ -234,15 +235,18 @@ private:
 	EnumValues _enumValues;
 	ScalarTypes _scalarTypes;
 
+	// These members store information that's specific to a single query and changes every time we
+	// visit a new one. They must be reset in between queries.
 	ExecutableNodes _fragmentDefinitions;
 	ExecutableNodes _operationDefinitions;
+	FragmentSet _referencedFragments;
+	FragmentSet _fragmentCycles;
 
+	// These members store state for the visitor. They implicitly reset each time we call visit.
 	OperationVariables _operationVariables;
 	VariableDefinitions _variableDefinitions;
 	VariableSet _referencedVariables;
-	FragmentSet _referencedFragments;
 	FragmentSet _fragmentStack;
-	FragmentSet _fragmentCycles;
 	size_t _fieldCount = 0;
 	TypeFields _typeFields;
 	InputTypeFields _inputTypeFields;

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -947,6 +947,9 @@ struct SubscriptionData : std::enable_shared_from_this<SubscriptionData>
 	const peg::ast_node& selection;
 };
 
+// Forward declare just the class type so we can reference it in the Request::_validation member.
+class ValidateExecutableVisitor;
+
 // Request scans the fragment definitions and finds the right operation definition to interpret
 // depending on the operation name (which might be empty for a single-operation document). It
 // also needs the values of the request variables.
@@ -954,7 +957,7 @@ class Request : public std::enable_shared_from_this<Request>
 {
 protected:
 	GRAPHQLSERVICE_EXPORT explicit Request(TypeMap&& operationTypes);
-	GRAPHQLSERVICE_EXPORT virtual ~Request() = default;
+	GRAPHQLSERVICE_EXPORT virtual ~Request();
 
 public:
 	GRAPHQLSERVICE_EXPORT std::vector<schema_error> validate(peg::ast& query) const;
@@ -1025,6 +1028,7 @@ private:
 		const std::string& operationName, response::Value&& variables) const;
 
 	TypeMap _operations;
+	std::unique_ptr<ValidateExecutableVisitor> _validation;
 	std::map<SubscriptionKey, std::shared_ptr<SubscriptionData>> _subscriptions;
 	std::unordered_map<SubscriptionName, std::set<SubscriptionKey>> _listeners;
 	SubscriptionKey _nextKey = 0;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,12 @@ if(GRAPHQL_BUILD_SCHEMAGEN)
   set(BOOST_COMPONENTS program_options)
   set(BOOST_LIBRARIES Boost::program_options)
   
+  if(NOT MSVC)
+    set(BOOST_COMPONENTS ${BOOST_COMPONENTS} filesystem)
+    set(BOOST_LIBRARIES ${BOOST_LIBRARIES} Boost::filesystem)
+    target_compile_options(schemagen PRIVATE -DUSE_BOOST_FILESYSTEM)
+  endif()
+  
   find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
   target_link_libraries(schemagen PRIVATE ${BOOST_LIBRARIES})
   

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,13 +50,55 @@ if(GRAPHQL_BUILD_SCHEMAGEN)
   
   set(BOOST_COMPONENTS program_options)
   set(BOOST_LIBRARIES Boost::program_options)
-  
-  if(NOT MSVC)
-    set(BOOST_COMPONENTS ${BOOST_COMPONENTS} filesystem)
-    set(BOOST_LIBRARIES ${BOOST_LIBRARIES} Boost::filesystem)
-    target_compile_options(schemagen PRIVATE -DUSE_BOOST_FILESYSTEM)
+
+  # Try compiling a test program with std::filesystem or one of its alternatives.
+  function(check_filesystem_impl FILESYSTEM_HEADER FILESYSTEM_NAMESPACE OPTIONAL_LIBS OUT_RESULT)
+    set(TEST_FILE "test_${OUT_RESULT}.cpp")
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/test_filesystem.cpp.in ${TEST_FILE} @ONLY)
+
+    try_compile(TEST_RESULT
+      ${CMAKE_CURRENT_BINARY_DIR}
+      ${CMAKE_CURRENT_BINARY_DIR}/${TEST_FILE}
+      CXX_STANDARD 17)
+
+    if(NOT TEST_RESULT)
+      # Retry with each of the optional libraries.
+      foreach(OPTIONAL_LIB IN LISTS OPTIONAL_LIBS)
+        try_compile(TEST_RESULT
+          ${CMAKE_CURRENT_BINARY_DIR}
+          ${CMAKE_CURRENT_BINARY_DIR}/${TEST_FILE}
+          LINK_LIBRARIES ${OPTIONAL_LIB}
+          CXX_STANDARD 17)
+
+        if(TEST_RESULT)
+          # Looks like the optional library was required, go ahead and add it to the link options.
+          target_link_libraries(schemagen PRIVATE ${OPTIONAL_LIB})
+          break()
+        endif()
+      endforeach(OPTIONAL_LIB)
+    endif()
+
+    set(${OUT_RESULT} ${TEST_RESULT} PARENT_SCOPE)
+  endfunction(check_filesystem_impl)
+
+  # Try compiling a minimal program with each header/namespace, in order of preference:
+  #   C++17: #include <filesystem> // std::filesystem
+  #   Experimental C++17: #include <experimental/filesystem> // std::experimental::filesystem
+  #   Boost.Filesystem: #include <boost/filesystem.hpp> // boost::filesystem
+  check_filesystem_impl("filesystem" "std::filesystem" "stdc++fs;c++fs" STD_FILESYTEM)
+  if(STD_FILESYTEM)
+    target_compile_definitions(schemagen PRIVATE USE_STD_FILESYSTEM)
+  else()
+    check_filesystem_impl("experimental/filesystem" "std::experimental::filesystem" "stdc++fs;c++fs" STD_EXPERIMENTAL_FILESYTEM)
+    if(STD_EXPERIMENTAL_FILESYTEM)
+      target_compile_definitions(schemagen PRIVATE USE_STD_EXPERIMENTAL_FILESYSTEM)
+    else()
+      set(BOOST_COMPONENTS ${BOOST_COMPONENTS} filesystem)
+      set(BOOST_LIBRARIES ${BOOST_LIBRARIES} Boost::filesystem)
+      target_compile_definitions(schemagen PRIVATE USE_BOOST_FILESYSTEM)
+    endif()
   endif()
-  
+
   find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
   target_link_libraries(schemagen PRIVATE ${BOOST_LIBRARIES})
   

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -5,8 +5,15 @@
 
 #include <boost/program_options.hpp>
 
-#include <cctype>
+#ifdef USE_BOOST_FILESYSTEM
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+#else
 #include <filesystem>
+namespace fs = std::filesystem;
+#endif
+
+#include <cctype>
 #include <fstream>
 #include <iostream>
 #include <regex>
@@ -297,11 +304,11 @@ std::string Generator::getHeaderDir() const noexcept
 {
 	if (_isIntrospection)
 	{
-		return (std::filesystem::path { "include" } / "graphqlservice").string();
+		return (fs::path { "include" } / "graphqlservice").string();
 	}
 	else if (_options.paths)
 	{
-		return std::filesystem::path { _options.paths->headerPath }.string();
+		return fs::path { _options.paths->headerPath }.string();
 	}
 	else
 	{
@@ -317,13 +324,13 @@ std::string Generator::getSourceDir() const noexcept
 	}
 	else
 	{
-		return std::filesystem::path(_options.paths->sourcePath).string();
+		return fs::path(_options.paths->sourcePath).string();
 	}
 }
 
 std::string Generator::getHeaderPath() const noexcept
 {
-	std::filesystem::path fullPath { _headerDir };
+	fs::path fullPath { _headerDir };
 
 	if (_isIntrospection)
 	{
@@ -341,7 +348,7 @@ std::string Generator::getObjectHeaderPath() const noexcept
 {
 	if (_options.separateFiles)
 	{
-		std::filesystem::path fullPath { _headerDir };
+		fs::path fullPath { _headerDir };
 
 		fullPath /= (_options.customSchema->filenamePrefix + "Objects.h");
 		return fullPath.string();
@@ -352,7 +359,7 @@ std::string Generator::getObjectHeaderPath() const noexcept
 
 std::string Generator::getSourcePath() const noexcept
 {
-	std::filesystem::path fullPath { _sourceDir };
+	fs::path fullPath { _sourceDir };
 
 	if (_isIntrospection)
 	{
@@ -1659,8 +1666,7 @@ std::string Generator::getOutputCppType(const OutputField& field) const noexcept
 bool Generator::outputHeader() const noexcept
 {
 	std::ofstream headerFile(_headerPath, std::ios_base::trunc);
-	IncludeGuardScope includeGuard { headerFile,
-		std::filesystem::path(_headerPath).filename().string() };
+	IncludeGuardScope includeGuard { headerFile, fs::path(_headerPath).filename().string() };
 
 	headerFile << R"cpp(#include "graphqlservice/GraphQLService.h"
 
@@ -2042,8 +2048,8 @@ bool Generator::outputSource() const noexcept
 )cpp";
 	if (!_isIntrospection)
 	{
-		sourceFile << R"cpp(#include ")cpp"
-				   << std::filesystem::path(_objectHeaderPath).filename().string() << R"cpp("
+		sourceFile << R"cpp(#include ")cpp" << fs::path(_objectHeaderPath).filename().string()
+				   << R"cpp("
 
 )cpp";
 	}
@@ -3421,8 +3427,8 @@ std::string Generator::getIntrospectionType(
 std::vector<std::string> Generator::outputSeparateFiles() const noexcept
 {
 	std::vector<std::string> files;
-	const std::filesystem::path headerDir(_headerDir);
-	const std::filesystem::path sourceDir(_sourceDir);
+	const fs::path headerDir(_headerDir);
+	const fs::path sourceDir(_sourceDir);
 	std::string queryType;
 
 	for (const auto& operation : _operationTypes)
@@ -3437,10 +3443,10 @@ std::vector<std::string> Generator::outputSeparateFiles() const noexcept
 	// Output a convenience header
 	std::ofstream objectHeaderFile(_objectHeaderPath, std::ios_base::trunc);
 	IncludeGuardScope includeGuard { objectHeaderFile,
-		std::filesystem::path(_objectHeaderPath).filename().string() };
+		fs::path(_objectHeaderPath).filename().string() };
 
-	objectHeaderFile << R"cpp(#include ")cpp"
-					 << std::filesystem::path(_headerPath).filename().string() << R"cpp("
+	objectHeaderFile << R"cpp(#include ")cpp" << fs::path(_headerPath).filename().string()
+					 << R"cpp("
 
 )cpp";
 
@@ -3474,8 +3480,7 @@ std::vector<std::string> Generator::outputSeparateFiles() const noexcept
 		std::ofstream headerFile(headerPath, std::ios_base::trunc);
 		IncludeGuardScope includeGuard { headerFile, headerFilename };
 
-		headerFile << R"cpp(#include ")cpp"
-				   << std::filesystem::path(_headerPath).filename().string() << R"cpp("
+		headerFile << R"cpp(#include ")cpp" << fs::path(_headerPath).filename().string() << R"cpp("
 
 )cpp";
 
@@ -3498,7 +3503,7 @@ std::vector<std::string> Generator::outputSeparateFiles() const noexcept
 		sourceFile << R"cpp(// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include ")cpp" << std::filesystem::path(_objectHeaderPath).filename().string()
+#include ")cpp" << fs::path(_objectHeaderPath).filename().string()
 				   << R"cpp("
 
 #include "graphqlservice/Introspection.h"

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -5,13 +5,24 @@
 
 #include <boost/program_options.hpp>
 
-#ifdef USE_BOOST_FILESYSTEM
-#include <boost/filesystem.hpp>
-namespace fs = boost::filesystem;
+// clang-format off
+#ifdef USE_STD_FILESYSTEM
+	#include <filesystem>
+	namespace fs = std::filesystem;
 #else
-#include <filesystem>
-namespace fs = std::filesystem;
+	#ifdef USE_STD_EXPERIMENTAL_FILESYSTEM
+		#include <experimental/filesystem>
+		namespace fs = std::experimental::filesystem;
+	#else
+		#ifdef USE_BOOST_FILESYSTEM
+			#include <boost/filesystem.hpp>
+			namespace fs = boost::filesystem;
+		#else
+			#error "No std::filesystem implementation defined"
+		#endif
+	#endif
 #endif
+// clang-format on
 
 #include <cctype>
 #include <fstream>

--- a/src/Validation.cpp
+++ b/src/Validation.cpp
@@ -792,6 +792,12 @@ std::vector<schema_error> ValidateExecutableVisitor::getStructuredErrors()
 {
 	auto errors = std::move(_errors);
 
+	// Reset all of the state for this query, but keep the Introspection schema information.
+	_fragmentDefinitions.clear();
+	_operationDefinitions.clear();
+	_referencedFragments.clear();
+	_fragmentCycles.clear();
+
 	return errors;
 }
 


### PR DESCRIPTION
After figuring out how to auto-detect `std::filesystem` support in PEGTL, I ported some of that CMake logic to this project. Now that they both have this capability, I can resume updating the vcpkg ports.