### PR TITLE
Merge cached validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ Debug/
 Release/
 Testing/
 Win32/
-/include/graphqlservice/IntrospectionSchema.h
+/include/graphqlservice/introspection/IntrospectionSchema.h
 /IntrospectionSchema.cpp
 *.filters
 *.vcxproj

--- a/.gitignore
+++ b/.gitignore
@@ -27,12 +27,15 @@ Makefile
 .ninja_*
 schemagen
 settings.json
+/samples/benchmark
 /samples/sample
+/samples/sample_nointrospection
 /src/cmake/
 /test/argument_tests
 /test/pegtl_tests
 /test/response_tests
 /test/today_tests
+/test/nointrospection_tests
 build/
 install/
 isenseconfig/

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Makefile
 schemagen
 settings.json
 /samples/benchmark
+/samples/benchmark_nointrospection
 /samples/sample
 /samples/sample_nointrospection
 /src/cmake/

--- a/doc/subscriptions.md
+++ b/doc/subscriptions.md
@@ -83,8 +83,8 @@ tell which operation type it is without parsing the query and searching for
 a specific operation name, so it's hard to tell whether you should call
 `resolve` or `subscribe` when the request is received that way. To help with
 that, there's a public `Request::findOperationDefinition` method which returns
-the operation type as a `std::string` along with a pointer to the AST node for
+the operation type as a `std::string_view` along with a pointer to the AST node for
 the selected operation in the parsed query:
 ```cpp
-std::pair<std::string, const peg::ast_node*> findOperationDefinition(const peg::ast_node& root, const std::string& operationName) const;
+std::pair<std::string_view, const peg::ast_node*> findOperationDefinition(peg::ast& root, std::string_view operationName) const;
 ```

--- a/include/SchemaGenerator.h
+++ b/include/SchemaGenerator.h
@@ -281,7 +281,7 @@ public:
 	bool reset() noexcept;
 
 private:
-	bool _pending = false;
+	bool _pending = true;
 	std::ostream& _outputFile;
 };
 

--- a/include/SchemaGenerator.h
+++ b/include/SchemaGenerator.h
@@ -237,6 +237,7 @@ struct GeneratorOptions
 	const bool verbose = false;
 	const bool separateFiles = false;
 	const bool noStubs = false;
+	const bool noIntrospection = false;
 };
 
 // RAII object to help with emitting matching include guard begin and end statements

--- a/include/Validation.h
+++ b/include/Validation.h
@@ -122,12 +122,12 @@ using ValidateFieldArguments = std::map<std::string_view, ValidateArgumentValueP
 
 struct ValidateField
 {
-	ValidateField(std::string_view returnType, std::optional<std::string_view> objectType,
+	ValidateField(std::string&& returnType, std::optional<std::string_view> objectType,
 		std::string_view fieldName, ValidateFieldArguments&& arguments);
 
 	bool operator==(const ValidateField& other) const;
 
-	std::string_view returnType;
+	std::string returnType;
 	std::optional<std::string_view> objectType;
 	std::string_view fieldName;
 	ValidateFieldArguments arguments;
@@ -140,7 +140,7 @@ using ValidateTypeKinds = std::map<std::string_view, introspection::TypeKind>;
 class ValidateVariableTypeVisitor
 {
 public:
-	ValidateVariableTypeVisitor(const schema::Schema& schema, const ValidateTypeKinds& typeKinds);
+	ValidateVariableTypeVisitor(const std::shared_ptr<schema::Schema>& schema, const ValidateTypeKinds& typeKinds);
 
 	void visit(const peg::ast_node& typeName);
 
@@ -152,7 +152,7 @@ private:
 	void visitListType(const peg::ast_node& listType);
 	void visitNonNullType(const peg::ast_node& nonNullType);
 
-	const schema::Schema& _schema;
+	const std::shared_ptr<schema::Schema>& _schema;
 	const ValidateTypeKinds& _typeKinds;
 
 	bool _isInputType = false;

--- a/include/graphqlservice/GraphQLGrammar.h
+++ b/include/graphqlservice/GraphQLGrammar.h
@@ -49,10 +49,14 @@ void on_first_child_if(const ast_node& n, std::function<bool(const ast_node&)>&&
 template <typename Rule>
 void on_first_child(const ast_node& n, std::function<void(const ast_node&)>&& func)
 {
-	on_first_child_if<Rule>(n, [funcVoid = std::move(func)](const ast_node& child) {
-		funcVoid(child);
-		return true;
-	});
+	for (const auto& child : n.children)
+	{
+		if (child->is_type<Rule>())
+		{
+			func(*child);
+			return;
+		}
+	}
 }
 
 // https://facebook.github.io/graphql/June2018/#sec-Source-Text

--- a/include/graphqlservice/GraphQLGrammar.h
+++ b/include/graphqlservice/GraphQLGrammar.h
@@ -35,96 +35,87 @@ void for_each_child(const ast_node& n, std::function<void(const ast_node&)>&& fu
 }
 
 template <typename Rule>
-void on_first_child(const ast_node& n, std::function<void(const ast_node&)>&& func)
+void on_first_child_if(const ast_node& n, std::function<bool(const ast_node&)>&& func)
 {
 	for (const auto& child : n.children)
 	{
-		if (child->is_type<Rule>())
+		if (child->is_type<Rule>() && func(*child))
 		{
-			func(*child);
 			return;
 		}
 	}
 }
 
+template <typename Rule>
+void on_first_child(const ast_node& n, std::function<void(const ast_node&)>&& func)
+{
+	on_first_child_if<Rule>(n, [funcVoid = std::move(func)](const ast_node& child) {
+		funcVoid(child);
+		return true;
+	});
+}
+
 // https://facebook.github.io/graphql/June2018/#sec-Source-Text
-struct source_character
-	: sor<one<0x0009, 0x000A, 0x000D>
-	, utf8::range<0x0020, 0xFFFF>>
+struct source_character : sor<one<0x0009, 0x000A, 0x000D>, utf8::range<0x0020, 0xFFFF>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#sec-Comments
-struct comment
-	: seq<one<'#'>, until<eolf>>
+struct comment : seq<one<'#'>, until<eolf>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#sec-Source-Text.Ignored-Tokens
-struct ignored
-	: sor<space
-	, one<','>
-	, comment>
+struct ignored : sor<space, one<','>, comment>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#sec-Names
-struct name
-	: identifier
+struct name : identifier
 {
 };
 
-struct variable_name_content
-	: name
+struct variable_name_content : name
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Variable
-struct variable_name
-	: if_must<one<'$'>, variable_name_content>
+struct variable_name : if_must<one<'$'>, variable_name_content>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#sec-Null-Value
-struct null_keyword
-	: TAO_PEGTL_KEYWORD("null")
+struct null_keyword : TAO_PEGTL_KEYWORD("null")
 {
 };
 
-struct quote_token
-	: one<'"'>
+struct quote_token : one<'"'>
 {
 };
 
-struct backslash_token
-	: one<'\\'>
+struct backslash_token : one<'\\'>
 {
 };
 
-struct escaped_unicode_content
-	: rep<4, xdigit>
+struct escaped_unicode_content : rep<4, xdigit>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#EscapedUnicode
-struct escaped_unicode
-	: if_must<one<'u'>, escaped_unicode_content>
+struct escaped_unicode : if_must<one<'u'>, escaped_unicode_content>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#EscapedCharacter
-struct escaped_char
-	: one<'"', '\\', '/', 'b', 'f', 'n', 'r', 't'>
+struct escaped_char : one<'"', '\\', '/', 'b', 'f', 'n', 'r', 't'>
 {
 };
 
-struct string_escape_sequence_content
-	: sor<escaped_unicode, escaped_char>
+struct string_escape_sequence_content : sor<escaped_unicode, escaped_char>
 {
 };
 
-struct string_escape_sequence
-	: if_must<backslash_token, string_escape_sequence_content>
+struct string_escape_sequence : if_must<backslash_token, string_escape_sequence_content>
 {
 };
 
@@ -139,18 +130,15 @@ struct string_quote_content
 };
 
 // https://facebook.github.io/graphql/June2018/#StringCharacter
-struct string_quote
-	: if_must<quote_token, string_quote_content>
+struct string_quote : if_must<quote_token, string_quote_content>
 {
 };
 
-struct block_quote_token
-	: rep<3, quote_token>
+struct block_quote_token : rep<3, quote_token>
 {
 };
 
-struct block_escape_sequence
-	: seq<backslash_token, block_quote_token>
+struct block_escape_sequence : seq<backslash_token, block_quote_token>
 {
 };
 
@@ -165,78 +153,64 @@ struct block_quote_content
 };
 
 // https://facebook.github.io/graphql/June2018/#BlockStringCharacter
-struct block_quote
-	: if_must<block_quote_token, block_quote_content>
+struct block_quote : if_must<block_quote_token, block_quote_content>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#StringValue
-struct string_value
-	: sor<block_quote
-	, string_quote>
+struct string_value : sor<block_quote, string_quote>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#NonZeroDigit
-struct nonzero_digit
-	: range<'1', '9'>
+struct nonzero_digit : range<'1', '9'>
 {
 };
 
-struct zero_digit
-	: one<'0'>
+struct zero_digit : one<'0'>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#NegativeSign
-struct negative_sign
-	: one<'-'>
+struct negative_sign : one<'-'>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#IntegerPart
-struct integer_part
-	: seq<opt<negative_sign>, sor<zero_digit, seq<nonzero_digit, star<digit>>>>
+struct integer_part : seq<opt<negative_sign>, sor<zero_digit, seq<nonzero_digit, star<digit>>>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#IntValue
-struct integer_value
-	: integer_part
+struct integer_value : integer_part
 {
 };
 
-struct fractional_part_content
-	: plus<digit>
+struct fractional_part_content : plus<digit>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#FractionalPart
-struct fractional_part
-	: if_must<one<'.'>, fractional_part_content>
+struct fractional_part : if_must<one<'.'>, fractional_part_content>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#ExponentIndicator
-struct exponent_indicator
-	: one<'e', 'E'>
+struct exponent_indicator : one<'e', 'E'>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Sign
-struct sign
-	: one<'+', '-'>
+struct sign : one<'+', '-'>
 {
 };
 
-struct exponent_part_content
-	: seq<opt<sign>, plus<digit>>
+struct exponent_part_content : seq<opt<sign>, plus<digit>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#ExponentPart
-struct exponent_part
-	: if_must<exponent_indicator, exponent_part_content>
+struct exponent_part : if_must<exponent_indicator, exponent_part_content>
 {
 };
 
@@ -246,63 +220,52 @@ struct float_value
 {
 };
 
-struct true_keyword
-	: TAO_PEGTL_KEYWORD("true")
+struct true_keyword : TAO_PEGTL_KEYWORD("true")
 {
 };
 
-struct false_keyword
-	: TAO_PEGTL_KEYWORD("false")
+struct false_keyword : TAO_PEGTL_KEYWORD("false")
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#BooleanValue
-struct bool_value
-	: sor<true_keyword
-	, false_keyword>
+struct bool_value : sor<true_keyword, false_keyword>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#EnumValue
-struct enum_value
-	: seq<not_at<true_keyword, false_keyword, null_keyword>, name>
+struct enum_value : seq<not_at<true_keyword, false_keyword, null_keyword>, name>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#OperationType
 struct operation_type
-	: sor<TAO_PEGTL_KEYWORD("query")
-	, TAO_PEGTL_KEYWORD("mutation")
-	, TAO_PEGTL_KEYWORD("subscription")>
+	: sor<TAO_PEGTL_KEYWORD("query"), TAO_PEGTL_KEYWORD("mutation"),
+		  TAO_PEGTL_KEYWORD("subscription")>
 {
 };
 
-struct alias_name
-	: name
+struct alias_name : name
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Alias
-struct alias
-	: seq<alias_name, star<ignored>, one<':'>>
+struct alias : seq<alias_name, star<ignored>, one<':'>>
 {
 };
 
-struct argument_name
-	: name
+struct argument_name : name
 {
 };
 
 struct input_value;
 
-struct argument_content
-	: seq<star<ignored>, one<':'>, star<ignored>, input_value>
+struct argument_content : seq<star<ignored>, one<':'>, star<ignored>, input_value>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Argument
-struct argument
-	: if_must<argument_name, argument_content>
+struct argument : if_must<argument_name, argument_content>
 {
 };
 
@@ -312,8 +275,7 @@ struct arguments_content
 };
 
 // https://facebook.github.io/graphql/June2018/#Arguments
-struct arguments
-	: if_must<one<'('>, arguments_content>
+struct arguments : if_must<one<'('>, arguments_content>
 {
 };
 
@@ -325,24 +287,20 @@ struct list_value_content
 };
 
 // https://facebook.github.io/graphql/June2018/#ListValue
-struct list_value
-	: if_must<one<'['>, list_value_content>
+struct list_value : if_must<one<'['>, list_value_content>
 {
 };
 
-struct object_field_name
-	: name
+struct object_field_name : name
 {
 };
 
-struct object_field_content
-	: seq<star<ignored>, one<':'>, star<ignored>, input_value>
+struct object_field_content : seq<star<ignored>, one<':'>, star<ignored>, input_value>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#ObjectField
-struct object_field
-	: if_must<object_field_name, object_field_content>
+struct object_field : if_must<object_field_name, object_field_content>
 {
 };
 
@@ -352,54 +310,40 @@ struct object_value_content
 };
 
 // https://facebook.github.io/graphql/June2018/#ObjectValue
-struct object_value
-	: if_must<one<'{'>, object_value_content>
+struct object_value : if_must<one<'{'>, object_value_content>
 {
 };
 
-struct variable_value
-	: variable_name
+struct variable_value : variable_name
 {
 };
 
 struct input_value_content
-	: sor<list_value
-	, object_value
-	, variable_value
-	, float_value
-	, integer_value
-	, string_value
-	, bool_value
-	, null_keyword
-	, enum_value>
+	: sor<list_value, object_value, variable_value, float_value, integer_value, string_value,
+		  bool_value, null_keyword, enum_value>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Value
-struct input_value
-	: must<input_value_content>
+struct input_value : must<input_value_content>
 {
 };
 
-struct list_entry
-	: input_value_content
+struct list_entry : input_value_content
 {
 };
 
-struct default_value_content
-	: seq<star<ignored>, input_value>
+struct default_value_content : seq<star<ignored>, input_value>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#DefaultValue
-struct default_value
-	: if_must<one<'='>, default_value_content>
+struct default_value : if_must<one<'='>, default_value_content>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#NamedType
-struct named_type
-	: name
+struct named_type : name
 {
 };
 
@@ -412,25 +356,21 @@ struct list_type_content
 };
 
 // https://facebook.github.io/graphql/June2018/#ListType
-struct list_type
-	: if_must<one<'['>, list_type_content>
+struct list_type : if_must<one<'['>, list_type_content>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#NonNullType
-struct nonnull_type
-	: seq<sor<list_type, named_type>, star<ignored>, one<'!'>>
+struct nonnull_type : seq<sor<list_type, named_type>, star<ignored>, one<'!'>>
 {
 };
 
-struct type_name_content
-	: sor<nonnull_type, list_type, named_type>
+struct type_name_content : sor<nonnull_type, list_type, named_type>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Type
-struct type_name
-	: must<type_name_content>
+struct type_name : must<type_name_content>
 {
 };
 
@@ -440,8 +380,7 @@ struct variable_content
 };
 
 // https://facebook.github.io/graphql/June2018/#VariableDefinition
-struct variable
-	: if_must<variable_name, variable_content>
+struct variable : if_must<variable_name, variable_content>
 {
 };
 
@@ -451,115 +390,96 @@ struct variable_definitions_content
 };
 
 // https://facebook.github.io/graphql/June2018/#VariableDefinitions
-struct variable_definitions
-	: if_must<one<'('>, variable_definitions_content>
+struct variable_definitions : if_must<one<'('>, variable_definitions_content>
 {
 };
 
-struct directive_name
-	: name
+struct directive_name : name
 {
 };
 
-struct directive_content
-	: seq<directive_name, opt<star<ignored>, arguments>>
+struct directive_content : seq<directive_name, opt<star<ignored>, arguments>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Directive
-struct directive
-	: if_must<one<'@'>, directive_content>
+struct directive : if_must<one<'@'>, directive_content>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Directives
-struct directives
-	: list<directive, plus<ignored>>
+struct directives : list<directive, plus<ignored>>
 {
 };
 
 struct selection_set;
 
-struct field_name
-	: name
+struct field_name : name
 {
 };
 
-struct field_start
-	: seq<opt<alias, star<ignored>>, field_name>
+struct field_start : seq<opt<alias, star<ignored>>, field_name>
 {
 };
 
-struct field_arguments
-	: opt<star<ignored>, arguments>
+struct field_arguments : opt<star<ignored>, arguments>
 {
 };
 
-struct field_directives
-	: seq<star<ignored>, directives>
+struct field_directives : seq<star<ignored>, directives>
 {
 };
 
-struct field_selection_set
-	: seq<star<ignored>, selection_set>
+struct field_selection_set : seq<star<ignored>, selection_set>
 {
 };
 
 struct field_content
-	: sor<seq<field_arguments, opt<field_directives>, field_selection_set>
-	, seq<field_arguments, field_directives>
-	, field_arguments>
+	: sor<seq<field_arguments, opt<field_directives>, field_selection_set>,
+		  seq<field_arguments, field_directives>, field_arguments>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Field
-struct field
-	: if_must<field_start, field_content>
+struct field : if_must<field_start, field_content>
 {
 };
 
-struct on_keyword
-	: TAO_PEGTL_KEYWORD("on")
+struct on_keyword : TAO_PEGTL_KEYWORD("on")
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#FragmentName
-struct fragment_name
-	: seq<not_at<on_keyword>, name>
+struct fragment_name : seq<not_at<on_keyword>, name>
 {
 };
 
-struct fragment_token
-	: ellipsis
+struct fragment_token : ellipsis
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#FragmentSpread
-struct fragment_spread
-	: seq<star<ignored>, fragment_name, opt<star<ignored>, directives>>
+struct fragment_spread : seq<star<ignored>, fragment_name, opt<star<ignored>, directives>>
 {
 };
 
-struct type_condition_content
-	: seq<plus<ignored>, named_type>
+struct type_condition_content : seq<plus<ignored>, named_type>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#TypeCondition
-struct type_condition
-	: if_must<on_keyword, type_condition_content>
+struct type_condition : if_must<on_keyword, type_condition_content>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#InlineFragment
 struct inline_fragment
-	: seq<opt<star<ignored>, type_condition>, opt<star<ignored>, directives>, star<ignored>, selection_set>
+	: seq<opt<star<ignored>, type_condition>, opt<star<ignored>, directives>, star<ignored>,
+		  selection_set>
 {
 };
 
-struct fragement_spread_or_inline_fragment_content
-	: sor<fragment_spread
-	, inline_fragment>
+struct fragement_spread_or_inline_fragment_content : sor<fragment_spread, inline_fragment>
 {
 };
 
@@ -569,9 +489,7 @@ struct fragement_spread_or_inline_fragment
 };
 
 // https://facebook.github.io/graphql/June2018/#Selection
-struct selection
-	: sor<field
-	, fragement_spread_or_inline_fragment>
+struct selection : sor<field, fragement_spread_or_inline_fragment>
 {
 };
 
@@ -581,91 +499,80 @@ struct selection_set_content
 };
 
 // https://facebook.github.io/graphql/June2018/#SelectionSet
-struct selection_set
-	: if_must<one<'{'>, selection_set_content>
+struct selection_set : if_must<one<'{'>, selection_set_content>
 {
 };
 
-struct operation_name
-	: name
+struct operation_name : name
 {
 };
 
 struct operation_definition_operation_type_content
-	: seq<opt<plus<ignored>, operation_name>, opt<star<ignored>, variable_definitions>, opt<star<ignored>, directives>, star<ignored>, selection_set>
+	: seq<opt<plus<ignored>, operation_name>, opt<star<ignored>, variable_definitions>,
+		  opt<star<ignored>, directives>, star<ignored>, selection_set>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#OperationDefinition
 struct operation_definition
-	: sor<if_must<operation_type, operation_definition_operation_type_content>
-	, selection_set>
+	: sor<if_must<operation_type, operation_definition_operation_type_content>, selection_set>
 {
 };
 
 struct fragment_definition_content
-	: seq<plus<ignored>, fragment_name, plus<ignored>, type_condition, opt<star<ignored>, directives>, star<ignored>, selection_set>
+	: seq<plus<ignored>, fragment_name, plus<ignored>, type_condition,
+		  opt<star<ignored>, directives>, star<ignored>, selection_set>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#FragmentDefinition
-struct fragment_definition
-	: if_must<TAO_PEGTL_KEYWORD("fragment"), fragment_definition_content>
+struct fragment_definition : if_must<TAO_PEGTL_KEYWORD("fragment"), fragment_definition_content>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#ExecutableDefinition
-struct executable_definition
-	: sor<fragment_definition
-	, operation_definition>
+struct executable_definition : sor<fragment_definition, operation_definition>
 {
 };
 
-struct schema_keyword
-	: TAO_PEGTL_KEYWORD("schema")
+struct schema_keyword : TAO_PEGTL_KEYWORD("schema")
 {
 };
 
-struct root_operation_definition_content
-	: seq<star<ignored>, one<':'>, star<ignored>, named_type>
+struct root_operation_definition_content : seq<star<ignored>, one<':'>, star<ignored>, named_type>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#RootOperationTypeDefinition
-struct root_operation_definition
-	: if_must<operation_type, root_operation_definition_content>
+struct root_operation_definition : if_must<operation_type, root_operation_definition_content>
 {
 };
 
 struct schema_definition_content
-	: seq<opt<star<ignored>, directives>, star<ignored>, one<'{'>, star<ignored>, list<root_operation_definition, plus<ignored>>, star<ignored>, must<one<'}'>>>
+	: seq<opt<star<ignored>, directives>, star<ignored>, one<'{'>, star<ignored>,
+		  list<root_operation_definition, plus<ignored>>, star<ignored>, must<one<'}'>>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#SchemaDefinition
-struct schema_definition
-	: if_must<schema_keyword, schema_definition_content>
+struct schema_definition : if_must<schema_keyword, schema_definition_content>
 {
 };
 
-struct scalar_keyword
-	: TAO_PEGTL_KEYWORD("scalar")
+struct scalar_keyword : TAO_PEGTL_KEYWORD("scalar")
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Description
-struct description
-	: string_value
+struct description : string_value
 {
 };
 
-struct scalar_name
-	: name
+struct scalar_name : name
 {
 };
 
-struct scalar_type_definition_start
-	: seq<opt<description, star<ignored>>, scalar_keyword>
+struct scalar_type_definition_start : seq<opt<description, star<ignored>>, scalar_keyword>
 {
 };
 
@@ -680,15 +587,13 @@ struct scalar_type_definition
 {
 };
 
-struct type_keyword
-	: TAO_PEGTL_KEYWORD("type")
+struct type_keyword : TAO_PEGTL_KEYWORD("type")
 {
 };
 
 struct input_field_definition;
 
-struct arguments_definition_start
-	: one<'('>
+struct arguments_definition_start : one<'('>
 {
 };
 
@@ -698,24 +603,22 @@ struct arguments_definition_content
 };
 
 // https://facebook.github.io/graphql/June2018/#ArgumentsDefinition
-struct arguments_definition
-	: if_must<arguments_definition_start, arguments_definition_content>
+struct arguments_definition : if_must<arguments_definition_start, arguments_definition_content>
 {
 };
 
-struct field_definition_start
-	: seq<opt<description, star<ignored>>, field_name>
+struct field_definition_start : seq<opt<description, star<ignored>>, field_name>
 {
 };
 
 struct field_definition_content
-	: seq<opt<star<ignored>, arguments_definition>, star<ignored>, one<':'>, star<ignored>, type_name, opt<star<ignored>, directives>>
+	: seq<opt<star<ignored>, arguments_definition>, star<ignored>, one<':'>, star<ignored>,
+		  type_name, opt<star<ignored>, directives>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#FieldDefinition
-struct field_definition
-	: if_must<field_definition_start, field_definition_content>
+struct field_definition : if_must<field_definition_start, field_definition_content>
 {
 };
 
@@ -725,18 +628,17 @@ struct fields_definition_content
 };
 
 // https://facebook.github.io/graphql/June2018/#FieldsDefinition
-struct fields_definition
-	: if_must<one<'{'>, fields_definition_content>
+struct fields_definition : if_must<one<'{'>, fields_definition_content>
 {
 };
 
-struct interface_type
-	: named_type
+struct interface_type : named_type
 {
 };
 
 struct implements_interfaces_content
-	: seq<opt<star<ignored>, one<'&'>>, star<ignored>, list<interface_type, seq<star<ignored>, one<'&'>, star<ignored>>>>
+	: seq<opt<star<ignored>, one<'&'>>, star<ignored>,
+		  list<interface_type, seq<star<ignored>, one<'&'>, star<ignored>>>>
 {
 };
 
@@ -746,41 +648,36 @@ struct implements_interfaces
 {
 };
 
-struct object_name
-	: name
+struct object_name : name
 {
 };
 
-struct object_type_definition_start
-	: seq<opt<description, star<ignored>>, type_keyword>
+struct object_type_definition_start : seq<opt<description, star<ignored>>, type_keyword>
 {
 };
 
-struct object_type_definition_object_name
-	: seq<plus<ignored>, object_name>
+struct object_type_definition_object_name : seq<plus<ignored>, object_name>
 {
 };
 
-struct object_type_definition_implements_interfaces
-	: opt<plus<ignored>, implements_interfaces>
+struct object_type_definition_implements_interfaces : opt<plus<ignored>, implements_interfaces>
 {
 };
 
-struct object_type_definition_directives
-	: seq<star<ignored>, directives>
+struct object_type_definition_directives : seq<star<ignored>, directives>
 {
 };
 
-struct object_type_definition_fields_definition
-	: seq<star<ignored>, fields_definition>
+struct object_type_definition_fields_definition : seq<star<ignored>, fields_definition>
 {
 };
 
 struct object_type_definition_content
 	: seq<object_type_definition_object_name,
-		sor<seq<object_type_definition_implements_interfaces, opt<object_type_definition_directives>, object_type_definition_fields_definition>
-		, seq<object_type_definition_implements_interfaces, object_type_definition_directives>
-		, object_type_definition_implements_interfaces>>
+		  sor<seq<object_type_definition_implements_interfaces,
+				  opt<object_type_definition_directives>, object_type_definition_fields_definition>,
+			  seq<object_type_definition_implements_interfaces, object_type_definition_directives>,
+			  object_type_definition_implements_interfaces>>
 {
 };
 
@@ -790,40 +687,35 @@ struct object_type_definition
 {
 };
 
-struct interface_keyword
-	: TAO_PEGTL_KEYWORD("interface")
+struct interface_keyword : TAO_PEGTL_KEYWORD("interface")
 {
 };
 
-struct interface_name
-	: name
+struct interface_name : name
 {
 };
 
-struct interface_type_definition_start
-	: seq<opt<description, star<ignored>>, interface_keyword>
+struct interface_type_definition_start : seq<opt<description, star<ignored>>, interface_keyword>
 {
 };
 
-struct interface_type_definition_interface_name
-	: seq<plus<ignored>, interface_name>
+struct interface_type_definition_interface_name : seq<plus<ignored>, interface_name>
 {
 };
 
-struct interface_type_definition_directives
-	: opt<star<ignored>, directives>
+struct interface_type_definition_directives : opt<star<ignored>, directives>
 {
 };
 
-struct interface_type_definition_fields_definition
-	: seq<star<ignored>, fields_definition>
+struct interface_type_definition_fields_definition : seq<star<ignored>, fields_definition>
 {
 };
 
 struct interface_type_definition_content
 	: seq<interface_type_definition_interface_name,
-		sor<seq<interface_type_definition_directives, interface_type_definition_fields_definition>
-		, interface_type_definition_directives>>
+		  sor<seq<interface_type_definition_directives,
+				  interface_type_definition_fields_definition>,
+			  interface_type_definition_directives>>
 {
 };
 
@@ -833,88 +725,75 @@ struct interface_type_definition
 {
 };
 
-struct union_keyword
-	: TAO_PEGTL_KEYWORD("union")
+struct union_keyword : TAO_PEGTL_KEYWORD("union")
 {
 };
 
-struct union_name
-	: name
+struct union_name : name
 {
 };
 
-struct union_type
-	: named_type
+struct union_type : named_type
 {
 };
 
-struct union_member_types_start
-	: one<'='>
+struct union_member_types_start : one<'='>
 {
 };
 
 struct union_member_types_content
-	: seq<opt<star<ignored>, one<'|'>>, star<ignored>, list<union_type, seq<star<ignored>, one<'|'>, star<ignored>>>>
+	: seq<opt<star<ignored>, one<'|'>>, star<ignored>,
+		  list<union_type, seq<star<ignored>, one<'|'>, star<ignored>>>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#UnionMemberTypes
-struct union_member_types
-	: if_must<union_member_types_start, union_member_types_content>
+struct union_member_types : if_must<union_member_types_start, union_member_types_content>
 {
 };
 
-struct union_type_definition_start
-	: seq<opt<description, star<ignored>>, union_keyword>
+struct union_type_definition_start : seq<opt<description, star<ignored>>, union_keyword>
 {
 };
 
-struct union_type_definition_directives
-	: opt<star<ignored>, directives>
+struct union_type_definition_directives : opt<star<ignored>, directives>
 {
 };
 
 struct union_type_definition_content
 	: seq<plus<ignored>, union_name,
-		sor<seq<union_type_definition_directives, seq<star<ignored>, union_member_types>>
-		, union_type_definition_directives>>
+		  sor<seq<union_type_definition_directives, seq<star<ignored>, union_member_types>>,
+			  union_type_definition_directives>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#UnionTypeDefinition
-struct union_type_definition
-	: if_must<union_type_definition_start, union_type_definition_content>
+struct union_type_definition : if_must<union_type_definition_start, union_type_definition_content>
 {
 };
 
-struct enum_keyword
-	: TAO_PEGTL_KEYWORD("enum")
+struct enum_keyword : TAO_PEGTL_KEYWORD("enum")
 {
 };
 
-struct enum_name
-	: name
+struct enum_name : name
 {
 };
 
-struct enum_value_definition_start
-	: seq<opt<description, star<ignored>>, enum_value>
+struct enum_value_definition_start : seq<opt<description, star<ignored>>, enum_value>
 {
 };
 
-struct enum_value_definition_content
-	: opt<star<ignored>, directives>
+struct enum_value_definition_content : opt<star<ignored>, directives>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#EnumValueDefinition
-struct enum_value_definition
-	: if_must<enum_value_definition_start, enum_value_definition_content>
+struct enum_value_definition : if_must<enum_value_definition_start, enum_value_definition_content>
 {
 };
 
-struct enum_values_definition_start
-	: one<'{'>
+struct enum_values_definition_start : one<'{'>
 {
 };
 
@@ -929,68 +808,58 @@ struct enum_values_definition
 {
 };
 
-struct enum_type_definition_start
-	: seq<opt<description, star<ignored>>, enum_keyword>
+struct enum_type_definition_start : seq<opt<description, star<ignored>>, enum_keyword>
 {
 };
 
-struct enum_type_definition_name
-	: seq<plus<ignored>, enum_name>
+struct enum_type_definition_name : seq<plus<ignored>, enum_name>
 {
 };
 
-struct enum_type_definition_directives
-	: opt<star<ignored>, directives>
+struct enum_type_definition_directives : opt<star<ignored>, directives>
 {
 };
 
-struct enum_type_definition_enum_values_definition
-	: seq<star<ignored>, enum_values_definition>
+struct enum_type_definition_enum_values_definition : seq<star<ignored>, enum_values_definition>
 {
 };
 
 struct enum_type_definition_content
 	: seq<enum_type_definition_name,
-		sor<seq<enum_type_definition_directives, enum_type_definition_enum_values_definition>
-		, enum_type_definition_directives>>
+		  sor<seq<enum_type_definition_directives, enum_type_definition_enum_values_definition>,
+			  enum_type_definition_directives>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#EnumTypeDefinition
-struct enum_type_definition
-	: if_must<enum_type_definition_start, enum_type_definition_content>
+struct enum_type_definition : if_must<enum_type_definition_start, enum_type_definition_content>
 {
 };
 
-struct input_keyword
-	: TAO_PEGTL_KEYWORD("input")
+struct input_keyword : TAO_PEGTL_KEYWORD("input")
 {
 };
 
-struct input_field_definition_start
-	: seq<opt<description, star<ignored>>, argument_name>
+struct input_field_definition_start : seq<opt<description, star<ignored>>, argument_name>
 {
 };
 
-struct input_field_definition_type_name
-	: seq<star<ignored>, one<':'>, star<ignored>, type_name>
+struct input_field_definition_type_name : seq<star<ignored>, one<':'>, star<ignored>, type_name>
 {
 };
 
-struct input_field_definition_default_value
-	: opt<star<ignored>, default_value>
+struct input_field_definition_default_value : opt<star<ignored>, default_value>
 {
 };
 
-struct input_field_definition_directives
-	: seq<star<ignored>, directives>
+struct input_field_definition_directives : seq<star<ignored>, directives>
 {
 };
 
 struct input_field_definition_content
 	: seq<input_field_definition_type_name,
-		sor<seq<input_field_definition_default_value, input_field_definition_directives>
-		, input_field_definition_default_value>>
+		  sor<seq<input_field_definition_default_value, input_field_definition_directives>,
+			  input_field_definition_default_value>>
 {
 };
 
@@ -1000,8 +869,7 @@ struct input_field_definition
 {
 };
 
-struct input_fields_definition_start
-	: one<'{'>
+struct input_fields_definition_start : one<'{'>
 {
 };
 
@@ -1016,30 +884,27 @@ struct input_fields_definition
 {
 };
 
-struct input_object_type_definition_start
-	: seq<opt<description, star<ignored>>, input_keyword>
+struct input_object_type_definition_start : seq<opt<description, star<ignored>>, input_keyword>
 {
 };
 
-struct input_object_type_definition_object_name
-	: seq<plus<ignored>, object_name>
+struct input_object_type_definition_object_name : seq<plus<ignored>, object_name>
 {
 };
 
-struct input_object_type_definition_directives
-	: opt<star<ignored>, directives>
+struct input_object_type_definition_directives : opt<star<ignored>, directives>
 {
 };
 
-struct input_object_type_definition_fields_definition
-	: seq<star<ignored>, input_fields_definition>
+struct input_object_type_definition_fields_definition : seq<star<ignored>, input_fields_definition>
 {
 };
 
 struct input_object_type_definition_content
 	: seq<input_object_type_definition_object_name,
-		sor<seq<input_object_type_definition_directives, input_object_type_definition_fields_definition>
-		, input_object_type_definition_directives>>
+		  sor<seq<input_object_type_definition_directives,
+				  input_object_type_definition_fields_definition>,
+			  input_object_type_definition_directives>>
 {
 };
 
@@ -1051,53 +916,39 @@ struct input_object_type_definition
 
 // https://facebook.github.io/graphql/June2018/#TypeDefinition
 struct type_definition
-	: sor<scalar_type_definition
-	, object_type_definition
-	, interface_type_definition
-	, union_type_definition
-	, enum_type_definition
-	, input_object_type_definition>
+	: sor<scalar_type_definition, object_type_definition, interface_type_definition,
+		  union_type_definition, enum_type_definition, input_object_type_definition>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#ExecutableDirectiveLocation
 struct executable_directive_location
-	: sor<TAO_PEGTL_KEYWORD("QUERY")
-	, TAO_PEGTL_KEYWORD("MUTATION")
-	, TAO_PEGTL_KEYWORD("SUBSCRIPTION")
-	, TAO_PEGTL_KEYWORD("FIELD")
-	, TAO_PEGTL_KEYWORD("FRAGMENT_DEFINITION")
-	, TAO_PEGTL_KEYWORD("FRAGMENT_SPREAD")
-	, TAO_PEGTL_KEYWORD("INLINE_FRAGMENT")>
+	: sor<TAO_PEGTL_KEYWORD("QUERY"), TAO_PEGTL_KEYWORD("MUTATION"),
+		  TAO_PEGTL_KEYWORD("SUBSCRIPTION"), TAO_PEGTL_KEYWORD("FIELD"),
+		  TAO_PEGTL_KEYWORD("FRAGMENT_DEFINITION"), TAO_PEGTL_KEYWORD("FRAGMENT_SPREAD"),
+		  TAO_PEGTL_KEYWORD("INLINE_FRAGMENT")>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#TypeSystemDirectiveLocation
 struct type_system_directive_location
-	: sor<TAO_PEGTL_KEYWORD("SCHEMA")
-	, TAO_PEGTL_KEYWORD("SCALAR")
-	, TAO_PEGTL_KEYWORD("OBJECT")
-	, TAO_PEGTL_KEYWORD("FIELD_DEFINITION")
-	, TAO_PEGTL_KEYWORD("ARGUMENT_DEFINITION")
-	, TAO_PEGTL_KEYWORD("INTERFACE")
-	, TAO_PEGTL_KEYWORD("UNION")
-	, TAO_PEGTL_KEYWORD("ENUM")
-	, TAO_PEGTL_KEYWORD("ENUM_VALUE")
-	, TAO_PEGTL_KEYWORD("INPUT_OBJECT")
-	, TAO_PEGTL_KEYWORD("INPUT_FIELD_DEFINITION")>
+	: sor<TAO_PEGTL_KEYWORD("SCHEMA"), TAO_PEGTL_KEYWORD("SCALAR"), TAO_PEGTL_KEYWORD("OBJECT"),
+		  TAO_PEGTL_KEYWORD("FIELD_DEFINITION"), TAO_PEGTL_KEYWORD("ARGUMENT_DEFINITION"),
+		  TAO_PEGTL_KEYWORD("INTERFACE"), TAO_PEGTL_KEYWORD("UNION"), TAO_PEGTL_KEYWORD("ENUM"),
+		  TAO_PEGTL_KEYWORD("ENUM_VALUE"), TAO_PEGTL_KEYWORD("INPUT_OBJECT"),
+		  TAO_PEGTL_KEYWORD("INPUT_FIELD_DEFINITION")>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#DirectiveLocation
-struct directive_location
-	: sor<executable_directive_location
-	, type_system_directive_location>
+struct directive_location : sor<executable_directive_location, type_system_directive_location>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#DirectiveLocations
 struct directive_locations
-	: seq<opt<one<'|'>, star<ignored>>, list<directive_location, seq<star<ignored>, one<'|'>, star<ignored>>>>
+	: seq<opt<one<'|'>, star<ignored>>,
+		  list<directive_location, seq<star<ignored>, one<'|'>, star<ignored>>>>
 {
 };
 
@@ -1107,117 +958,102 @@ struct directive_definition_start
 };
 
 struct directive_definition_content
-	: seq<star<ignored>, one<'@'>, directive_name, opt<star<ignored>, arguments_definition>, plus<ignored>, on_keyword, plus<ignored>, directive_locations>
+	: seq<star<ignored>, one<'@'>, directive_name, opt<star<ignored>, arguments_definition>,
+		  plus<ignored>, on_keyword, plus<ignored>, directive_locations>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#DirectiveDefinition
-struct directive_definition
-	: if_must<directive_definition_start, directive_definition_content>
+struct directive_definition : if_must<directive_definition_start, directive_definition_content>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#TypeSystemDefinition
-struct type_system_definition
-	: sor<schema_definition
-	, type_definition
-	, directive_definition>
+struct type_system_definition : sor<schema_definition, type_definition, directive_definition>
 {
 };
 
-struct extend_keyword
-	: TAO_PEGTL_KEYWORD("extend")
+struct extend_keyword : TAO_PEGTL_KEYWORD("extend")
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#OperationTypeDefinition
-struct operation_type_definition
-	: root_operation_definition
+struct operation_type_definition : root_operation_definition
 {
 };
 
-struct schema_extension_start
-	: seq<extend_keyword, plus<ignored>, schema_keyword>
+struct schema_extension_start : seq<extend_keyword, plus<ignored>, schema_keyword>
 {
 };
 
 struct schema_extension_operation_type_definitions
-	: seq<one<'{'>, star<ignored>, list<operation_type_definition, plus<ignored>>, star<ignored>, must<one<'}'>>>
+	: seq<one<'{'>, star<ignored>, list<operation_type_definition, plus<ignored>>, star<ignored>,
+		  must<one<'}'>>>
 {
 };
 
 struct schema_extension_content
 	: seq<star<ignored>,
-		sor<seq<opt<directives>, schema_extension_operation_type_definitions>
-		, directives>>
+		  sor<seq<opt<directives>, schema_extension_operation_type_definitions>, directives>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#SchemaExtension
-struct schema_extension
-	: if_must<schema_extension_start, schema_extension_content>
+struct schema_extension : if_must<schema_extension_start, schema_extension_content>
 {
 };
 
-struct scalar_type_extension_start
-	: seq<extend_keyword, plus<ignored>, scalar_keyword>
+struct scalar_type_extension_start : seq<extend_keyword, plus<ignored>, scalar_keyword>
 {
 };
 
-struct scalar_type_extension_content
-	: seq<star<ignored>, scalar_name, star<ignored>, directives>
+struct scalar_type_extension_content : seq<star<ignored>, scalar_name, star<ignored>, directives>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#ScalarTypeExtension
-struct scalar_type_extension
-	: if_must<scalar_type_extension_start, scalar_type_extension_content>
+struct scalar_type_extension : if_must<scalar_type_extension_start, scalar_type_extension_content>
 {
 };
 
-struct object_type_extension_start
-	: seq<extend_keyword, plus<ignored>, type_keyword>
+struct object_type_extension_start : seq<extend_keyword, plus<ignored>, type_keyword>
 {
 };
 
-struct object_type_extension_implements_interfaces
-	: seq<plus<ignored>, implements_interfaces>
+struct object_type_extension_implements_interfaces : seq<plus<ignored>, implements_interfaces>
 {
 };
 
-struct object_type_extension_directives
-	: seq<star<ignored>, directives>
+struct object_type_extension_directives : seq<star<ignored>, directives>
 {
 };
 
-struct object_type_extension_fields_definition
-	: seq<star<ignored>, fields_definition>
+struct object_type_extension_fields_definition : seq<star<ignored>, fields_definition>
 {
 };
 
 struct object_type_extension_content
 	: seq<plus<ignored>, object_name,
-		sor<seq<opt<object_type_extension_implements_interfaces>, opt<object_type_extension_directives>, object_type_extension_fields_definition>
-		, seq<opt<object_type_extension_implements_interfaces>, object_type_extension_directives>
-		, object_type_extension_implements_interfaces>>
+		  sor<seq<opt<object_type_extension_implements_interfaces>,
+				  opt<object_type_extension_directives>, object_type_extension_fields_definition>,
+			  seq<opt<object_type_extension_implements_interfaces>,
+				  object_type_extension_directives>,
+			  object_type_extension_implements_interfaces>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#ObjectTypeExtension
-struct object_type_extension
-	: if_must<object_type_extension_start, object_type_extension_content>
+struct object_type_extension : if_must<object_type_extension_start, object_type_extension_content>
 {
 };
 
-struct interface_type_extension_start
-	: seq<extend_keyword, plus<ignored>, interface_keyword>
+struct interface_type_extension_start : seq<extend_keyword, plus<ignored>, interface_keyword>
 {
 };
 
 struct interface_type_extension_content
 	: seq<plus<ignored>, interface_name, star<ignored>,
-		sor<seq<opt<directives, star<ignored>>, fields_definition>
-		, directives>>
+		  sor<seq<opt<directives, star<ignored>>, fields_definition>, directives>>
 {
 };
 
@@ -1227,51 +1063,43 @@ struct interface_type_extension
 {
 };
 
-struct union_type_extension_start
-	: seq<extend_keyword, plus<ignored>, union_keyword>
+struct union_type_extension_start : seq<extend_keyword, plus<ignored>, union_keyword>
 {
 };
 
 struct union_type_extension_content
 	: seq<plus<ignored>, union_name, star<ignored>,
-		sor<seq<opt<directives, star<ignored>>, union_member_types>
-		, directives>>
+		  sor<seq<opt<directives, star<ignored>>, union_member_types>, directives>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#UnionTypeExtension
-struct union_type_extension
-	: if_must<union_type_extension_start, union_type_extension_content>
+struct union_type_extension : if_must<union_type_extension_start, union_type_extension_content>
 {
 };
 
-struct enum_type_extension_start
-	: seq<extend_keyword, plus<ignored>, enum_keyword>
+struct enum_type_extension_start : seq<extend_keyword, plus<ignored>, enum_keyword>
 {
 };
 
 struct enum_type_extension_content
 	: seq<plus<ignored>, enum_name, star<ignored>,
-		sor<seq<opt<directives, star<ignored>>, enum_values_definition>
-		, directives>>
+		  sor<seq<opt<directives, star<ignored>>, enum_values_definition>, directives>>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#EnumTypeExtension
-struct enum_type_extension
-	: if_must<enum_type_extension_start, enum_type_extension_content>
+struct enum_type_extension : if_must<enum_type_extension_start, enum_type_extension_content>
 {
 };
 
-struct input_object_type_extension_start
-	: seq<extend_keyword, plus<ignored>, input_keyword>
+struct input_object_type_extension_start : seq<extend_keyword, plus<ignored>, input_keyword>
 {
 };
 
 struct input_object_type_extension_content
 	: seq<plus<ignored>, object_name, star<ignored>,
-		sor<seq<opt<directives, star<ignored>>, input_fields_definition>
-		, directives>>
+		  sor<seq<opt<directives, star<ignored>>, input_fields_definition>, directives>>
 {
 };
 
@@ -1283,38 +1111,29 @@ struct input_object_type_extension
 
 // https://facebook.github.io/graphql/June2018/#TypeExtension
 struct type_extension
-	: sor<scalar_type_extension
-	, object_type_extension
-	, interface_type_extension
-	, union_type_extension
-	, enum_type_extension
-	, input_object_type_extension>
+	: sor<scalar_type_extension, object_type_extension, interface_type_extension,
+		  union_type_extension, enum_type_extension, input_object_type_extension>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#TypeSystemExtension
-struct type_system_extension
-	: sor<schema_extension
-	, type_extension>
+struct type_system_extension : sor<schema_extension, type_extension>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Definition
-struct definition
-	: sor<executable_definition
-	, type_system_definition
-	, type_system_extension>
+struct definition : sor<executable_definition, type_system_definition, type_system_extension>
 {
 };
 
 struct document_content
-	: seq<bof, opt<utf8::bom>, star<ignored>, list<definition, star<ignored>>, star<ignored>, tao::graphqlpeg::eof>
+	: seq<bof, opt<utf8::bom>, star<ignored>, list<definition, star<ignored>>, star<ignored>,
+		  tao::graphqlpeg::eof>
 {
 };
 
 // https://facebook.github.io/graphql/June2018/#Document
-struct document
-	: must<document_content>
+struct document : must<document_content>
 {
 };
 

--- a/include/graphqlservice/GraphQLSchema.h
+++ b/include/graphqlservice/GraphQLSchema.h
@@ -1,0 +1,297 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef GRAPHQLSCHEMA_H
+#define GRAPHQLSCHEMA_H
+
+#include "graphqlservice/GraphQLService.h"
+
+namespace graphql {
+namespace introspection {
+
+enum class TypeKind;
+enum class DirectiveLocation;
+
+} // namespace introspection
+
+namespace schema {
+
+class Schema;
+class Directive;
+class BaseType;
+class ScalarType;
+class ObjectType;
+class InterfaceType;
+class UnionType;
+class EnumType;
+class InputObjectType;
+class WrapperType;
+class Field;
+class InputValue;
+class EnumValue;
+
+class Schema : public std::enable_shared_from_this<Schema>
+{
+public:
+	GRAPHQLSERVICE_EXPORT explicit Schema();
+
+	GRAPHQLSERVICE_EXPORT void AddQueryType(std::shared_ptr<ObjectType> query);
+	GRAPHQLSERVICE_EXPORT void AddMutationType(std::shared_ptr<ObjectType> mutation);
+	GRAPHQLSERVICE_EXPORT void AddSubscriptionType(std::shared_ptr<ObjectType> subscription);
+	GRAPHQLSERVICE_EXPORT void AddType(std::string_view name, std::shared_ptr<BaseType> type);
+	GRAPHQLSERVICE_EXPORT const std::shared_ptr<BaseType>& LookupType(std::string_view name) const;
+	GRAPHQLSERVICE_EXPORT const std::shared_ptr<BaseType>& WrapType(
+		introspection::TypeKind kind, const std::shared_ptr<BaseType>& ofType);
+	GRAPHQLSERVICE_EXPORT void AddDirective(std::shared_ptr<Directive> directive);
+
+	// Accessors
+	const std::vector<std::pair<std::string_view, std::shared_ptr<BaseType>>>& types()
+		const noexcept;
+	const std::shared_ptr<ObjectType>& queryType() const noexcept;
+	const std::shared_ptr<ObjectType>& mutationType() const noexcept;
+	const std::shared_ptr<ObjectType>& subscriptionType() const noexcept;
+	const std::vector<std::shared_ptr<Directive>>& directives() const noexcept;
+
+private:
+	std::shared_ptr<ObjectType> _query;
+	std::shared_ptr<ObjectType> _mutation;
+	std::shared_ptr<ObjectType> _subscription;
+	std::unordered_map<std::string_view, size_t> _typeMap;
+	std::vector<std::pair<std::string_view, std::shared_ptr<BaseType>>> _types;
+	std::vector<std::shared_ptr<Directive>> _directives;
+	std::unordered_map<std::shared_ptr<BaseType>, std::shared_ptr<BaseType>> _nonNullWrappers;
+	std::unordered_map<std::shared_ptr<BaseType>, std::shared_ptr<BaseType>> _listWrappers;
+};
+
+class BaseType : public std::enable_shared_from_this<BaseType>
+{
+public:
+	// Accessors
+	introspection::TypeKind kind() const noexcept;
+	virtual std::string_view name() const noexcept;
+	std::string_view description() const noexcept;
+	virtual const std::vector<std::shared_ptr<Field>>& fields() const noexcept;
+	virtual const std::vector<std::shared_ptr<InterfaceType>>& interfaces() const noexcept;
+	virtual const std::vector<std::weak_ptr<BaseType>>& possibleTypes() const noexcept;
+	virtual const std::vector<std::shared_ptr<EnumValue>>& enumValues() const noexcept;
+	virtual const std::vector<std::shared_ptr<InputValue>>& inputFields() const noexcept;
+	virtual const std::weak_ptr<BaseType>& ofType() const noexcept;
+
+protected:
+	BaseType(introspection::TypeKind kind, std::string_view description);
+
+private:
+	const introspection::TypeKind _kind;
+	const std::string_view _description;
+};
+
+class ScalarType : public BaseType
+{
+public:
+	GRAPHQLSERVICE_EXPORT explicit ScalarType(std::string_view name, std::string_view description);
+
+	// Accessors
+	std::string_view name() const noexcept final;
+
+private:
+	const std::string_view _name;
+};
+
+class ObjectType : public BaseType
+{
+public:
+	GRAPHQLSERVICE_EXPORT explicit ObjectType(std::string_view name, std::string_view description);
+
+	GRAPHQLSERVICE_EXPORT void AddInterfaces(
+		std::vector<std::shared_ptr<InterfaceType>> interfaces);
+	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<Field>> fields);
+
+	// Accessors
+	std::string_view name() const noexcept final;
+	const std::vector<std::shared_ptr<Field>>& fields() const noexcept final;
+	const std::vector<std::shared_ptr<InterfaceType>>& interfaces() const noexcept final;
+
+private:
+	const std::string_view _name;
+
+	std::vector<std::shared_ptr<InterfaceType>> _interfaces;
+	std::vector<std::shared_ptr<Field>> _fields;
+};
+
+class InterfaceType : public BaseType
+{
+public:
+	GRAPHQLSERVICE_EXPORT explicit InterfaceType(
+		std::string_view name, std::string_view description);
+
+	GRAPHQLSERVICE_EXPORT void AddPossibleType(std::weak_ptr<ObjectType> possibleType);
+	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<Field>> fields);
+
+	// Accessors
+	std::string_view name() const noexcept final;
+	const std::vector<std::shared_ptr<Field>>& fields() const noexcept final;
+	const std::vector<std::weak_ptr<BaseType>>& possibleTypes() const noexcept final;
+
+private:
+	const std::string_view _name;
+
+	std::vector<std::shared_ptr<Field>> _fields;
+	std::vector<std::weak_ptr<BaseType>> _possibleTypes;
+};
+
+class UnionType : public BaseType
+{
+public:
+	GRAPHQLSERVICE_EXPORT explicit UnionType(std::string_view name, std::string_view description);
+
+	GRAPHQLSERVICE_EXPORT void AddPossibleTypes(std::vector<std::weak_ptr<BaseType>> possibleTypes);
+
+	// Accessors
+	std::string_view name() const noexcept final;
+	const std::vector<std::weak_ptr<BaseType>>& possibleTypes() const noexcept final;
+
+private:
+	const std::string_view _name;
+
+	std::vector<std::weak_ptr<BaseType>> _possibleTypes;
+};
+
+struct EnumValueType
+{
+	std::string_view value;
+	std::string_view description;
+	std::optional<std::string_view> deprecationReason;
+};
+
+class EnumType : public BaseType
+{
+public:
+	GRAPHQLSERVICE_EXPORT explicit EnumType(std::string_view name, std::string_view description);
+
+	GRAPHQLSERVICE_EXPORT void AddEnumValues(std::vector<EnumValueType> enumValues);
+
+	// Accessors
+	std::string_view name() const noexcept final;
+	const std::vector<std::shared_ptr<EnumValue>>& enumValues() const noexcept final;
+
+private:
+	const std::string_view _name;
+
+	std::vector<std::shared_ptr<EnumValue>> _enumValues;
+};
+
+class InputObjectType : public BaseType
+{
+public:
+	GRAPHQLSERVICE_EXPORT explicit InputObjectType(
+		std::string_view name, std::string_view description);
+
+	GRAPHQLSERVICE_EXPORT void AddInputValues(std::vector<std::shared_ptr<InputValue>> inputValues);
+
+	// Accessors
+	std::string_view name() const noexcept final;
+	const std::vector<std::shared_ptr<InputValue>>& inputFields() const noexcept final;
+
+private:
+	const std::string_view _name;
+
+	std::vector<std::shared_ptr<InputValue>> _inputValues;
+};
+
+class WrapperType : public BaseType
+{
+public:
+	GRAPHQLSERVICE_EXPORT explicit WrapperType(
+		introspection::TypeKind kind, const std::shared_ptr<BaseType>& ofType);
+
+	// Accessors
+	const std::weak_ptr<BaseType>& ofType() const noexcept final;
+
+private:
+	const std::weak_ptr<BaseType> _ofType;
+};
+
+class Field : public std::enable_shared_from_this<Field>
+{
+public:
+	GRAPHQLSERVICE_EXPORT explicit Field(std::string_view name, std::string_view description,
+		std::optional<std::string_view> deprecationReason,
+		std::vector<std::shared_ptr<InputValue>>&& args, const std::shared_ptr<BaseType>& type);
+
+	// Accessors
+	std::string_view name() const noexcept;
+	std::string_view description() const noexcept;
+	const std::vector<std::shared_ptr<InputValue>>& args() const noexcept;
+	const std::weak_ptr<BaseType>& type() const noexcept;
+	const std::optional<std::string_view>& deprecationReason() const noexcept;
+
+private:
+	const std::string_view _name;
+	const std::string_view _description;
+	const std::optional<std::string_view> _deprecationReason;
+	const std::vector<std::shared_ptr<InputValue>> _args;
+	const std::weak_ptr<BaseType> _type;
+};
+
+class InputValue : public std::enable_shared_from_this<InputValue>
+{
+public:
+	GRAPHQLSERVICE_EXPORT explicit InputValue(std::string_view name, std::string_view description,
+		const std::shared_ptr<BaseType>& type, std::string_view defaultValue);
+
+	// Accessors
+	std::string_view name() const noexcept;
+	std::string_view description() const noexcept;
+	const std::weak_ptr<BaseType>& type() const noexcept;
+	std::string_view defaultValue() const noexcept;
+
+private:
+	const std::string_view _name;
+	const std::string_view _description;
+	const std::weak_ptr<BaseType> _type;
+	const std::string_view _defaultValue;
+};
+
+class EnumValue : public std::enable_shared_from_this<EnumValue>
+{
+public:
+	GRAPHQLSERVICE_EXPORT explicit EnumValue(std::string_view name, std::string_view description,
+		std::optional<std::string_view> deprecationReason);
+
+	// Accessors
+	std::string_view name() const noexcept;
+	std::string_view description() const noexcept;
+	const std::optional<std::string_view>& deprecationReason() const noexcept;
+
+private:
+	const std::string_view _name;
+	const std::string_view _description;
+	const std::optional<std::string_view> _deprecationReason;
+};
+
+class Directive : public std::enable_shared_from_this<Directive>
+{
+public:
+	GRAPHQLSERVICE_EXPORT explicit Directive(std::string_view name, std::string_view description,
+		std::vector<introspection::DirectiveLocation>&& locations,
+		std::vector<std::shared_ptr<InputValue>>&& args);
+
+	// Accessors
+	std::string_view name() const noexcept;
+	std::string_view description() const noexcept;
+	const std::vector<introspection::DirectiveLocation>& locations() const noexcept;
+	const std::vector<std::shared_ptr<InputValue>>& args() const noexcept;
+
+private:
+	const std::string_view _name;
+	const std::string_view _description;
+	const std::vector<introspection::DirectiveLocation> _locations;
+	const std::vector<std::shared_ptr<InputValue>> _args;
+};
+
+} // namespace schema
+} // namespace graphql
+
+#endif // GRAPHQLSCHEMA_H

--- a/include/graphqlservice/GraphQLSchema.h
+++ b/include/graphqlservice/GraphQLSchema.h
@@ -8,6 +8,8 @@
 
 #include "graphqlservice/GraphQLService.h"
 
+#include <initializer_list>
+
 namespace graphql {
 namespace introspection {
 
@@ -41,33 +43,37 @@ public:
 	GRAPHQLSERVICE_EXPORT void AddMutationType(std::shared_ptr<ObjectType> mutation);
 	GRAPHQLSERVICE_EXPORT void AddSubscriptionType(std::shared_ptr<ObjectType> subscription);
 	GRAPHQLSERVICE_EXPORT void AddType(std::string_view name, std::shared_ptr<BaseType> type);
-	GRAPHQLSERVICE_EXPORT const std::shared_ptr<BaseType>& LookupType(std::string_view name) const;
-	GRAPHQLSERVICE_EXPORT const std::shared_ptr<BaseType>& WrapType(
-		introspection::TypeKind kind, const std::shared_ptr<BaseType>& ofType);
+	GRAPHQLSERVICE_EXPORT const std::shared_ptr<const BaseType>& LookupType(
+		std::string_view name) const;
+	GRAPHQLSERVICE_EXPORT const std::shared_ptr<const BaseType>& WrapType(
+		introspection::TypeKind kind, const std::shared_ptr<const BaseType>& ofType);
 	GRAPHQLSERVICE_EXPORT void AddDirective(std::shared_ptr<Directive> directive);
 
 	// Accessors
 	GRAPHQLSERVICE_EXPORT bool supportsIntrospection() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::pair<std::string_view, std::shared_ptr<BaseType>>>&
-	types()
+	GRAPHQLSERVICE_EXPORT const std::vector<
+		std::pair<std::string_view, std::shared_ptr<const BaseType>>>&
+	types() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::shared_ptr<const ObjectType>& queryType() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::shared_ptr<const ObjectType>& mutationType() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::shared_ptr<const ObjectType>& subscriptionType()
 		const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::shared_ptr<ObjectType>& queryType() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::shared_ptr<ObjectType>& mutationType() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::shared_ptr<ObjectType>& subscriptionType() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<Directive>>& directives()
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const Directive>>& directives()
 		const noexcept;
 
 private:
 	const bool _noIntrospection = false;
 
-	std::shared_ptr<ObjectType> _query;
-	std::shared_ptr<ObjectType> _mutation;
-	std::shared_ptr<ObjectType> _subscription;
+	std::shared_ptr<const ObjectType> _query;
+	std::shared_ptr<const ObjectType> _mutation;
+	std::shared_ptr<const ObjectType> _subscription;
 	std::unordered_map<std::string_view, size_t> _typeMap;
-	std::vector<std::pair<std::string_view, std::shared_ptr<BaseType>>> _types;
-	std::vector<std::shared_ptr<Directive>> _directives;
-	std::unordered_map<std::shared_ptr<BaseType>, std::shared_ptr<BaseType>> _nonNullWrappers;
-	std::unordered_map<std::shared_ptr<BaseType>, std::shared_ptr<BaseType>> _listWrappers;
+	std::vector<std::pair<std::string_view, std::shared_ptr<const BaseType>>> _types;
+	std::vector<std::shared_ptr<const Directive>> _directives;
+	std::unordered_map<std::shared_ptr<const BaseType>, std::shared_ptr<const BaseType>>
+		_nonNullWrappers;
+	std::unordered_map<std::shared_ptr<const BaseType>, std::shared_ptr<const BaseType>>
+		_listWrappers;
 };
 
 class BaseType : public std::enable_shared_from_this<BaseType>
@@ -77,12 +83,17 @@ public:
 	GRAPHQLSERVICE_EXPORT introspection::TypeKind kind() const noexcept;
 	GRAPHQLSERVICE_EXPORT virtual std::string_view name() const noexcept;
 	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<Field>>& fields() const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<InterfaceType>>& interfaces() const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::weak_ptr<BaseType>>& possibleTypes() const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<EnumValue>>& enumValues() const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<InputValue>>& inputFields() const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual const std::weak_ptr<BaseType>& ofType() const noexcept;
+	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<const Field>>& fields()
+		const noexcept;
+	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<const InterfaceType>>&
+	interfaces() const noexcept;
+	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::weak_ptr<const BaseType>>& possibleTypes()
+		const noexcept;
+	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<const EnumValue>>& enumValues()
+		const noexcept;
+	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<const InputValue>>&
+	inputFields() const noexcept;
+	GRAPHQLSERVICE_EXPORT virtual const std::weak_ptr<const BaseType>& ofType() const noexcept;
 
 protected:
 	BaseType(introspection::TypeKind kind, std::string_view description);
@@ -94,8 +105,16 @@ private:
 
 class ScalarType : public BaseType
 {
+private:
+	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
+	// method without exposing the constructor as part of the public interface.
+	struct init;
+
 public:
-	GRAPHQLSERVICE_EXPORT explicit ScalarType(std::string_view name, std::string_view description);
+	explicit ScalarType(init&& params);
+
+	GRAPHQLSERVICE_EXPORT static std::shared_ptr<ScalarType> Make(
+		std::string_view name, std::string_view description);
 
 	// Accessors
 	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
@@ -106,61 +125,90 @@ private:
 
 class ObjectType : public BaseType
 {
+private:
+	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
+	// method without exposing the constructor as part of the public interface.
+	struct init;
+
 public:
-	GRAPHQLSERVICE_EXPORT explicit ObjectType(std::string_view name, std::string_view description);
+	explicit ObjectType(init&& params);
+
+	GRAPHQLSERVICE_EXPORT static std::shared_ptr<ObjectType> Make(
+		std::string_view name, std::string_view description);
 
 	GRAPHQLSERVICE_EXPORT void AddInterfaces(
-		std::vector<std::shared_ptr<InterfaceType>> interfaces);
-	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<Field>> fields);
+		std::initializer_list<std::shared_ptr<const InterfaceType>> interfaces);
+	GRAPHQLSERVICE_EXPORT void AddFields(std::initializer_list<std::shared_ptr<Field>> fields);
 
 	// Accessors
 	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<Field>>& fields() const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<InterfaceType>>& interfaces() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const Field>>& fields()
+		const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const InterfaceType>>& interfaces()
+		const noexcept final;
 
 private:
 	const std::string_view _name;
 
-	std::vector<std::shared_ptr<InterfaceType>> _interfaces;
-	std::vector<std::shared_ptr<Field>> _fields;
+	std::vector<std::shared_ptr<const InterfaceType>> _interfaces;
+	std::vector<std::shared_ptr<const Field>> _fields;
 };
 
 class InterfaceType : public BaseType
 {
+private:
+	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
+	// method without exposing the constructor as part of the public interface.
+	struct init;
+
 public:
-	GRAPHQLSERVICE_EXPORT explicit InterfaceType(
+	explicit InterfaceType(init&& params);
+
+	GRAPHQLSERVICE_EXPORT static std::shared_ptr<InterfaceType> Make(
 		std::string_view name, std::string_view description);
 
 	GRAPHQLSERVICE_EXPORT void AddPossibleType(std::weak_ptr<ObjectType> possibleType);
-	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<Field>> fields);
+	GRAPHQLSERVICE_EXPORT void AddFields(std::initializer_list<std::shared_ptr<Field>> fields);
 
 	// Accessors
 	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<Field>>& fields() const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::weak_ptr<BaseType>>& possibleTypes() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const Field>>& fields()
+		const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::weak_ptr<const BaseType>>& possibleTypes()
+		const noexcept final;
 
 private:
 	const std::string_view _name;
 
-	std::vector<std::shared_ptr<Field>> _fields;
-	std::vector<std::weak_ptr<BaseType>> _possibleTypes;
+	std::vector<std::shared_ptr<const Field>> _fields;
+	std::vector<std::weak_ptr<const BaseType>> _possibleTypes;
 };
 
 class UnionType : public BaseType
 {
-public:
-	GRAPHQLSERVICE_EXPORT explicit UnionType(std::string_view name, std::string_view description);
+private:
+	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
+	// method without exposing the constructor as part of the public interface.
+	struct init;
 
-	GRAPHQLSERVICE_EXPORT void AddPossibleTypes(std::vector<std::weak_ptr<BaseType>> possibleTypes);
+public:
+	explicit UnionType(init&& params);
+
+	GRAPHQLSERVICE_EXPORT static std::shared_ptr<UnionType> Make(
+		std::string_view name, std::string_view description);
+
+	GRAPHQLSERVICE_EXPORT void AddPossibleTypes(
+		std::initializer_list<std::weak_ptr<const BaseType>> possibleTypes);
 
 	// Accessors
 	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::weak_ptr<BaseType>>& possibleTypes() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::weak_ptr<const BaseType>>& possibleTypes()
+		const noexcept final;
 
 private:
 	const std::string_view _name;
 
-	std::vector<std::weak_ptr<BaseType>> _possibleTypes;
+	std::vector<std::weak_ptr<const BaseType>> _possibleTypes;
 };
 
 struct EnumValueType
@@ -172,98 +220,147 @@ struct EnumValueType
 
 class EnumType : public BaseType
 {
-public:
-	GRAPHQLSERVICE_EXPORT explicit EnumType(std::string_view name, std::string_view description);
+private:
+	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
+	// method without exposing the constructor as part of the public interface.
+	struct init;
 
-	GRAPHQLSERVICE_EXPORT void AddEnumValues(std::vector<EnumValueType> enumValues);
+public:
+	explicit EnumType(init&& params);
+
+	GRAPHQLSERVICE_EXPORT static std::shared_ptr<EnumType> Make(
+		std::string_view name, std::string_view description);
+
+	GRAPHQLSERVICE_EXPORT void AddEnumValues(std::initializer_list<EnumValueType> enumValues);
 
 	// Accessors
 	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<EnumValue>>& enumValues() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const EnumValue>>& enumValues()
+		const noexcept final;
 
 private:
 	const std::string_view _name;
 
-	std::vector<std::shared_ptr<EnumValue>> _enumValues;
+	std::vector<std::shared_ptr<const EnumValue>> _enumValues;
 };
 
 class InputObjectType : public BaseType
 {
+private:
+	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
+	// method without exposing the constructor as part of the public interface.
+	struct init;
+
 public:
-	GRAPHQLSERVICE_EXPORT explicit InputObjectType(
+	explicit InputObjectType(init&& params);
+
+	GRAPHQLSERVICE_EXPORT static std::shared_ptr<InputObjectType> Make(
 		std::string_view name, std::string_view description);
 
-	GRAPHQLSERVICE_EXPORT void AddInputValues(std::vector<std::shared_ptr<InputValue>> inputValues);
+	GRAPHQLSERVICE_EXPORT void AddInputValues(
+		std::initializer_list<std::shared_ptr<InputValue>> inputValues);
 
 	// Accessors
 	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<InputValue>>& inputFields() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const InputValue>>& inputFields()
+		const noexcept final;
 
 private:
 	const std::string_view _name;
 
-	std::vector<std::shared_ptr<InputValue>> _inputValues;
+	std::vector<std::shared_ptr<const InputValue>> _inputValues;
 };
 
 class WrapperType : public BaseType
 {
+private:
+	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
+	// method without exposing the constructor as part of the public interface.
+	struct init;
+
 public:
-	GRAPHQLSERVICE_EXPORT explicit WrapperType(
-		introspection::TypeKind kind, const std::shared_ptr<BaseType>& ofType);
+	explicit WrapperType(init&& params);
+
+	GRAPHQLSERVICE_EXPORT static std::shared_ptr<WrapperType> Make(
+		introspection::TypeKind kind, const std::shared_ptr<const BaseType>& ofType);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT const std::weak_ptr<BaseType>& ofType() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::weak_ptr<const BaseType>& ofType() const noexcept final;
 
 private:
-	const std::weak_ptr<BaseType> _ofType;
+	const std::weak_ptr<const BaseType> _ofType;
 };
 
 class Field : public std::enable_shared_from_this<Field>
 {
+private:
+	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
+	// method without exposing the constructor as part of the public interface.
+	struct init;
+
 public:
-	GRAPHQLSERVICE_EXPORT explicit Field(std::string_view name, std::string_view description,
-		std::optional<std::string_view> deprecationReason,
-		std::vector<std::shared_ptr<InputValue>>&& args, const std::shared_ptr<BaseType>& type);
+	explicit Field(init&& params);
+
+	GRAPHQLSERVICE_EXPORT static std::shared_ptr<Field> Make(std::string_view name,
+		std::string_view description, std::optional<std::string_view> deprecationReason,
+		const std::shared_ptr<const BaseType>& type,
+		std::initializer_list<std::shared_ptr<InputValue>> args = {});
 
 	// Accessors
 	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept;
 	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<InputValue>>& args() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::weak_ptr<BaseType>& type() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const InputValue>>& args()
+		const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::weak_ptr<const BaseType>& type() const noexcept;
 	GRAPHQLSERVICE_EXPORT const std::optional<std::string_view>& deprecationReason() const noexcept;
 
 private:
 	const std::string_view _name;
 	const std::string_view _description;
 	const std::optional<std::string_view> _deprecationReason;
-	const std::vector<std::shared_ptr<InputValue>> _args;
-	const std::weak_ptr<BaseType> _type;
+	const std::weak_ptr<const BaseType> _type;
+	const std::vector<std::shared_ptr<const InputValue>> _args;
 };
 
 class InputValue : public std::enable_shared_from_this<InputValue>
 {
+private:
+	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
+	// method without exposing the constructor as part of the public interface.
+	struct init;
+
 public:
-	GRAPHQLSERVICE_EXPORT explicit InputValue(std::string_view name, std::string_view description,
-		const std::shared_ptr<BaseType>& type, std::string_view defaultValue);
+	explicit InputValue(init&& params);
+
+	GRAPHQLSERVICE_EXPORT static std::shared_ptr<InputValue> Make(std::string_view name,
+		std::string_view description, const std::shared_ptr<const BaseType>& type,
+		std::string_view defaultValue);
 
 	// Accessors
 	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept;
 	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::weak_ptr<BaseType>& type() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::weak_ptr<const BaseType>& type() const noexcept;
 	GRAPHQLSERVICE_EXPORT std::string_view defaultValue() const noexcept;
 
 private:
 	const std::string_view _name;
 	const std::string_view _description;
-	const std::weak_ptr<BaseType> _type;
+	const std::weak_ptr<const BaseType> _type;
 	const std::string_view _defaultValue;
 };
 
 class EnumValue : public std::enable_shared_from_this<EnumValue>
 {
+private:
+	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
+	// method without exposing the constructor as part of the public interface.
+	struct init;
+
 public:
-	GRAPHQLSERVICE_EXPORT explicit EnumValue(std::string_view name, std::string_view description,
-		std::optional<std::string_view> deprecationReason);
+	explicit EnumValue(init&& params);
+
+	GRAPHQLSERVICE_EXPORT static std::shared_ptr<EnumValue> Make(std::string_view name,
+		std::string_view description, std::optional<std::string_view> deprecationReason);
 
 	// Accessors
 	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept;
@@ -278,22 +375,32 @@ private:
 
 class Directive : public std::enable_shared_from_this<Directive>
 {
+private:
+	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
+	// method without exposing the constructor as part of the public interface.
+	struct init;
+
 public:
-	GRAPHQLSERVICE_EXPORT explicit Directive(std::string_view name, std::string_view description,
-		std::vector<introspection::DirectiveLocation>&& locations,
-		std::vector<std::shared_ptr<InputValue>>&& args);
+	explicit Directive(init&& params);
+
+	GRAPHQLSERVICE_EXPORT static std::shared_ptr<Directive> Make(std::string_view name,
+		std::string_view description,
+		std::initializer_list<introspection::DirectiveLocation> locations,
+		std::initializer_list<std::shared_ptr<InputValue>> args = {});
 
 	// Accessors
 	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept;
 	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::vector<introspection::DirectiveLocation>& locations() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<InputValue>>& args() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::vector<introspection::DirectiveLocation>& locations()
+		const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const InputValue>>& args()
+		const noexcept;
 
 private:
 	const std::string_view _name;
 	const std::string_view _description;
 	const std::vector<introspection::DirectiveLocation> _locations;
-	const std::vector<std::shared_ptr<InputValue>> _args;
+	const std::vector<std::shared_ptr<const InputValue>> _args;
 };
 
 } // namespace schema

--- a/include/graphqlservice/GraphQLSchema.h
+++ b/include/graphqlservice/GraphQLSchema.h
@@ -35,7 +35,7 @@ class EnumValue;
 class Schema : public std::enable_shared_from_this<Schema>
 {
 public:
-	GRAPHQLSERVICE_EXPORT explicit Schema();
+	GRAPHQLSERVICE_EXPORT explicit Schema(bool noIntrospection = false);
 
 	GRAPHQLSERVICE_EXPORT void AddQueryType(std::shared_ptr<ObjectType> query);
 	GRAPHQLSERVICE_EXPORT void AddMutationType(std::shared_ptr<ObjectType> mutation);
@@ -47,6 +47,7 @@ public:
 	GRAPHQLSERVICE_EXPORT void AddDirective(std::shared_ptr<Directive> directive);
 
 	// Accessors
+	bool supportsIntrospection() const noexcept;
 	const std::vector<std::pair<std::string_view, std::shared_ptr<BaseType>>>& types()
 		const noexcept;
 	const std::shared_ptr<ObjectType>& queryType() const noexcept;
@@ -55,6 +56,8 @@ public:
 	const std::vector<std::shared_ptr<Directive>>& directives() const noexcept;
 
 private:
+	const bool _noIntrospection = false;
+
 	std::shared_ptr<ObjectType> _query;
 	std::shared_ptr<ObjectType> _mutation;
 	std::shared_ptr<ObjectType> _subscription;

--- a/include/graphqlservice/GraphQLSchema.h
+++ b/include/graphqlservice/GraphQLSchema.h
@@ -47,13 +47,15 @@ public:
 	GRAPHQLSERVICE_EXPORT void AddDirective(std::shared_ptr<Directive> directive);
 
 	// Accessors
-	bool supportsIntrospection() const noexcept;
-	const std::vector<std::pair<std::string_view, std::shared_ptr<BaseType>>>& types()
+	GRAPHQLSERVICE_EXPORT bool supportsIntrospection() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::pair<std::string_view, std::shared_ptr<BaseType>>>&
+	types()
 		const noexcept;
-	const std::shared_ptr<ObjectType>& queryType() const noexcept;
-	const std::shared_ptr<ObjectType>& mutationType() const noexcept;
-	const std::shared_ptr<ObjectType>& subscriptionType() const noexcept;
-	const std::vector<std::shared_ptr<Directive>>& directives() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::shared_ptr<ObjectType>& queryType() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::shared_ptr<ObjectType>& mutationType() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::shared_ptr<ObjectType>& subscriptionType() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<Directive>>& directives()
+		const noexcept;
 
 private:
 	const bool _noIntrospection = false;
@@ -72,15 +74,15 @@ class BaseType : public std::enable_shared_from_this<BaseType>
 {
 public:
 	// Accessors
-	introspection::TypeKind kind() const noexcept;
-	virtual std::string_view name() const noexcept;
-	std::string_view description() const noexcept;
-	virtual const std::vector<std::shared_ptr<Field>>& fields() const noexcept;
-	virtual const std::vector<std::shared_ptr<InterfaceType>>& interfaces() const noexcept;
-	virtual const std::vector<std::weak_ptr<BaseType>>& possibleTypes() const noexcept;
-	virtual const std::vector<std::shared_ptr<EnumValue>>& enumValues() const noexcept;
-	virtual const std::vector<std::shared_ptr<InputValue>>& inputFields() const noexcept;
-	virtual const std::weak_ptr<BaseType>& ofType() const noexcept;
+	GRAPHQLSERVICE_EXPORT introspection::TypeKind kind() const noexcept;
+	GRAPHQLSERVICE_EXPORT virtual std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
+	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<Field>>& fields() const noexcept;
+	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<InterfaceType>>& interfaces() const noexcept;
+	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::weak_ptr<BaseType>>& possibleTypes() const noexcept;
+	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<EnumValue>>& enumValues() const noexcept;
+	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<InputValue>>& inputFields() const noexcept;
+	GRAPHQLSERVICE_EXPORT virtual const std::weak_ptr<BaseType>& ofType() const noexcept;
 
 protected:
 	BaseType(introspection::TypeKind kind, std::string_view description);
@@ -96,7 +98,7 @@ public:
 	GRAPHQLSERVICE_EXPORT explicit ScalarType(std::string_view name, std::string_view description);
 
 	// Accessors
-	std::string_view name() const noexcept final;
+	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -112,9 +114,9 @@ public:
 	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<Field>> fields);
 
 	// Accessors
-	std::string_view name() const noexcept final;
-	const std::vector<std::shared_ptr<Field>>& fields() const noexcept final;
-	const std::vector<std::shared_ptr<InterfaceType>>& interfaces() const noexcept final;
+	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<Field>>& fields() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<InterfaceType>>& interfaces() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -133,9 +135,9 @@ public:
 	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<Field>> fields);
 
 	// Accessors
-	std::string_view name() const noexcept final;
-	const std::vector<std::shared_ptr<Field>>& fields() const noexcept final;
-	const std::vector<std::weak_ptr<BaseType>>& possibleTypes() const noexcept final;
+	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<Field>>& fields() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::weak_ptr<BaseType>>& possibleTypes() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -152,8 +154,8 @@ public:
 	GRAPHQLSERVICE_EXPORT void AddPossibleTypes(std::vector<std::weak_ptr<BaseType>> possibleTypes);
 
 	// Accessors
-	std::string_view name() const noexcept final;
-	const std::vector<std::weak_ptr<BaseType>>& possibleTypes() const noexcept final;
+	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::weak_ptr<BaseType>>& possibleTypes() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -176,8 +178,8 @@ public:
 	GRAPHQLSERVICE_EXPORT void AddEnumValues(std::vector<EnumValueType> enumValues);
 
 	// Accessors
-	std::string_view name() const noexcept final;
-	const std::vector<std::shared_ptr<EnumValue>>& enumValues() const noexcept final;
+	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<EnumValue>>& enumValues() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -194,8 +196,8 @@ public:
 	GRAPHQLSERVICE_EXPORT void AddInputValues(std::vector<std::shared_ptr<InputValue>> inputValues);
 
 	// Accessors
-	std::string_view name() const noexcept final;
-	const std::vector<std::shared_ptr<InputValue>>& inputFields() const noexcept final;
+	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<InputValue>>& inputFields() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -210,7 +212,7 @@ public:
 		introspection::TypeKind kind, const std::shared_ptr<BaseType>& ofType);
 
 	// Accessors
-	const std::weak_ptr<BaseType>& ofType() const noexcept final;
+	GRAPHQLSERVICE_EXPORT const std::weak_ptr<BaseType>& ofType() const noexcept final;
 
 private:
 	const std::weak_ptr<BaseType> _ofType;
@@ -224,11 +226,11 @@ public:
 		std::vector<std::shared_ptr<InputValue>>&& args, const std::shared_ptr<BaseType>& type);
 
 	// Accessors
-	std::string_view name() const noexcept;
-	std::string_view description() const noexcept;
-	const std::vector<std::shared_ptr<InputValue>>& args() const noexcept;
-	const std::weak_ptr<BaseType>& type() const noexcept;
-	const std::optional<std::string_view>& deprecationReason() const noexcept;
+	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<InputValue>>& args() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::weak_ptr<BaseType>& type() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::optional<std::string_view>& deprecationReason() const noexcept;
 
 private:
 	const std::string_view _name;
@@ -245,10 +247,10 @@ public:
 		const std::shared_ptr<BaseType>& type, std::string_view defaultValue);
 
 	// Accessors
-	std::string_view name() const noexcept;
-	std::string_view description() const noexcept;
-	const std::weak_ptr<BaseType>& type() const noexcept;
-	std::string_view defaultValue() const noexcept;
+	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::weak_ptr<BaseType>& type() const noexcept;
+	GRAPHQLSERVICE_EXPORT std::string_view defaultValue() const noexcept;
 
 private:
 	const std::string_view _name;
@@ -264,9 +266,9 @@ public:
 		std::optional<std::string_view> deprecationReason);
 
 	// Accessors
-	std::string_view name() const noexcept;
-	std::string_view description() const noexcept;
-	const std::optional<std::string_view>& deprecationReason() const noexcept;
+	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::optional<std::string_view>& deprecationReason() const noexcept;
 
 private:
 	const std::string_view _name;
@@ -282,10 +284,10 @@ public:
 		std::vector<std::shared_ptr<InputValue>>&& args);
 
 	// Accessors
-	std::string_view name() const noexcept;
-	std::string_view description() const noexcept;
-	const std::vector<introspection::DirectiveLocation>& locations() const noexcept;
-	const std::vector<std::shared_ptr<InputValue>>& args() const noexcept;
+	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::vector<introspection::DirectiveLocation>& locations() const noexcept;
+	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<InputValue>>& args() const noexcept;
 
 private:
 	const std::string_view _name;

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -1035,7 +1035,7 @@ private:
 		const std::shared_ptr<RequestState>& state, const peg::ast_node& root,
 		const std::string& operationName, response::Value&& variables) const;
 
-	TypeMap _operations;
+	const TypeMap _operations;
 	std::unique_ptr<ValidateExecutableVisitor> _validation;
 	std::map<SubscriptionKey, std::shared_ptr<SubscriptionData>> _subscriptions;
 	std::unordered_map<SubscriptionName, std::set<SubscriptionKey>> _listeners;

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -40,7 +40,14 @@
 #include <variant>
 #include <vector>
 
-namespace graphql::service {
+namespace graphql {
+namespace schema {
+
+class Schema;
+
+} // namespace schema
+
+namespace service {
 
 // Errors should have a message string, and optional locations and a path.
 GRAPHQLSERVICE_EXPORT void addErrorMessage(std::string&& message, response::Value& error);
@@ -956,7 +963,8 @@ class ValidateExecutableVisitor;
 class Request : public std::enable_shared_from_this<Request>
 {
 protected:
-	GRAPHQLSERVICE_EXPORT explicit Request(TypeMap&& operationTypes);
+	GRAPHQLSERVICE_EXPORT explicit Request(
+		TypeMap&& operationTypes, const std::shared_ptr<schema::Schema>& schema);
 	GRAPHQLSERVICE_EXPORT virtual ~Request();
 
 public:
@@ -1034,6 +1042,7 @@ private:
 	SubscriptionKey _nextKey = 0;
 };
 
-} /* namespace graphql::service */
+} // namespace service
+} // namespace graphql
 
 #endif // GRAPHQLSERVICE_H

--- a/include/graphqlservice/introspection/Introspection.h
+++ b/include/graphqlservice/introspection/Introspection.h
@@ -37,22 +37,12 @@ public:
 
 private:
 	const std::shared_ptr<schema::Schema> _schema;
-
-	std::shared_ptr<schema::ObjectType> _query;
-	std::shared_ptr<schema::ObjectType> _mutation;
-	std::shared_ptr<schema::ObjectType> _subscription;
-	std::unordered_map<response::StringType, size_t> _typeMap;
-	std::vector<std::pair<response::StringType, std::shared_ptr<object::Type>>> _types;
-	std::vector<std::shared_ptr<object::Directive>> _directives;
-	std::unordered_map<std::shared_ptr<object::Type>, std::shared_ptr<object::Type>>
-		_nonNullWrappers;
-	std::unordered_map<std::shared_ptr<object::Type>, std::shared_ptr<object::Type>> _listWrappers;
 };
 
 class Type : public object::Type
 {
 public:
-	GRAPHQLINTROSPECTION_EXPORT explicit Type(const std::shared_ptr<schema::BaseType>& type);
+	GRAPHQLINTROSPECTION_EXPORT explicit Type(const std::shared_ptr<const schema::BaseType>& type);
 
 	// Accessors
 	service::FieldResult<TypeKind> getKind(service::FieldParams&&) const override;
@@ -76,13 +66,13 @@ public:
 		service::FieldParams&& params) const override;
 
 private:
-	const std::shared_ptr<schema::BaseType> _type;
+	const std::shared_ptr<const schema::BaseType> _type;
 };
 
 class Field : public object::Field
 {
 public:
-	GRAPHQLINTROSPECTION_EXPORT explicit Field(const std::shared_ptr<schema::Field>& field);
+	GRAPHQLINTROSPECTION_EXPORT explicit Field(const std::shared_ptr<const schema::Field>& field);
 
 	// Accessors
 	service::FieldResult<response::StringType> getName(
@@ -99,14 +89,14 @@ public:
 		service::FieldParams&& params) const override;
 
 private:
-	const std::shared_ptr<schema::Field> _field;
+	const std::shared_ptr<const schema::Field> _field;
 };
 
 class InputValue : public object::InputValue
 {
 public:
 	GRAPHQLINTROSPECTION_EXPORT explicit InputValue(
-		const std::shared_ptr<schema::InputValue>& inputValue);
+		const std::shared_ptr<const schema::InputValue>& inputValue);
 
 	// Accessors
 	service::FieldResult<response::StringType> getName(
@@ -119,13 +109,14 @@ public:
 		service::FieldParams&& params) const override;
 
 private:
-	const std::shared_ptr<schema::InputValue> _inputValue;
+	const std::shared_ptr<const schema::InputValue> _inputValue;
 };
 
 class EnumValue : public object::EnumValue
 {
 public:
-	GRAPHQLINTROSPECTION_EXPORT explicit EnumValue(const std::shared_ptr<schema::EnumValue>& enumValue);
+	GRAPHQLINTROSPECTION_EXPORT explicit EnumValue(
+		const std::shared_ptr<const schema::EnumValue>& enumValue);
 
 	// Accessors
 	service::FieldResult<response::StringType> getName(
@@ -138,13 +129,14 @@ public:
 		service::FieldParams&& params) const override;
 
 private:
-	const std::shared_ptr<schema::EnumValue> _enumValue;
+	const std::shared_ptr<const schema::EnumValue> _enumValue;
 };
 
 class Directive : public object::Directive
 {
 public:
-	GRAPHQLINTROSPECTION_EXPORT explicit Directive(const std::shared_ptr<schema::Directive>& directive);
+	GRAPHQLINTROSPECTION_EXPORT explicit Directive(
+		const std::shared_ptr<const schema::Directive>& directive);
 
 	// Accessors
 	service::FieldResult<response::StringType> getName(
@@ -157,7 +149,7 @@ public:
 		service::FieldParams&& params) const override;
 
 private:
-	const std::shared_ptr<schema::Directive> _directive;
+	const std::shared_ptr<const schema::Directive> _directive;
 };
 
 } /* namespace graphql::introspection */

--- a/include/graphqlservice/introspection/Introspection.h
+++ b/include/graphqlservice/introspection/Introspection.h
@@ -7,7 +7,7 @@
 #define INTROSPECTION_H
 
 #include "graphqlservice/GraphQLSchema.h"
-#include "graphqlservice/IntrospectionSchema.h"
+#include "graphqlservice/introspection/IntrospectionSchema.h"
 
 namespace graphql::introspection {
 
@@ -21,7 +21,7 @@ class EnumValue;
 class Schema : public object::Schema
 {
 public:
-	GRAPHQLSERVICE_EXPORT explicit Schema(const std::shared_ptr<schema::Schema>& schema);
+	GRAPHQLINTROSPECTION_EXPORT explicit Schema(const std::shared_ptr<schema::Schema>& schema);
 
 	// Accessors
 	service::FieldResult<std::vector<std::shared_ptr<object::Type>>> getTypes(
@@ -52,7 +52,7 @@ private:
 class Type : public object::Type
 {
 public:
-	GRAPHQLSERVICE_EXPORT explicit Type(const std::shared_ptr<schema::BaseType>& type);
+	GRAPHQLINTROSPECTION_EXPORT explicit Type(const std::shared_ptr<schema::BaseType>& type);
 
 	// Accessors
 	service::FieldResult<TypeKind> getKind(service::FieldParams&&) const override;
@@ -82,7 +82,7 @@ private:
 class Field : public object::Field
 {
 public:
-	GRAPHQLSERVICE_EXPORT explicit Field(const std::shared_ptr<schema::Field>& field);
+	GRAPHQLINTROSPECTION_EXPORT explicit Field(const std::shared_ptr<schema::Field>& field);
 
 	// Accessors
 	service::FieldResult<response::StringType> getName(
@@ -105,7 +105,7 @@ private:
 class InputValue : public object::InputValue
 {
 public:
-	GRAPHQLSERVICE_EXPORT explicit InputValue(
+	GRAPHQLINTROSPECTION_EXPORT explicit InputValue(
 		const std::shared_ptr<schema::InputValue>& inputValue);
 
 	// Accessors
@@ -125,7 +125,7 @@ private:
 class EnumValue : public object::EnumValue
 {
 public:
-	GRAPHQLSERVICE_EXPORT explicit EnumValue(const std::shared_ptr<schema::EnumValue>& enumValue);
+	GRAPHQLINTROSPECTION_EXPORT explicit EnumValue(const std::shared_ptr<schema::EnumValue>& enumValue);
 
 	// Accessors
 	service::FieldResult<response::StringType> getName(
@@ -144,7 +144,7 @@ private:
 class Directive : public object::Directive
 {
 public:
-	GRAPHQLSERVICE_EXPORT explicit Directive(const std::shared_ptr<schema::Directive>& directive);
+	GRAPHQLINTROSPECTION_EXPORT explicit Directive(const std::shared_ptr<schema::Directive>& directive);
 
 	// Accessors
 	service::FieldResult<response::StringType> getName(

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -137,7 +137,7 @@ foreach(CPP_FILE IN LISTS SEPARATE_NOINTROSPECTION_SCHEMA_FILES)
 endforeach(CPP_FILE)
 
 add_library(separateschema_nointrospection STATIC ${SEPARATE_NOINTROSPECTION_SCHEMA_PATHS})
-target_link_libraries(separateschema_nointrospection PUBLIC graphqlservice)
+target_link_libraries(separateschema_nointrospection PUBLIC graphqlservice_nointrospection)
 target_compile_definitions(separateschema_nointrospection PUBLIC IMPL_SEPARATE_TODAY)
 target_include_directories(separateschema_nointrospection PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/../include
@@ -182,7 +182,8 @@ target_include_directories(sample_nointrospection PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../PEGTL/include)
 
 if(WIN32 AND BUILD_SHARED_LIBS)
-  add_custom_target(copy_sample_dlls ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlservice> ${CMAKE_CURRENT_BINARY_DIR}
+  add_custom_target(copy_sample_dlls ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlservice_nointrospection> ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlservice> ${CMAKE_CURRENT_BINARY_DIR}
       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqljson> ${CMAKE_CURRENT_BINARY_DIR}
       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlpeg> ${CMAKE_CURRENT_BINARY_DIR}
       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlresponse> ${CMAKE_CURRENT_BINARY_DIR}
@@ -239,7 +240,7 @@ if(GRAPHQL_BUILD_TESTS)
   add_bigobj_flag(unifiedgraphql)
 
   add_library(unifiedschema_nointrospection STATIC unified_nointrospection/TodaySchema.cpp)
-  target_link_libraries(unifiedschema_nointrospection PUBLIC graphqlservice)
+  target_link_libraries(unifiedschema_nointrospection PUBLIC graphqlservice_nointrospection)
   target_include_directories(unifiedschema_nointrospection PUBLIC
     ${CMAKE_CURRENT_BINARY_DIR}/../include
     ${CMAKE_CURRENT_SOURCE_DIR}/../include

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -172,6 +172,7 @@ target_include_directories(sample PRIVATE
 
 # sample_nointrospection
 add_executable(sample_nointrospection today/sample.cpp)
+target_compile_definitions(sample_nointrospection PRIVATE NO_INTROSPECTION)
 target_link_libraries(sample_nointrospection PRIVATE
   separategraphql_nointrospection
   graphqljson)
@@ -201,8 +202,20 @@ target_include_directories(benchmark PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../include
   ${CMAKE_CURRENT_SOURCE_DIR}/../PEGTL/include)
 
+# benchmark_nointrospection
+add_executable(benchmark_nointrospection today/benchmark.cpp)
+target_compile_definitions(benchmark_nointrospection PRIVATE NO_INTROSPECTION)
+target_link_libraries(benchmark_nointrospection PRIVATE
+  separategraphql_nointrospection
+  graphqljson)
+target_include_directories(benchmark_nointrospection PRIVATE
+  ${CMAKE_CURRENT_BINARY_DIR}/../include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../PEGTL/include)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   add_dependencies(benchmark copy_sample_dlls)
+  add_dependencies(benchmark_nointrospection copy_sample_dlls)
 endif()
 
 if(GRAPHQL_BUILD_TESTS)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -16,10 +16,24 @@ if(GRAPHQL_UPDATE_SAMPLES)
     WORKING_DIRECTORY unified
     COMMENT "Generating mock TodaySchema files")
 
+  # unifiedschema_nointrospection
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/unified_nointrospection)
+
+  add_custom_command(
+    OUTPUT
+      ${CMAKE_CURRENT_BINARY_DIR}/unified_nointrospection/TodaySchema.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/unified_nointrospection/TodaySchema.h
+    COMMAND schemagen --schema="${CMAKE_CURRENT_SOURCE_DIR}/schema.today.graphql" --prefix="Today" --namespace="today" --no-introspection
+    DEPENDS schemagen schema.today.graphql
+    WORKING_DIRECTORY unified_nointrospection
+    COMMENT "Generating mock TodaySchema files without Introspection (--no-introspection)")
+
   add_custom_target(unified_schema_files ALL
     DEPENDS
       ${CMAKE_CURRENT_BINARY_DIR}/unified/TodaySchema.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/unified/TodaySchema.h)
+      ${CMAKE_CURRENT_BINARY_DIR}/unified/TodaySchema.h
+      ${CMAKE_CURRENT_BINARY_DIR}/unified_nointrospection/TodaySchema.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/unified_nointrospection/TodaySchema.h)
 
   # separateschema
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/separate)
@@ -31,10 +45,22 @@ if(GRAPHQL_UPDATE_SAMPLES)
     WORKING_DIRECTORY separate
     COMMENT "Generating mock TodaySchema (--separate-files)")
 
-  add_custom_target(separate_schema_files ALL
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/separate/today_schema_files)
+  # separateschema_nointrospection
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/separate_nointrospection)
 
-  # unifiedschema
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/separate_nointrospection/today_schema_files
+    COMMAND schemagen --schema="${CMAKE_CURRENT_SOURCE_DIR}/schema.today.graphql" --prefix="Today" --namespace="today" --no-introspection --separate-files > today_schema_files
+    DEPENDS schemagen schema.today.graphql
+    WORKING_DIRECTORY separate_nointrospection
+    COMMENT "Generating mock TodaySchema without Introspection (--no-introspection --separate-files)")
+
+  add_custom_target(separate_schema_files ALL
+    DEPENDS
+      ${CMAKE_CURRENT_BINARY_DIR}/separate/today_schema_files
+      ${CMAKE_CURRENT_BINARY_DIR}/separate_nointrospection/today_schema_files)
+
+  # validationschema
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/validation)
 
   add_custom_command(
@@ -52,15 +78,21 @@ if(GRAPHQL_UPDATE_SAMPLES)
       ${CMAKE_CURRENT_BINARY_DIR}/validation/ValidationSchema.h)
 
   file(GLOB OLD_UNIFIED_FILES ${CMAKE_CURRENT_SOURCE_DIR}/unified/*)
+  file(GLOB OLD_UNIFIED_NOINTROSPECTION_FILES ${CMAKE_CURRENT_SOURCE_DIR}/unified_nointrospection/*)
   file(GLOB OLD_SEPARATE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/separate/*)
+  file(GLOB OLD_SEPARATE_NOINTROSPECTION_FILES ${CMAKE_CURRENT_SOURCE_DIR}/separate_nointrospection/*)
   file(GLOB OLD_VALIDATION_FILES ${CMAKE_CURRENT_SOURCE_DIR}/validation/ValidationSchema.*)
 
   add_custom_command(
     OUTPUT updated_samples
     COMMAND ${CMAKE_COMMAND} -E remove -f ${OLD_UNIFIED_FILES}
     COMMAND ${CMAKE_COMMAND} -E copy_directory unified/ ${CMAKE_CURRENT_SOURCE_DIR}/unified/
+    COMMAND ${CMAKE_COMMAND} -E remove -f ${OLD_UNIFIED_NOINTROSPECTION_FILES}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory unified_nointrospection/ ${CMAKE_CURRENT_SOURCE_DIR}/unified_nointrospection/
     COMMAND ${CMAKE_COMMAND} -E remove -f ${OLD_SEPARATE_FILES}
     COMMAND ${CMAKE_COMMAND} -E copy_directory separate/ ${CMAKE_CURRENT_SOURCE_DIR}/separate/
+    COMMAND ${CMAKE_COMMAND} -E remove -f ${OLD_SEPARATE_NOINTROSPECTION_FILES}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory separate_nointrospection/ ${CMAKE_CURRENT_SOURCE_DIR}/separate_nointrospection/
     COMMAND ${CMAKE_COMMAND} -E remove -f ${OLD_VALIDATION_FILES}
     COMMAND ${CMAKE_COMMAND} -E copy_directory validation/ ${CMAKE_CURRENT_SOURCE_DIR}/validation/
     COMMAND ${CMAKE_COMMAND} -E touch updated_samples
@@ -76,7 +108,7 @@ if(GRAPHQL_UPDATE_SAMPLES)
     DEPENDS updated_samples)
 endif()
 
-# sample
+# separateschema
 set(SEPARATE_SCHEMA_PATHS "")
 file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/separate/today_schema_files SEPARATE_SCHEMA_FILES)
 foreach(CPP_FILE IN LISTS SEPARATE_SCHEMA_FILES)
@@ -97,16 +129,53 @@ if(GRAPHQL_UPDATE_SAMPLES)
   add_dependencies(separateschema update_samples)
 endif()
 
+# separateschema_nointrospection
+set(SEPARATE_NOINTROSPECTION_SCHEMA_PATHS "")
+file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/separate_nointrospection/today_schema_files SEPARATE_NOINTROSPECTION_SCHEMA_FILES)
+foreach(CPP_FILE IN LISTS SEPARATE_NOINTROSPECTION_SCHEMA_FILES)
+  list(APPEND SEPARATE_NOINTROSPECTION_SCHEMA_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/separate_nointrospection/${CPP_FILE}")
+endforeach(CPP_FILE)
+
+add_library(separateschema_nointrospection STATIC ${SEPARATE_NOINTROSPECTION_SCHEMA_PATHS})
+target_link_libraries(separateschema_nointrospection PUBLIC graphqlservice)
+target_compile_definitions(separateschema_nointrospection PUBLIC IMPL_SEPARATE_TODAY)
+target_include_directories(separateschema_nointrospection PUBLIC
+  ${CMAKE_CURRENT_BINARY_DIR}/../include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../PEGTL/include
+  separate_nointrospection)
+
+if(GRAPHQL_UPDATE_SAMPLES)
+  # wait for the sample update to complete
+  add_dependencies(separateschema_nointrospection update_samples)
+endif()
+
+# separategraphql
 add_library(separategraphql STATIC today/TodayMock.cpp)
 target_link_libraries(separategraphql PUBLIC separateschema)
-target_compile_definitions(separategraphql PUBLIC IMPL_SEPARATE_TODAY)
 target_include_directories(separategraphql PUBLIC today)
 
+# separategraphql_nointrospection
+add_library(separategraphql_nointrospection STATIC today/TodayMock.cpp)
+target_link_libraries(separategraphql_nointrospection PUBLIC separateschema_nointrospection)
+target_include_directories(separategraphql_nointrospection PUBLIC today)
+
+# sample
 add_executable(sample today/sample.cpp)
 target_link_libraries(sample PRIVATE
   separategraphql
   graphqljson)
 target_include_directories(sample PRIVATE
+  ${CMAKE_CURRENT_BINARY_DIR}/../include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../PEGTL/include)
+
+# sample_nointrospection
+add_executable(sample_nointrospection today/sample.cpp)
+target_link_libraries(sample_nointrospection PRIVATE
+  separategraphql_nointrospection
+  graphqljson)
+target_include_directories(sample_nointrospection PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}/../include
   ${CMAKE_CURRENT_SOURCE_DIR}/../include
   ${CMAKE_CURRENT_SOURCE_DIR}/../PEGTL/include)
@@ -119,6 +188,7 @@ if(WIN32 AND BUILD_SHARED_LIBS)
     DEPENDS graphqlservice graphqljson graphqlpeg graphqlresponse)
 
   add_dependencies(sample copy_sample_dlls)
+  add_dependencies(sample_nointrospection copy_sample_dlls)
 endif()
 
 # benchmark
@@ -154,6 +224,24 @@ if(GRAPHQL_BUILD_TESTS)
   target_link_libraries(unifiedgraphql PUBLIC unifiedschema)
   target_include_directories(unifiedgraphql PUBLIC today)
   add_bigobj_flag(unifiedgraphql)
+
+  add_library(unifiedschema_nointrospection STATIC unified_nointrospection/TodaySchema.cpp)
+  target_link_libraries(unifiedschema_nointrospection PUBLIC graphqlservice)
+  target_include_directories(unifiedschema_nointrospection PUBLIC
+    ${CMAKE_CURRENT_BINARY_DIR}/../include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../PEGTL/include
+    unified_nointrospection)
+
+  if(GRAPHQL_UPDATE_SAMPLES)
+    # wait for the sample update to complete
+    add_dependencies(unifiedschema_nointrospection update_samples)
+  endif()
+
+  add_library(unifiedgraphql_nointrospection STATIC today/TodayMock.cpp)
+  target_link_libraries(unifiedgraphql_nointrospection PUBLIC unifiedschema_nointrospection)
+  target_include_directories(unifiedgraphql_nointrospection PUBLIC today)
+  add_bigobj_flag(unifiedgraphql_nointrospection)
 
   add_library(validationgraphql STATIC
     validation/ValidationMock.cpp

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -121,6 +121,20 @@ if(WIN32 AND BUILD_SHARED_LIBS)
   add_dependencies(sample copy_sample_dlls)
 endif()
 
+# benchmark
+add_executable(benchmark today/benchmark.cpp)
+target_link_libraries(benchmark PRIVATE
+  separategraphql
+  graphqljson)
+target_include_directories(benchmark PRIVATE
+  ${CMAKE_CURRENT_BINARY_DIR}/../include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../PEGTL/include)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+  add_dependencies(benchmark copy_sample_dlls)
+endif()
+
 if(GRAPHQL_BUILD_TESTS)
   # tests
   add_library(unifiedschema STATIC unified/TodaySchema.cpp)

--- a/samples/introspection/IntrospectionSchema.cpp
+++ b/samples/introspection/IntrospectionSchema.cpp
@@ -556,26 +556,26 @@ std::future<service::ResolverResult> Directive::resolve_typename(service::Resolv
 
 void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 {
-	schema->AddType(R"gql(Boolean)gql"sv, std::make_shared<schema::ScalarType>(R"gql(Boolean)gql"sv, R"md(Built-in type)md"));
-	schema->AddType(R"gql(Float)gql"sv, std::make_shared<schema::ScalarType>(R"gql(Float)gql"sv, R"md(Built-in type)md"));
-	schema->AddType(R"gql(ID)gql"sv, std::make_shared<schema::ScalarType>(R"gql(ID)gql"sv, R"md(Built-in type)md"));
-	schema->AddType(R"gql(Int)gql"sv, std::make_shared<schema::ScalarType>(R"gql(Int)gql"sv, R"md(Built-in type)md"));
-	schema->AddType(R"gql(String)gql"sv, std::make_shared<schema::ScalarType>(R"gql(String)gql"sv, R"md(Built-in type)md"));
-	auto typeTypeKind = std::make_shared<schema::EnumType>(R"gql(__TypeKind)gql"sv, R"md()md"sv);
+	schema->AddType(R"gql(Boolean)gql"sv, schema::ScalarType::Make(R"gql(Boolean)gql"sv, R"md(Built-in type)md"));
+	schema->AddType(R"gql(Float)gql"sv, schema::ScalarType::Make(R"gql(Float)gql"sv, R"md(Built-in type)md"));
+	schema->AddType(R"gql(ID)gql"sv, schema::ScalarType::Make(R"gql(ID)gql"sv, R"md(Built-in type)md"));
+	schema->AddType(R"gql(Int)gql"sv, schema::ScalarType::Make(R"gql(Int)gql"sv, R"md(Built-in type)md"));
+	schema->AddType(R"gql(String)gql"sv, schema::ScalarType::Make(R"gql(String)gql"sv, R"md(Built-in type)md"));
+	auto typeTypeKind = schema::EnumType::Make(R"gql(__TypeKind)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(__TypeKind)gql"sv, typeTypeKind);
-	auto typeDirectiveLocation = std::make_shared<schema::EnumType>(R"gql(__DirectiveLocation)gql"sv, R"md()md"sv);
+	auto typeDirectiveLocation = schema::EnumType::Make(R"gql(__DirectiveLocation)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(__DirectiveLocation)gql"sv, typeDirectiveLocation);
-	auto typeSchema = std::make_shared<schema::ObjectType>(R"gql(__Schema)gql"sv, R"md()md");
+	auto typeSchema = schema::ObjectType::Make(R"gql(__Schema)gql"sv, R"md()md");
 	schema->AddType(R"gql(__Schema)gql"sv, typeSchema);
-	auto typeType = std::make_shared<schema::ObjectType>(R"gql(__Type)gql"sv, R"md()md");
+	auto typeType = schema::ObjectType::Make(R"gql(__Type)gql"sv, R"md()md");
 	schema->AddType(R"gql(__Type)gql"sv, typeType);
-	auto typeField = std::make_shared<schema::ObjectType>(R"gql(__Field)gql"sv, R"md()md");
+	auto typeField = schema::ObjectType::Make(R"gql(__Field)gql"sv, R"md()md");
 	schema->AddType(R"gql(__Field)gql"sv, typeField);
-	auto typeInputValue = std::make_shared<schema::ObjectType>(R"gql(__InputValue)gql"sv, R"md()md");
+	auto typeInputValue = schema::ObjectType::Make(R"gql(__InputValue)gql"sv, R"md()md");
 	schema->AddType(R"gql(__InputValue)gql"sv, typeInputValue);
-	auto typeEnumValue = std::make_shared<schema::ObjectType>(R"gql(__EnumValue)gql"sv, R"md()md");
+	auto typeEnumValue = schema::ObjectType::Make(R"gql(__EnumValue)gql"sv, R"md()md");
 	schema->AddType(R"gql(__EnumValue)gql"sv, typeEnumValue);
-	auto typeDirective = std::make_shared<schema::ObjectType>(R"gql(__Directive)gql"sv, R"md()md");
+	auto typeDirective = schema::ObjectType::Make(R"gql(__Directive)gql"sv, R"md()md");
 	schema->AddType(R"gql(__Directive)gql"sv, typeDirective);
 
 	typeTypeKind->AddEnumValues({
@@ -610,74 +610,74 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	});
 
 	typeSchema->AddFields({
-		std::make_shared<schema::Field>(R"gql(types)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))))),
-		std::make_shared<schema::Field>(R"gql(queryType)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))),
-		std::make_shared<schema::Field>(R"gql(mutationType)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("__Type")),
-		std::make_shared<schema::Field>(R"gql(subscriptionType)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("__Type")),
-		std::make_shared<schema::Field>(R"gql(directives)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Directive")))))
+		schema::Field::Make(R"gql(types)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))))),
+		schema::Field::Make(R"gql(queryType)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))),
+		schema::Field::Make(R"gql(mutationType)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("__Type")),
+		schema::Field::Make(R"gql(subscriptionType)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("__Type")),
+		schema::Field::Make(R"gql(directives)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Directive")))))
 	});
 	typeType->AddFields({
-		std::make_shared<schema::Field>(R"gql(kind)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__TypeKind"))),
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(fields)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(includeDeprecated)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(false)gql"sv)
-		}), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Field")))),
-		std::make_shared<schema::Field>(R"gql(interfaces)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type")))),
-		std::make_shared<schema::Field>(R"gql(possibleTypes)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type")))),
-		std::make_shared<schema::Field>(R"gql(enumValues)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(includeDeprecated)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(false)gql"sv)
-		}), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__EnumValue")))),
-		std::make_shared<schema::Field>(R"gql(inputFields)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__InputValue")))),
-		std::make_shared<schema::Field>(R"gql(ofType)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("__Type"))
+		schema::Field::Make(R"gql(kind)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__TypeKind"))),
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(fields)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Field"))), {
+			schema::InputValue::Make(R"gql(includeDeprecated)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(false)gql"sv)
+		}),
+		schema::Field::Make(R"gql(interfaces)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type")))),
+		schema::Field::Make(R"gql(possibleTypes)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type")))),
+		schema::Field::Make(R"gql(enumValues)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__EnumValue"))), {
+			schema::InputValue::Make(R"gql(includeDeprecated)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(false)gql"sv)
+		}),
+		schema::Field::Make(R"gql(inputFields)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__InputValue")))),
+		schema::Field::Make(R"gql(ofType)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("__Type"))
 	});
 	typeField->AddFields({
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<schema::Field>(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(args)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__InputValue"))))),
-		std::make_shared<schema::Field>(R"gql(type)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))),
-		std::make_shared<schema::Field>(R"gql(isDeprecated)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(deprecationReason)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		schema::Field::Make(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(args)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__InputValue"))))),
+		schema::Field::Make(R"gql(type)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))),
+		schema::Field::Make(R"gql(isDeprecated)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		schema::Field::Make(R"gql(deprecationReason)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String"))
 	});
 	typeInputValue->AddFields({
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<schema::Field>(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(type)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))),
-		std::make_shared<schema::Field>(R"gql(defaultValue)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		schema::Field::Make(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(type)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))),
+		schema::Field::Make(R"gql(defaultValue)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String"))
 	});
 	typeEnumValue->AddFields({
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<schema::Field>(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(isDeprecated)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(deprecationReason)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		schema::Field::Make(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(isDeprecated)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		schema::Field::Make(R"gql(deprecationReason)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String"))
 	});
 	typeDirective->AddFields({
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<schema::Field>(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(locations)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__DirectiveLocation"))))),
-		std::make_shared<schema::Field>(R"gql(args)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__InputValue")))))
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		schema::Field::Make(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(locations)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__DirectiveLocation"))))),
+		schema::Field::Make(R"gql(args)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__InputValue")))))
 	});
 
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(skip)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	schema->AddDirective(schema::Directive::Make(R"gql(skip)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FIELD,
 		introspection::DirectiveLocation::FRAGMENT_SPREAD,
 		introspection::DirectiveLocation::INLINE_FRAGMENT
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(if)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(include)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(if)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(include)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FIELD,
 		introspection::DirectiveLocation::FRAGMENT_SPREAD,
 		introspection::DirectiveLocation::INLINE_FRAGMENT
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(if)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(deprecated)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(if)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(deprecated)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FIELD_DEFINITION,
 		introspection::DirectiveLocation::ENUM_VALUE
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(reason)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql("No longer supported")gql"sv)
-	})));
+	}, {
+		schema::InputValue::Make(R"gql(reason)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql("No longer supported")gql"sv)
+	}));
 }
 
 } /* namespace introspection */

--- a/samples/introspection/IntrospectionSchema.cpp
+++ b/samples/introspection/IntrospectionSchema.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <array>

--- a/samples/introspection/IntrospectionSchema.cpp
+++ b/samples/introspection/IntrospectionSchema.cpp
@@ -47,7 +47,7 @@ introspection::TypeKind ModifiedArgument<introspection::TypeKind>::convert(const
 }
 
 template <>
-std::future<response::Value> ModifiedResult<introspection::TypeKind>::convert(service::FieldResult<introspection::TypeKind>&& result, ResolverParams&& params)
+std::future<service::ResolverResult> ModifiedResult<introspection::TypeKind>::convert(service::FieldResult<introspection::TypeKind>&& result, ResolverParams&& params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](introspection::TypeKind&& value, const ResolverParams&)
@@ -100,7 +100,7 @@ introspection::DirectiveLocation ModifiedArgument<introspection::DirectiveLocati
 }
 
 template <>
-std::future<response::Value> ModifiedResult<introspection::DirectiveLocation>::convert(service::FieldResult<introspection::DirectiveLocation>&& result, ResolverParams&& params)
+std::future<service::ResolverResult> ModifiedResult<introspection::DirectiveLocation>::convert(service::FieldResult<introspection::DirectiveLocation>&& result, ResolverParams&& params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](introspection::DirectiveLocation&& value, const ResolverParams&)
@@ -132,7 +132,7 @@ Schema::Schema()
 {
 }
 
-std::future<response::Value> Schema::resolveTypes(service::ResolverParams&& params)
+std::future<service::ResolverResult> Schema::resolveTypes(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getTypes(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -141,7 +141,7 @@ std::future<response::Value> Schema::resolveTypes(service::ResolverParams&& para
 	return service::ModifiedResult<Type>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Schema::resolveQueryType(service::ResolverParams&& params)
+std::future<service::ResolverResult> Schema::resolveQueryType(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getQueryType(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -150,7 +150,7 @@ std::future<response::Value> Schema::resolveQueryType(service::ResolverParams&& 
 	return service::ModifiedResult<Type>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Schema::resolveMutationType(service::ResolverParams&& params)
+std::future<service::ResolverResult> Schema::resolveMutationType(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getMutationType(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -159,7 +159,7 @@ std::future<response::Value> Schema::resolveMutationType(service::ResolverParams
 	return service::ModifiedResult<Type>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Schema::resolveSubscriptionType(service::ResolverParams&& params)
+std::future<service::ResolverResult> Schema::resolveSubscriptionType(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getSubscriptionType(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -168,7 +168,7 @@ std::future<response::Value> Schema::resolveSubscriptionType(service::ResolverPa
 	return service::ModifiedResult<Type>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Schema::resolveDirectives(service::ResolverParams&& params)
+std::future<service::ResolverResult> Schema::resolveDirectives(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDirectives(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -177,7 +177,7 @@ std::future<response::Value> Schema::resolveDirectives(service::ResolverParams&&
 	return service::ModifiedResult<Directive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Schema::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Schema::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(__Schema)gql" }, std::move(params));
 }
@@ -200,7 +200,7 @@ Type::Type()
 {
 }
 
-std::future<response::Value> Type::resolveKind(service::ResolverParams&& params)
+std::future<service::ResolverResult> Type::resolveKind(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getKind(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -209,7 +209,7 @@ std::future<response::Value> Type::resolveKind(service::ResolverParams&& params)
 	return service::ModifiedResult<TypeKind>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Type::resolveName(service::ResolverParams&& params)
+std::future<service::ResolverResult> Type::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -218,7 +218,7 @@ std::future<response::Value> Type::resolveName(service::ResolverParams&& params)
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Type::resolveDescription(service::ResolverParams&& params)
+std::future<service::ResolverResult> Type::resolveDescription(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDescription(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -227,7 +227,7 @@ std::future<response::Value> Type::resolveDescription(service::ResolverParams&& 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Type::resolveFields(service::ResolverParams&& params)
+std::future<service::ResolverResult> Type::resolveFields(service::ResolverParams&& params)
 {
 	const auto defaultArguments = []()
 	{
@@ -251,7 +251,7 @@ std::future<response::Value> Type::resolveFields(service::ResolverParams&& param
 	return service::ModifiedResult<Field>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Type::resolveInterfaces(service::ResolverParams&& params)
+std::future<service::ResolverResult> Type::resolveInterfaces(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getInterfaces(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -260,7 +260,7 @@ std::future<response::Value> Type::resolveInterfaces(service::ResolverParams&& p
 	return service::ModifiedResult<Type>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Type::resolvePossibleTypes(service::ResolverParams&& params)
+std::future<service::ResolverResult> Type::resolvePossibleTypes(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPossibleTypes(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -269,7 +269,7 @@ std::future<response::Value> Type::resolvePossibleTypes(service::ResolverParams&
 	return service::ModifiedResult<Type>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Type::resolveEnumValues(service::ResolverParams&& params)
+std::future<service::ResolverResult> Type::resolveEnumValues(service::ResolverParams&& params)
 {
 	const auto defaultArguments = []()
 	{
@@ -293,7 +293,7 @@ std::future<response::Value> Type::resolveEnumValues(service::ResolverParams&& p
 	return service::ModifiedResult<EnumValue>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Type::resolveInputFields(service::ResolverParams&& params)
+std::future<service::ResolverResult> Type::resolveInputFields(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getInputFields(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -302,7 +302,7 @@ std::future<response::Value> Type::resolveInputFields(service::ResolverParams&& 
 	return service::ModifiedResult<InputValue>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Type::resolveOfType(service::ResolverParams&& params)
+std::future<service::ResolverResult> Type::resolveOfType(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getOfType(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -311,7 +311,7 @@ std::future<response::Value> Type::resolveOfType(service::ResolverParams&& param
 	return service::ModifiedResult<Type>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Type::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Type::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(__Type)gql" }, std::move(params));
 }
@@ -331,7 +331,7 @@ Field::Field()
 {
 }
 
-std::future<response::Value> Field::resolveName(service::ResolverParams&& params)
+std::future<service::ResolverResult> Field::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -340,7 +340,7 @@ std::future<response::Value> Field::resolveName(service::ResolverParams&& params
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Field::resolveDescription(service::ResolverParams&& params)
+std::future<service::ResolverResult> Field::resolveDescription(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDescription(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -349,7 +349,7 @@ std::future<response::Value> Field::resolveDescription(service::ResolverParams&&
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Field::resolveArgs(service::ResolverParams&& params)
+std::future<service::ResolverResult> Field::resolveArgs(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getArgs(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -358,7 +358,7 @@ std::future<response::Value> Field::resolveArgs(service::ResolverParams&& params
 	return service::ModifiedResult<InputValue>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Field::resolveType(service::ResolverParams&& params)
+std::future<service::ResolverResult> Field::resolveType(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getType(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -367,7 +367,7 @@ std::future<response::Value> Field::resolveType(service::ResolverParams&& params
 	return service::ModifiedResult<Type>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Field::resolveIsDeprecated(service::ResolverParams&& params)
+std::future<service::ResolverResult> Field::resolveIsDeprecated(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getIsDeprecated(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -376,7 +376,7 @@ std::future<response::Value> Field::resolveIsDeprecated(service::ResolverParams&
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Field::resolveDeprecationReason(service::ResolverParams&& params)
+std::future<service::ResolverResult> Field::resolveDeprecationReason(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDeprecationReason(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -385,7 +385,7 @@ std::future<response::Value> Field::resolveDeprecationReason(service::ResolverPa
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Field::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Field::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(__Field)gql" }, std::move(params));
 }
@@ -403,7 +403,7 @@ InputValue::InputValue()
 {
 }
 
-std::future<response::Value> InputValue::resolveName(service::ResolverParams&& params)
+std::future<service::ResolverResult> InputValue::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -412,7 +412,7 @@ std::future<response::Value> InputValue::resolveName(service::ResolverParams&& p
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> InputValue::resolveDescription(service::ResolverParams&& params)
+std::future<service::ResolverResult> InputValue::resolveDescription(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDescription(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -421,7 +421,7 @@ std::future<response::Value> InputValue::resolveDescription(service::ResolverPar
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> InputValue::resolveType(service::ResolverParams&& params)
+std::future<service::ResolverResult> InputValue::resolveType(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getType(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -430,7 +430,7 @@ std::future<response::Value> InputValue::resolveType(service::ResolverParams&& p
 	return service::ModifiedResult<Type>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> InputValue::resolveDefaultValue(service::ResolverParams&& params)
+std::future<service::ResolverResult> InputValue::resolveDefaultValue(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDefaultValue(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -439,7 +439,7 @@ std::future<response::Value> InputValue::resolveDefaultValue(service::ResolverPa
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> InputValue::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> InputValue::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(__InputValue)gql" }, std::move(params));
 }
@@ -457,7 +457,7 @@ EnumValue::EnumValue()
 {
 }
 
-std::future<response::Value> EnumValue::resolveName(service::ResolverParams&& params)
+std::future<service::ResolverResult> EnumValue::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -466,7 +466,7 @@ std::future<response::Value> EnumValue::resolveName(service::ResolverParams&& pa
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> EnumValue::resolveDescription(service::ResolverParams&& params)
+std::future<service::ResolverResult> EnumValue::resolveDescription(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDescription(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -475,7 +475,7 @@ std::future<response::Value> EnumValue::resolveDescription(service::ResolverPara
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> EnumValue::resolveIsDeprecated(service::ResolverParams&& params)
+std::future<service::ResolverResult> EnumValue::resolveIsDeprecated(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getIsDeprecated(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -484,7 +484,7 @@ std::future<response::Value> EnumValue::resolveIsDeprecated(service::ResolverPar
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> EnumValue::resolveDeprecationReason(service::ResolverParams&& params)
+std::future<service::ResolverResult> EnumValue::resolveDeprecationReason(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDeprecationReason(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -493,7 +493,7 @@ std::future<response::Value> EnumValue::resolveDeprecationReason(service::Resolv
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> EnumValue::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> EnumValue::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(__EnumValue)gql" }, std::move(params));
 }
@@ -511,7 +511,7 @@ Directive::Directive()
 {
 }
 
-std::future<response::Value> Directive::resolveName(service::ResolverParams&& params)
+std::future<service::ResolverResult> Directive::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -520,7 +520,7 @@ std::future<response::Value> Directive::resolveName(service::ResolverParams&& pa
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Directive::resolveDescription(service::ResolverParams&& params)
+std::future<service::ResolverResult> Directive::resolveDescription(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDescription(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -529,7 +529,7 @@ std::future<response::Value> Directive::resolveDescription(service::ResolverPara
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Directive::resolveLocations(service::ResolverParams&& params)
+std::future<service::ResolverResult> Directive::resolveLocations(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getLocations(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -538,7 +538,7 @@ std::future<response::Value> Directive::resolveLocations(service::ResolverParams
 	return service::ModifiedResult<DirectiveLocation>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Directive::resolveArgs(service::ResolverParams&& params)
+std::future<service::ResolverResult> Directive::resolveArgs(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getArgs(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -547,7 +547,7 @@ std::future<response::Value> Directive::resolveArgs(service::ResolverParams&& pa
 	return service::ModifiedResult<InputValue>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Directive::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Directive::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(__Directive)gql" }, std::move(params));
 }

--- a/samples/introspection/IntrospectionSchema.cpp
+++ b/samples/introspection/IntrospectionSchema.cpp
@@ -554,129 +554,129 @@ std::future<response::Value> Directive::resolve_typename(service::ResolverParams
 
 } /* namespace object */
 
-void AddTypesToSchema(const std::shared_ptr<introspection::Schema>& schema)
+void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 {
-	schema->AddType("Boolean", std::make_shared<introspection::ScalarType>("Boolean", R"md(Built-in type)md"));
-	schema->AddType("Float", std::make_shared<introspection::ScalarType>("Float", R"md(Built-in type)md"));
-	schema->AddType("ID", std::make_shared<introspection::ScalarType>("ID", R"md(Built-in type)md"));
-	schema->AddType("Int", std::make_shared<introspection::ScalarType>("Int", R"md(Built-in type)md"));
-	schema->AddType("String", std::make_shared<introspection::ScalarType>("String", R"md(Built-in type)md"));
-	auto typeTypeKind = std::make_shared<introspection::EnumType>("__TypeKind", R"md()md");
-	schema->AddType("__TypeKind", typeTypeKind);
-	auto typeDirectiveLocation = std::make_shared<introspection::EnumType>("__DirectiveLocation", R"md()md");
-	schema->AddType("__DirectiveLocation", typeDirectiveLocation);
-	auto typeSchema = std::make_shared<introspection::ObjectType>("__Schema", R"md()md");
-	schema->AddType("__Schema", typeSchema);
-	auto typeType = std::make_shared<introspection::ObjectType>("__Type", R"md()md");
-	schema->AddType("__Type", typeType);
-	auto typeField = std::make_shared<introspection::ObjectType>("__Field", R"md()md");
-	schema->AddType("__Field", typeField);
-	auto typeInputValue = std::make_shared<introspection::ObjectType>("__InputValue", R"md()md");
-	schema->AddType("__InputValue", typeInputValue);
-	auto typeEnumValue = std::make_shared<introspection::ObjectType>("__EnumValue", R"md()md");
-	schema->AddType("__EnumValue", typeEnumValue);
-	auto typeDirective = std::make_shared<introspection::ObjectType>("__Directive", R"md()md");
-	schema->AddType("__Directive", typeDirective);
+	schema->AddType(R"gql(Boolean)gql"sv, std::make_shared<schema::ScalarType>(R"gql(Boolean)gql"sv, R"md(Built-in type)md"));
+	schema->AddType(R"gql(Float)gql"sv, std::make_shared<schema::ScalarType>(R"gql(Float)gql"sv, R"md(Built-in type)md"));
+	schema->AddType(R"gql(ID)gql"sv, std::make_shared<schema::ScalarType>(R"gql(ID)gql"sv, R"md(Built-in type)md"));
+	schema->AddType(R"gql(Int)gql"sv, std::make_shared<schema::ScalarType>(R"gql(Int)gql"sv, R"md(Built-in type)md"));
+	schema->AddType(R"gql(String)gql"sv, std::make_shared<schema::ScalarType>(R"gql(String)gql"sv, R"md(Built-in type)md"));
+	auto typeTypeKind = std::make_shared<schema::EnumType>(R"gql(__TypeKind)gql"sv, R"md()md"sv);
+	schema->AddType(R"gql(__TypeKind)gql"sv, typeTypeKind);
+	auto typeDirectiveLocation = std::make_shared<schema::EnumType>(R"gql(__DirectiveLocation)gql"sv, R"md()md"sv);
+	schema->AddType(R"gql(__DirectiveLocation)gql"sv, typeDirectiveLocation);
+	auto typeSchema = std::make_shared<schema::ObjectType>(R"gql(__Schema)gql"sv, R"md()md");
+	schema->AddType(R"gql(__Schema)gql"sv, typeSchema);
+	auto typeType = std::make_shared<schema::ObjectType>(R"gql(__Type)gql"sv, R"md()md");
+	schema->AddType(R"gql(__Type)gql"sv, typeType);
+	auto typeField = std::make_shared<schema::ObjectType>(R"gql(__Field)gql"sv, R"md()md");
+	schema->AddType(R"gql(__Field)gql"sv, typeField);
+	auto typeInputValue = std::make_shared<schema::ObjectType>(R"gql(__InputValue)gql"sv, R"md()md");
+	schema->AddType(R"gql(__InputValue)gql"sv, typeInputValue);
+	auto typeEnumValue = std::make_shared<schema::ObjectType>(R"gql(__EnumValue)gql"sv, R"md()md");
+	schema->AddType(R"gql(__EnumValue)gql"sv, typeEnumValue);
+	auto typeDirective = std::make_shared<schema::ObjectType>(R"gql(__Directive)gql"sv, R"md()md");
+	schema->AddType(R"gql(__Directive)gql"sv, typeDirective);
 
 	typeTypeKind->AddEnumValues({
-		{ std::string{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::SCALAR)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::OBJECT)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::INTERFACE)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::UNION)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::ENUM)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::INPUT_OBJECT)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::LIST)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::NON_NULL)] }, R"md()md", std::nullopt }
+		{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::SCALAR)], R"md()md"sv, std::nullopt },
+		{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::OBJECT)], R"md()md"sv, std::nullopt },
+		{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::INTERFACE)], R"md()md"sv, std::nullopt },
+		{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::UNION)], R"md()md"sv, std::nullopt },
+		{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::ENUM)], R"md()md"sv, std::nullopt },
+		{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::INPUT_OBJECT)], R"md()md"sv, std::nullopt },
+		{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::LIST)], R"md()md"sv, std::nullopt },
+		{ service::s_namesTypeKind[static_cast<size_t>(introspection::TypeKind::NON_NULL)], R"md()md"sv, std::nullopt }
 	});
 	typeDirectiveLocation->AddEnumValues({
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::QUERY)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::MUTATION)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::SUBSCRIPTION)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::FIELD)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::FRAGMENT_DEFINITION)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::FRAGMENT_SPREAD)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::INLINE_FRAGMENT)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::SCHEMA)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::SCALAR)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::OBJECT)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::FIELD_DEFINITION)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::ARGUMENT_DEFINITION)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::INTERFACE)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::UNION)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::ENUM)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::ENUM_VALUE)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::INPUT_OBJECT)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::INPUT_FIELD_DEFINITION)] }, R"md()md", std::nullopt }
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::QUERY)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::MUTATION)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::SUBSCRIPTION)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::FIELD)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::FRAGMENT_DEFINITION)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::FRAGMENT_SPREAD)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::INLINE_FRAGMENT)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::SCHEMA)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::SCALAR)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::OBJECT)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::FIELD_DEFINITION)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::ARGUMENT_DEFINITION)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::INTERFACE)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::UNION)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::ENUM)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::ENUM_VALUE)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::INPUT_OBJECT)], R"md()md"sv, std::nullopt },
+		{ service::s_namesDirectiveLocation[static_cast<size_t>(introspection::DirectiveLocation::INPUT_FIELD_DEFINITION)], R"md()md"sv, std::nullopt }
 	});
 
 	typeSchema->AddFields({
-		std::make_shared<introspection::Field>("types", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))))),
-		std::make_shared<introspection::Field>("queryType", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))),
-		std::make_shared<introspection::Field>("mutationType", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("__Type")),
-		std::make_shared<introspection::Field>("subscriptionType", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("__Type")),
-		std::make_shared<introspection::Field>("directives", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Directive")))))
+		std::make_shared<schema::Field>(R"gql(types)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))))),
+		std::make_shared<schema::Field>(R"gql(queryType)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))),
+		std::make_shared<schema::Field>(R"gql(mutationType)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("__Type")),
+		std::make_shared<schema::Field>(R"gql(subscriptionType)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("__Type")),
+		std::make_shared<schema::Field>(R"gql(directives)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Directive")))))
 	});
 	typeType->AddFields({
-		std::make_shared<introspection::Field>("kind", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__TypeKind"))),
-		std::make_shared<introspection::Field>("name", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<introspection::Field>("description", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<introspection::Field>("fields", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("includeDeprecated", R"md()md", schema->LookupType("Boolean"), R"gql(false)gql")
+		std::make_shared<schema::Field>(R"gql(kind)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__TypeKind"))),
+		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
+		std::make_shared<schema::Field>(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
+		std::make_shared<schema::Field>(R"gql(fields)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(includeDeprecated)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(false)gql"sv)
 		}), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Field")))),
-		std::make_shared<introspection::Field>("interfaces", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type")))),
-		std::make_shared<introspection::Field>("possibleTypes", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type")))),
-		std::make_shared<introspection::Field>("enumValues", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("includeDeprecated", R"md()md", schema->LookupType("Boolean"), R"gql(false)gql")
+		std::make_shared<schema::Field>(R"gql(interfaces)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type")))),
+		std::make_shared<schema::Field>(R"gql(possibleTypes)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type")))),
+		std::make_shared<schema::Field>(R"gql(enumValues)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(includeDeprecated)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(false)gql"sv)
 		}), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__EnumValue")))),
-		std::make_shared<introspection::Field>("inputFields", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__InputValue")))),
-		std::make_shared<introspection::Field>("ofType", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("__Type"))
+		std::make_shared<schema::Field>(R"gql(inputFields)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__InputValue")))),
+		std::make_shared<schema::Field>(R"gql(ofType)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("__Type"))
 	});
 	typeField->AddFields({
-		std::make_shared<introspection::Field>("name", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<introspection::Field>("description", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<introspection::Field>("args", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__InputValue"))))),
-		std::make_shared<introspection::Field>("type", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))),
-		std::make_shared<introspection::Field>("isDeprecated", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<introspection::Field>("deprecationReason", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String"))
+		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		std::make_shared<schema::Field>(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
+		std::make_shared<schema::Field>(R"gql(args)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__InputValue"))))),
+		std::make_shared<schema::Field>(R"gql(type)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))),
+		std::make_shared<schema::Field>(R"gql(isDeprecated)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		std::make_shared<schema::Field>(R"gql(deprecationReason)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
 	});
 	typeInputValue->AddFields({
-		std::make_shared<introspection::Field>("name", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<introspection::Field>("description", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<introspection::Field>("type", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))),
-		std::make_shared<introspection::Field>("defaultValue", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String"))
+		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		std::make_shared<schema::Field>(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
+		std::make_shared<schema::Field>(R"gql(type)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__Type"))),
+		std::make_shared<schema::Field>(R"gql(defaultValue)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
 	});
 	typeEnumValue->AddFields({
-		std::make_shared<introspection::Field>("name", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<introspection::Field>("description", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<introspection::Field>("isDeprecated", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<introspection::Field>("deprecationReason", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String"))
+		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		std::make_shared<schema::Field>(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
+		std::make_shared<schema::Field>(R"gql(isDeprecated)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		std::make_shared<schema::Field>(R"gql(deprecationReason)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
 	});
 	typeDirective->AddFields({
-		std::make_shared<introspection::Field>("name", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<introspection::Field>("description", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<introspection::Field>("locations", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__DirectiveLocation"))))),
-		std::make_shared<introspection::Field>("args", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__InputValue")))))
+		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		std::make_shared<schema::Field>(R"gql(description)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
+		std::make_shared<schema::Field>(R"gql(locations)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__DirectiveLocation"))))),
+		std::make_shared<schema::Field>(R"gql(args)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("__InputValue")))))
 	});
 
-	schema->AddDirective(std::make_shared<introspection::Directive>("skip", R"md()md", std::vector<response::StringType>({
-		R"gql(FIELD)gql",
-		R"gql(FRAGMENT_SPREAD)gql",
-		R"gql(INLINE_FRAGMENT)gql"
-	}), std::vector<std::shared_ptr<introspection::InputValue>>({
-		std::make_shared<introspection::InputValue>("if", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), R"gql()gql")
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(skip)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::FIELD,
+		introspection::DirectiveLocation::FRAGMENT_SPREAD,
+		introspection::DirectiveLocation::INLINE_FRAGMENT
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(if)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), R"gql()gql"sv)
 	})));
-	schema->AddDirective(std::make_shared<introspection::Directive>("include", R"md()md", std::vector<response::StringType>({
-		R"gql(FIELD)gql",
-		R"gql(FRAGMENT_SPREAD)gql",
-		R"gql(INLINE_FRAGMENT)gql"
-	}), std::vector<std::shared_ptr<introspection::InputValue>>({
-		std::make_shared<introspection::InputValue>("if", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), R"gql()gql")
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(include)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::FIELD,
+		introspection::DirectiveLocation::FRAGMENT_SPREAD,
+		introspection::DirectiveLocation::INLINE_FRAGMENT
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(if)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), R"gql()gql"sv)
 	})));
-	schema->AddDirective(std::make_shared<introspection::Directive>("deprecated", R"md()md", std::vector<response::StringType>({
-		R"gql(FIELD_DEFINITION)gql",
-		R"gql(ENUM_VALUE)gql"
-	}), std::vector<std::shared_ptr<introspection::InputValue>>({
-		std::make_shared<introspection::InputValue>("reason", R"md()md", schema->LookupType("String"), R"gql("No longer supported")gql")
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(deprecated)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::FIELD_DEFINITION,
+		introspection::DirectiveLocation::ENUM_VALUE
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(reason)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql("No longer supported")gql"sv)
 	})));
 }
 

--- a/samples/introspection/IntrospectionSchema.h
+++ b/samples/introspection/IntrospectionSchema.h
@@ -9,6 +9,18 @@
 #include "graphqlservice/GraphQLSchema.h"
 #include "graphqlservice/GraphQLService.h"
 
+// clang-format off
+#ifdef GRAPHQL_DLLEXPORTS
+	#ifdef IMPL_GRAPHQLINTROSPECTION_DLL
+		#define GRAPHQLINTROSPECTION_EXPORT __declspec(dllexport)
+	#else // !IMPL_GRAPHQLINTROSPECTION_DLL
+		#define GRAPHQLINTROSPECTION_EXPORT __declspec(dllimport)
+	#endif // !IMPL_GRAPHQLINTROSPECTION_DLL
+#else // !GRAPHQL_DLLEXPORTS
+	#define GRAPHQLINTROSPECTION_EXPORT
+#endif // !GRAPHQL_DLLEXPORTS
+// clang-format on
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -203,7 +215,7 @@ private:
 
 } /* namespace object */
 
-GRAPHQLSERVICE_EXPORT void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema);
+GRAPHQLINTROSPECTION_EXPORT void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema);
 
 } /* namespace introspection */
 } /* namespace graphql */

--- a/samples/introspection/IntrospectionSchema.h
+++ b/samples/introspection/IntrospectionSchema.h
@@ -6,6 +6,7 @@
 #ifndef INTROSPECTIONSCHEMA_H
 #define INTROSPECTIONSCHEMA_H
 
+#include "graphqlservice/GraphQLSchema.h"
 #include "graphqlservice/GraphQLService.h"
 
 #include <memory>
@@ -204,7 +205,7 @@ private:
 
 } /* namespace object */
 
-GRAPHQLSERVICE_EXPORT void AddTypesToSchema(const std::shared_ptr<introspection::Schema>& schema);
+GRAPHQLSERVICE_EXPORT void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema);
 
 } /* namespace introspection */
 } /* namespace graphql */

--- a/samples/introspection/IntrospectionSchema.h
+++ b/samples/introspection/IntrospectionSchema.h
@@ -85,13 +85,13 @@ public:
 	virtual service::FieldResult<std::vector<std::shared_ptr<Directive>>> getDirectives(service::FieldParams&& params) const = 0;
 
 private:
-	std::future<response::Value> resolveTypes(service::ResolverParams&& params);
-	std::future<response::Value> resolveQueryType(service::ResolverParams&& params);
-	std::future<response::Value> resolveMutationType(service::ResolverParams&& params);
-	std::future<response::Value> resolveSubscriptionType(service::ResolverParams&& params);
-	std::future<response::Value> resolveDirectives(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTypes(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveQueryType(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveMutationType(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveSubscriptionType(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDirectives(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Type
@@ -112,17 +112,17 @@ public:
 	virtual service::FieldResult<std::shared_ptr<Type>> getOfType(service::FieldParams&& params) const = 0;
 
 private:
-	std::future<response::Value> resolveKind(service::ResolverParams&& params);
-	std::future<response::Value> resolveName(service::ResolverParams&& params);
-	std::future<response::Value> resolveDescription(service::ResolverParams&& params);
-	std::future<response::Value> resolveFields(service::ResolverParams&& params);
-	std::future<response::Value> resolveInterfaces(service::ResolverParams&& params);
-	std::future<response::Value> resolvePossibleTypes(service::ResolverParams&& params);
-	std::future<response::Value> resolveEnumValues(service::ResolverParams&& params);
-	std::future<response::Value> resolveInputFields(service::ResolverParams&& params);
-	std::future<response::Value> resolveOfType(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveKind(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveName(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDescription(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveFields(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveInterfaces(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePossibleTypes(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveEnumValues(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveInputFields(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveOfType(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Field
@@ -140,14 +140,14 @@ public:
 	virtual service::FieldResult<std::optional<response::StringType>> getDeprecationReason(service::FieldParams&& params) const = 0;
 
 private:
-	std::future<response::Value> resolveName(service::ResolverParams&& params);
-	std::future<response::Value> resolveDescription(service::ResolverParams&& params);
-	std::future<response::Value> resolveArgs(service::ResolverParams&& params);
-	std::future<response::Value> resolveType(service::ResolverParams&& params);
-	std::future<response::Value> resolveIsDeprecated(service::ResolverParams&& params);
-	std::future<response::Value> resolveDeprecationReason(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveName(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDescription(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveArgs(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveType(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveIsDeprecated(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDeprecationReason(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class InputValue
@@ -163,12 +163,12 @@ public:
 	virtual service::FieldResult<std::optional<response::StringType>> getDefaultValue(service::FieldParams&& params) const = 0;
 
 private:
-	std::future<response::Value> resolveName(service::ResolverParams&& params);
-	std::future<response::Value> resolveDescription(service::ResolverParams&& params);
-	std::future<response::Value> resolveType(service::ResolverParams&& params);
-	std::future<response::Value> resolveDefaultValue(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveName(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDescription(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveType(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDefaultValue(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class EnumValue
@@ -184,12 +184,12 @@ public:
 	virtual service::FieldResult<std::optional<response::StringType>> getDeprecationReason(service::FieldParams&& params) const = 0;
 
 private:
-	std::future<response::Value> resolveName(service::ResolverParams&& params);
-	std::future<response::Value> resolveDescription(service::ResolverParams&& params);
-	std::future<response::Value> resolveIsDeprecated(service::ResolverParams&& params);
-	std::future<response::Value> resolveDeprecationReason(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveName(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDescription(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveIsDeprecated(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDeprecationReason(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Directive
@@ -205,12 +205,12 @@ public:
 	virtual service::FieldResult<std::vector<std::shared_ptr<InputValue>>> getArgs(service::FieldParams&& params) const = 0;
 
 private:
-	std::future<response::Value> resolveName(service::ResolverParams&& params);
-	std::future<response::Value> resolveDescription(service::ResolverParams&& params);
-	std::future<response::Value> resolveLocations(service::ResolverParams&& params);
-	std::future<response::Value> resolveArgs(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveName(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDescription(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveLocations(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveArgs(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace object */

--- a/samples/introspection/IntrospectionSchema.h
+++ b/samples/introspection/IntrospectionSchema.h
@@ -16,8 +16,6 @@
 namespace graphql {
 namespace introspection {
 
-class Schema;
-
 enum class TypeKind
 {
 	SCALAR,

--- a/samples/schema.today.graphql
+++ b/samples/schema.today.graphql
@@ -115,6 +115,7 @@ type Appointment implements Node {
     when: DateTime
     subject: String
     isNow: Boolean!
+    forceError: String
 }
 
 type Task implements Node {

--- a/samples/separate/AppointmentConnectionObject.cpp
+++ b/samples/separate/AppointmentConnectionObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/AppointmentConnectionObject.cpp
+++ b/samples/separate/AppointmentConnectionObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> AppointmentConnection::resolve_typename(ser
 void AddAppointmentConnectionDetails(std::shared_ptr<schema::ObjectType> typeAppointmentConnection, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeAppointmentConnection->AddFields({
-		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("AppointmentEdge")))
+		schema::Field::Make(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		schema::Field::Make(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("AppointmentEdge")))
 	});
 }
 

--- a/samples/separate/AppointmentConnectionObject.cpp
+++ b/samples/separate/AppointmentConnectionObject.cpp
@@ -62,11 +62,11 @@ std::future<response::Value> AppointmentConnection::resolve_typename(service::Re
 
 } /* namespace object */
 
-void AddAppointmentConnectionDetails(std::shared_ptr<introspection::ObjectType> typeAppointmentConnection, const std::shared_ptr<introspection::Schema>& schema)
+void AddAppointmentConnectionDetails(std::shared_ptr<schema::ObjectType> typeAppointmentConnection, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeAppointmentConnection->AddFields({
-		std::make_shared<introspection::Field>("pageInfo", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<introspection::Field>("edges", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("AppointmentEdge")))
+		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("AppointmentEdge")))
 	});
 }
 

--- a/samples/separate/AppointmentConnectionObject.cpp
+++ b/samples/separate/AppointmentConnectionObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<PageInfo>> AppointmentConnection::getPageIn
 	throw std::runtime_error(R"ex(AppointmentConnection::getPageInfo is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>
 	throw std::runtime_error(R"ex(AppointmentConnection::getEdges is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> AppointmentConnection::resolveEdges(service::Resolv
 	return service::ModifiedResult<AppointmentEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> AppointmentConnection::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentConnection::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(AppointmentConnection)gql" }, std::move(params));
 }

--- a/samples/separate/AppointmentConnectionObject.h
+++ b/samples/separate/AppointmentConnectionObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePageInfo(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveEdges(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/AppointmentEdgeObject.cpp
+++ b/samples/separate/AppointmentEdgeObject.cpp
@@ -62,11 +62,11 @@ std::future<response::Value> AppointmentEdge::resolve_typename(service::Resolver
 
 } /* namespace object */
 
-void AddAppointmentEdgeDetails(std::shared_ptr<introspection::ObjectType> typeAppointmentEdge, const std::shared_ptr<introspection::Schema>& schema)
+void AddAppointmentEdgeDetails(std::shared_ptr<schema::ObjectType> typeAppointmentEdge, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeAppointmentEdge->AddFields({
-		std::make_shared<introspection::Field>("node", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("Appointment")),
-		std::make_shared<introspection::Field>("cursor", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Appointment")),
+		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 }
 

--- a/samples/separate/AppointmentEdgeObject.cpp
+++ b/samples/separate/AppointmentEdgeObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/AppointmentEdgeObject.cpp
+++ b/samples/separate/AppointmentEdgeObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> AppointmentEdge::resolve_typename(service::
 void AddAppointmentEdgeDetails(std::shared_ptr<schema::ObjectType> typeAppointmentEdge, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeAppointmentEdge->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Appointment")),
-		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Appointment")),
+		schema::Field::Make(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 }
 

--- a/samples/separate/AppointmentEdgeObject.cpp
+++ b/samples/separate/AppointmentEdgeObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<Appointment>> AppointmentEdge::getNode(serv
 	throw std::runtime_error(R"ex(AppointmentEdge::getNode is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentEdge::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<response::Value> AppointmentEdge::getCursor(service::FieldP
 	throw std::runtime_error(R"ex(AppointmentEdge::getCursor is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> AppointmentEdge::resolveCursor(service::ResolverPar
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> AppointmentEdge::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentEdge::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(AppointmentEdge)gql" }, std::move(params));
 }

--- a/samples/separate/AppointmentEdgeObject.h
+++ b/samples/separate/AppointmentEdgeObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCursor(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/AppointmentObject.cpp
+++ b/samples/separate/AppointmentObject.cpp
@@ -94,16 +94,16 @@ std::future<response::Value> Appointment::resolve_typename(service::ResolverPara
 
 } /* namespace object */
 
-void AddAppointmentDetails(std::shared_ptr<introspection::ObjectType> typeAppointment, const std::shared_ptr<introspection::Schema>& schema)
+void AddAppointmentDetails(std::shared_ptr<schema::ObjectType> typeAppointment, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeAppointment->AddInterfaces({
-		std::static_pointer_cast<introspection::InterfaceType>(schema->LookupType("Node"))
+		std::static_pointer_cast<schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
 	});
 	typeAppointment->AddFields({
-		std::make_shared<introspection::Field>("id", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<introspection::Field>("when", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("DateTime")),
-		std::make_shared<introspection::Field>("subject", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<introspection::Field>("isNow", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		std::make_shared<schema::Field>(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("DateTime")),
+		std::make_shared<schema::Field>(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
+		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
 	});
 }
 

--- a/samples/separate/AppointmentObject.cpp
+++ b/samples/separate/AppointmentObject.cpp
@@ -112,14 +112,14 @@ std::future<service::ResolverResult> Appointment::resolve_typename(service::Reso
 void AddAppointmentDetails(std::shared_ptr<schema::ObjectType> typeAppointment, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeAppointment->AddInterfaces({
-		std::static_pointer_cast<schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
+		std::static_pointer_cast<const schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
 	});
 	typeAppointment->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<schema::Field>(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("DateTime")),
-		std::make_shared<schema::Field>(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(forceError)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		schema::Field::Make(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("DateTime")),
+		schema::Field::Make(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		schema::Field::Make(R"gql(forceError)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String"))
 	});
 }
 

--- a/samples/separate/AppointmentObject.cpp
+++ b/samples/separate/AppointmentObject.cpp
@@ -23,6 +23,7 @@ Appointment::Appointment()
 		"Appointment"
 	}, {
 		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(forceError)gql"sv, [this](service::ResolverParams&& params) { return resolveForceError(std::move(params)); } },
 		{ R"gql(id)gql"sv, [this](service::ResolverParams&& params) { return resolveId(std::move(params)); } },
 		{ R"gql(isNow)gql"sv, [this](service::ResolverParams&& params) { return resolveIsNow(std::move(params)); } },
 		{ R"gql(subject)gql"sv, [this](service::ResolverParams&& params) { return resolveSubject(std::move(params)); } },
@@ -87,6 +88,20 @@ std::future<response::Value> Appointment::resolveIsNow(service::ResolverParams&&
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
+service::FieldResult<std::optional<response::StringType>> Appointment::getForceError(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Appointment::getForceError is not implemented)ex");
+}
+
+std::future<response::Value> Appointment::resolveForceError(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getForceError(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
 std::future<response::Value> Appointment::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Appointment)gql" }, std::move(params));
@@ -103,7 +118,8 @@ void AddAppointmentDetails(std::shared_ptr<schema::ObjectType> typeAppointment, 
 		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
 		std::make_shared<schema::Field>(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("DateTime")),
 		std::make_shared<schema::Field>(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		std::make_shared<schema::Field>(R"gql(forceError)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
 	});
 }
 

--- a/samples/separate/AppointmentObject.cpp
+++ b/samples/separate/AppointmentObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/AppointmentObject.cpp
+++ b/samples/separate/AppointmentObject.cpp
@@ -37,7 +37,7 @@ service::FieldResult<response::IdType> Appointment::getId(service::FieldParams&&
 	throw std::runtime_error(R"ex(Appointment::getId is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveId(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -51,7 +51,7 @@ service::FieldResult<std::optional<response::Value>> Appointment::getWhen(servic
 	throw std::runtime_error(R"ex(Appointment::getWhen is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveWhen(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveWhen(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getWhen(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -65,7 +65,7 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getSubjec
 	throw std::runtime_error(R"ex(Appointment::getSubject is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveSubject(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveSubject(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getSubject(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -79,7 +79,7 @@ service::FieldResult<response::BooleanType> Appointment::getIsNow(service::Field
 	throw std::runtime_error(R"ex(Appointment::getIsNow is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveIsNow(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveIsNow(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getIsNow(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -93,7 +93,7 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getForceE
 	throw std::runtime_error(R"ex(Appointment::getForceError is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveForceError(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveForceError(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getForceError(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -102,7 +102,7 @@ std::future<response::Value> Appointment::resolveForceError(service::ResolverPar
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Appointment::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Appointment)gql" }, std::move(params));
 }

--- a/samples/separate/AppointmentObject.h
+++ b/samples/separate/AppointmentObject.h
@@ -22,12 +22,14 @@ public:
 	virtual service::FieldResult<std::optional<response::Value>> getWhen(service::FieldParams&& params) const;
 	virtual service::FieldResult<std::optional<response::StringType>> getSubject(service::FieldParams&& params) const;
 	virtual service::FieldResult<response::BooleanType> getIsNow(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<response::StringType>> getForceError(service::FieldParams&& params) const;
 
 private:
 	std::future<response::Value> resolveId(service::ResolverParams&& params);
 	std::future<response::Value> resolveWhen(service::ResolverParams&& params);
 	std::future<response::Value> resolveSubject(service::ResolverParams&& params);
 	std::future<response::Value> resolveIsNow(service::ResolverParams&& params);
+	std::future<response::Value> resolveForceError(service::ResolverParams&& params);
 
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };

--- a/samples/separate/AppointmentObject.h
+++ b/samples/separate/AppointmentObject.h
@@ -25,13 +25,13 @@ public:
 	virtual service::FieldResult<std::optional<response::StringType>> getForceError(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveId(service::ResolverParams&& params);
-	std::future<response::Value> resolveWhen(service::ResolverParams&& params);
-	std::future<response::Value> resolveSubject(service::ResolverParams&& params);
-	std::future<response::Value> resolveIsNow(service::ResolverParams&& params);
-	std::future<response::Value> resolveForceError(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveWhen(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveSubject(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveIsNow(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveForceError(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/CompleteTaskPayloadObject.cpp
+++ b/samples/separate/CompleteTaskPayloadObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<Task>> CompleteTaskPayload::getTask(service
 	throw std::runtime_error(R"ex(CompleteTaskPayload::getTask is not implemented)ex");
 }
 
-std::future<response::Value> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
+std::future<service::ResolverResult> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getTask(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<std::optional<response::StringType>> CompleteTaskPayload::g
 	throw std::runtime_error(R"ex(CompleteTaskPayload::getClientMutationId is not implemented)ex");
 }
 
-std::future<response::Value> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
+std::future<service::ResolverResult> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getClientMutationId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> CompleteTaskPayload::resolveClientMutationId(servic
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> CompleteTaskPayload::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> CompleteTaskPayload::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(CompleteTaskPayload)gql" }, std::move(params));
 }

--- a/samples/separate/CompleteTaskPayloadObject.cpp
+++ b/samples/separate/CompleteTaskPayloadObject.cpp
@@ -62,11 +62,11 @@ std::future<response::Value> CompleteTaskPayload::resolve_typename(service::Reso
 
 } /* namespace object */
 
-void AddCompleteTaskPayloadDetails(std::shared_ptr<introspection::ObjectType> typeCompleteTaskPayload, const std::shared_ptr<introspection::Schema>& schema)
+void AddCompleteTaskPayloadDetails(std::shared_ptr<schema::ObjectType> typeCompleteTaskPayload, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeCompleteTaskPayload->AddFields({
-		std::make_shared<introspection::Field>("task", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("Task")),
-		std::make_shared<introspection::Field>("clientMutationId", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String"))
+		std::make_shared<schema::Field>(R"gql(task)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Task")),
+		std::make_shared<schema::Field>(R"gql(clientMutationId)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
 	});
 }
 

--- a/samples/separate/CompleteTaskPayloadObject.cpp
+++ b/samples/separate/CompleteTaskPayloadObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> CompleteTaskPayload::resolve_typename(servi
 void AddCompleteTaskPayloadDetails(std::shared_ptr<schema::ObjectType> typeCompleteTaskPayload, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeCompleteTaskPayload->AddFields({
-		std::make_shared<schema::Field>(R"gql(task)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Task")),
-		std::make_shared<schema::Field>(R"gql(clientMutationId)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
+		schema::Field::Make(R"gql(task)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Task")),
+		schema::Field::Make(R"gql(clientMutationId)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String"))
 	});
 }
 

--- a/samples/separate/CompleteTaskPayloadObject.cpp
+++ b/samples/separate/CompleteTaskPayloadObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/CompleteTaskPayloadObject.h
+++ b/samples/separate/CompleteTaskPayloadObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<std::optional<response::StringType>> getClientMutationId(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveTask(service::ResolverParams&& params);
-	std::future<response::Value> resolveClientMutationId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTask(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveClientMutationId(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/ExpensiveObject.cpp
+++ b/samples/separate/ExpensiveObject.cpp
@@ -50,7 +50,7 @@ std::future<service::ResolverResult> Expensive::resolve_typename(service::Resolv
 void AddExpensiveDetails(std::shared_ptr<schema::ObjectType> typeExpensive, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeExpensive->AddFields({
-		std::make_shared<schema::Field>(R"gql(order)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
+		schema::Field::Make(R"gql(order)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
 	});
 }
 

--- a/samples/separate/ExpensiveObject.cpp
+++ b/samples/separate/ExpensiveObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/ExpensiveObject.cpp
+++ b/samples/separate/ExpensiveObject.cpp
@@ -47,10 +47,10 @@ std::future<response::Value> Expensive::resolve_typename(service::ResolverParams
 
 } /* namespace object */
 
-void AddExpensiveDetails(std::shared_ptr<introspection::ObjectType> typeExpensive, const std::shared_ptr<introspection::Schema>& schema)
+void AddExpensiveDetails(std::shared_ptr<schema::ObjectType> typeExpensive, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeExpensive->AddFields({
-		std::make_shared<introspection::Field>("order", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
+		std::make_shared<schema::Field>(R"gql(order)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
 	});
 }
 

--- a/samples/separate/ExpensiveObject.cpp
+++ b/samples/separate/ExpensiveObject.cpp
@@ -31,7 +31,7 @@ service::FieldResult<response::IntType> Expensive::getOrder(service::FieldParams
 	throw std::runtime_error(R"ex(Expensive::getOrder is not implemented)ex");
 }
 
-std::future<response::Value> Expensive::resolveOrder(service::ResolverParams&& params)
+std::future<service::ResolverResult> Expensive::resolveOrder(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getOrder(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -40,7 +40,7 @@ std::future<response::Value> Expensive::resolveOrder(service::ResolverParams&& p
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Expensive::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Expensive::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Expensive)gql" }, std::move(params));
 }

--- a/samples/separate/ExpensiveObject.h
+++ b/samples/separate/ExpensiveObject.h
@@ -20,9 +20,9 @@ public:
 	virtual service::FieldResult<response::IntType> getOrder(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveOrder(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveOrder(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/FolderConnectionObject.cpp
+++ b/samples/separate/FolderConnectionObject.cpp
@@ -62,11 +62,11 @@ std::future<response::Value> FolderConnection::resolve_typename(service::Resolve
 
 } /* namespace object */
 
-void AddFolderConnectionDetails(std::shared_ptr<introspection::ObjectType> typeFolderConnection, const std::shared_ptr<introspection::Schema>& schema)
+void AddFolderConnectionDetails(std::shared_ptr<schema::ObjectType> typeFolderConnection, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeFolderConnection->AddFields({
-		std::make_shared<introspection::Field>("pageInfo", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<introspection::Field>("edges", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("FolderEdge")))
+		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("FolderEdge")))
 	});
 }
 

--- a/samples/separate/FolderConnectionObject.cpp
+++ b/samples/separate/FolderConnectionObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> FolderConnection::resolve_typename(service:
 void AddFolderConnectionDetails(std::shared_ptr<schema::ObjectType> typeFolderConnection, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeFolderConnection->AddFields({
-		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("FolderEdge")))
+		schema::Field::Make(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		schema::Field::Make(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("FolderEdge")))
 	});
 }
 

--- a/samples/separate/FolderConnectionObject.cpp
+++ b/samples/separate/FolderConnectionObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/FolderConnectionObject.cpp
+++ b/samples/separate/FolderConnectionObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<PageInfo>> FolderConnection::getPageInfo(se
 	throw std::runtime_error(R"ex(FolderConnection::getPageInfo is not implemented)ex");
 }
 
-std::future<response::Value> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> Fo
 	throw std::runtime_error(R"ex(FolderConnection::getEdges is not implemented)ex");
 }
 
-std::future<response::Value> FolderConnection::resolveEdges(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> FolderConnection::resolveEdges(service::ResolverPar
 	return service::ModifiedResult<FolderEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> FolderConnection::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderConnection::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(FolderConnection)gql" }, std::move(params));
 }

--- a/samples/separate/FolderConnectionObject.h
+++ b/samples/separate/FolderConnectionObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePageInfo(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveEdges(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/FolderEdgeObject.cpp
+++ b/samples/separate/FolderEdgeObject.cpp
@@ -62,11 +62,11 @@ std::future<response::Value> FolderEdge::resolve_typename(service::ResolverParam
 
 } /* namespace object */
 
-void AddFolderEdgeDetails(std::shared_ptr<introspection::ObjectType> typeFolderEdge, const std::shared_ptr<introspection::Schema>& schema)
+void AddFolderEdgeDetails(std::shared_ptr<schema::ObjectType> typeFolderEdge, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeFolderEdge->AddFields({
-		std::make_shared<introspection::Field>("node", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("Folder")),
-		std::make_shared<introspection::Field>("cursor", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Folder")),
+		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 }
 

--- a/samples/separate/FolderEdgeObject.cpp
+++ b/samples/separate/FolderEdgeObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/FolderEdgeObject.cpp
+++ b/samples/separate/FolderEdgeObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<Folder>> FolderEdge::getNode(service::Field
 	throw std::runtime_error(R"ex(FolderEdge::getNode is not implemented)ex");
 }
 
-std::future<response::Value> FolderEdge::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<response::Value> FolderEdge::getCursor(service::FieldParams
 	throw std::runtime_error(R"ex(FolderEdge::getCursor is not implemented)ex");
 }
 
-std::future<response::Value> FolderEdge::resolveCursor(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> FolderEdge::resolveCursor(service::ResolverParams&&
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> FolderEdge::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderEdge::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(FolderEdge)gql" }, std::move(params));
 }

--- a/samples/separate/FolderEdgeObject.cpp
+++ b/samples/separate/FolderEdgeObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> FolderEdge::resolve_typename(service::Resol
 void AddFolderEdgeDetails(std::shared_ptr<schema::ObjectType> typeFolderEdge, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeFolderEdge->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Folder")),
-		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Folder")),
+		schema::Field::Make(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 }
 

--- a/samples/separate/FolderEdgeObject.h
+++ b/samples/separate/FolderEdgeObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCursor(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/FolderObject.cpp
+++ b/samples/separate/FolderObject.cpp
@@ -82,12 +82,12 @@ std::future<service::ResolverResult> Folder::resolve_typename(service::ResolverP
 void AddFolderDetails(std::shared_ptr<schema::ObjectType> typeFolder, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeFolder->AddInterfaces({
-		std::static_pointer_cast<schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
+		std::static_pointer_cast<const schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
 	});
 	typeFolder->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(unreadCount)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(unreadCount)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
 	});
 }
 

--- a/samples/separate/FolderObject.cpp
+++ b/samples/separate/FolderObject.cpp
@@ -79,15 +79,15 @@ std::future<response::Value> Folder::resolve_typename(service::ResolverParams&& 
 
 } /* namespace object */
 
-void AddFolderDetails(std::shared_ptr<introspection::ObjectType> typeFolder, const std::shared_ptr<introspection::Schema>& schema)
+void AddFolderDetails(std::shared_ptr<schema::ObjectType> typeFolder, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeFolder->AddInterfaces({
-		std::static_pointer_cast<introspection::InterfaceType>(schema->LookupType("Node"))
+		std::static_pointer_cast<schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
 	});
 	typeFolder->AddFields({
-		std::make_shared<introspection::Field>("id", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<introspection::Field>("name", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<introspection::Field>("unreadCount", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
+		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
+		std::make_shared<schema::Field>(R"gql(unreadCount)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
 	});
 }
 

--- a/samples/separate/FolderObject.cpp
+++ b/samples/separate/FolderObject.cpp
@@ -35,7 +35,7 @@ service::FieldResult<response::IdType> Folder::getId(service::FieldParams&&) con
 	throw std::runtime_error(R"ex(Folder::getId is not implemented)ex");
 }
 
-std::future<response::Value> Folder::resolveId(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -49,7 +49,7 @@ service::FieldResult<std::optional<response::StringType>> Folder::getName(servic
 	throw std::runtime_error(R"ex(Folder::getName is not implemented)ex");
 }
 
-std::future<response::Value> Folder::resolveName(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -63,7 +63,7 @@ service::FieldResult<response::IntType> Folder::getUnreadCount(service::FieldPar
 	throw std::runtime_error(R"ex(Folder::getUnreadCount is not implemented)ex");
 }
 
-std::future<response::Value> Folder::resolveUnreadCount(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolveUnreadCount(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getUnreadCount(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -72,7 +72,7 @@ std::future<response::Value> Folder::resolveUnreadCount(service::ResolverParams&
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Folder::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Folder)gql" }, std::move(params));
 }

--- a/samples/separate/FolderObject.cpp
+++ b/samples/separate/FolderObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/FolderObject.h
+++ b/samples/separate/FolderObject.h
@@ -23,11 +23,11 @@ public:
 	virtual service::FieldResult<response::IntType> getUnreadCount(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveId(service::ResolverParams&& params);
-	std::future<response::Value> resolveName(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnreadCount(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveName(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnreadCount(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/MutationObject.cpp
+++ b/samples/separate/MutationObject.cpp
@@ -67,12 +67,12 @@ std::future<service::ResolverResult> Mutation::resolve_typename(service::Resolve
 void AddMutationDetails(std::shared_ptr<schema::ObjectType> typeMutation, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeMutation->AddFields({
-		std::make_shared<schema::Field>(R"gql(completeTask)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(input)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskInput")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskPayload"))),
-		std::make_shared<schema::Field>(R"gql(setFloat)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(value)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")))
+		schema::Field::Make(R"gql(completeTask)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskPayload")), {
+			schema::InputValue::Make(R"gql(input)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskInput")), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(setFloat)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), {
+			schema::InputValue::Make(R"gql(value)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), R"gql()gql"sv)
+		})
 	});
 }
 

--- a/samples/separate/MutationObject.cpp
+++ b/samples/separate/MutationObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<CompleteTaskPayload>> Mutation::applyComple
 	throw std::runtime_error(R"ex(Mutation::applyCompleteTask is not implemented)ex");
 }
 
-std::future<response::Value> Mutation::resolveCompleteTask(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolveCompleteTask(service::ResolverParams&& params)
 {
 	auto argInput = service::ModifiedArgument<today::CompleteTaskInput>::require("input", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -47,7 +47,7 @@ service::FieldResult<response::FloatType> Mutation::applySetFloat(service::Field
 	throw std::runtime_error(R"ex(Mutation::applySetFloat is not implemented)ex");
 }
 
-std::future<response::Value> Mutation::resolveSetFloat(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolveSetFloat(service::ResolverParams&& params)
 {
 	auto argValue = service::ModifiedArgument<response::FloatType>::require("value", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -57,7 +57,7 @@ std::future<response::Value> Mutation::resolveSetFloat(service::ResolverParams&&
 	return service::ModifiedResult<response::FloatType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Mutation::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Mutation)gql" }, std::move(params));
 }

--- a/samples/separate/MutationObject.cpp
+++ b/samples/separate/MutationObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/MutationObject.cpp
+++ b/samples/separate/MutationObject.cpp
@@ -64,14 +64,14 @@ std::future<response::Value> Mutation::resolve_typename(service::ResolverParams&
 
 } /* namespace object */
 
-void AddMutationDetails(std::shared_ptr<introspection::ObjectType> typeMutation, const std::shared_ptr<introspection::Schema>& schema)
+void AddMutationDetails(std::shared_ptr<schema::ObjectType> typeMutation, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeMutation->AddFields({
-		std::make_shared<introspection::Field>("completeTask", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("input", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskInput")), R"gql()gql")
+		std::make_shared<schema::Field>(R"gql(completeTask)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(input)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskInput")), R"gql()gql"sv)
 		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskPayload"))),
-		std::make_shared<introspection::Field>("setFloat", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("value", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), R"gql()gql")
+		std::make_shared<schema::Field>(R"gql(setFloat)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(value)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), R"gql()gql"sv)
 		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")))
 	});
 }

--- a/samples/separate/MutationObject.h
+++ b/samples/separate/MutationObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<response::FloatType> applySetFloat(service::FieldParams&& params, response::FloatType&& valueArg) const;
 
 private:
-	std::future<response::Value> resolveCompleteTask(service::ResolverParams&& params);
-	std::future<response::Value> resolveSetFloat(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCompleteTask(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveSetFloat(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/NestedTypeObject.cpp
+++ b/samples/separate/NestedTypeObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> NestedType::resolve_typename(service::Resol
 void AddNestedTypeDetails(std::shared_ptr<schema::ObjectType> typeNestedType, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeNestedType->AddFields({
-		std::make_shared<schema::Field>(R"gql(depth)gql"sv, R"md(Depth of the nested element)md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
-		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md(Link to the next level)md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
+		schema::Field::Make(R"gql(depth)gql"sv, R"md(Depth of the nested element)md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
+		schema::Field::Make(R"gql(nested)gql"sv, R"md(Link to the next level)md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
 	});
 }
 

--- a/samples/separate/NestedTypeObject.cpp
+++ b/samples/separate/NestedTypeObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<response::IntType> NestedType::getDepth(service::FieldParam
 	throw std::runtime_error(R"ex(NestedType::getDepth is not implemented)ex");
 }
 
-std::future<response::Value> NestedType::resolveDepth(service::ResolverParams&& params)
+std::future<service::ResolverResult> NestedType::resolveDepth(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDepth(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<std::shared_ptr<NestedType>> NestedType::getNested(service:
 	throw std::runtime_error(R"ex(NestedType::getNested is not implemented)ex");
 }
 
-std::future<response::Value> NestedType::resolveNested(service::ResolverParams&& params)
+std::future<service::ResolverResult> NestedType::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> NestedType::resolveNested(service::ResolverParams&&
 	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> NestedType::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> NestedType::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(NestedType)gql" }, std::move(params));
 }

--- a/samples/separate/NestedTypeObject.cpp
+++ b/samples/separate/NestedTypeObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/NestedTypeObject.cpp
+++ b/samples/separate/NestedTypeObject.cpp
@@ -62,11 +62,11 @@ std::future<response::Value> NestedType::resolve_typename(service::ResolverParam
 
 } /* namespace object */
 
-void AddNestedTypeDetails(std::shared_ptr<introspection::ObjectType> typeNestedType, const std::shared_ptr<introspection::Schema>& schema)
+void AddNestedTypeDetails(std::shared_ptr<schema::ObjectType> typeNestedType, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeNestedType->AddFields({
-		std::make_shared<introspection::Field>("depth", R"md(Depth of the nested element)md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
-		std::make_shared<introspection::Field>("nested", R"md(Link to the next level)md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
+		std::make_shared<schema::Field>(R"gql(depth)gql"sv, R"md(Depth of the nested element)md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
+		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md(Link to the next level)md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
 	});
 }
 

--- a/samples/separate/NestedTypeObject.h
+++ b/samples/separate/NestedTypeObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveDepth(service::ResolverParams&& params);
-	std::future<response::Value> resolveNested(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDepth(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNested(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/PageInfoObject.cpp
+++ b/samples/separate/PageInfoObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<response::BooleanType> PageInfo::getHasNextPage(service::Fi
 	throw std::runtime_error(R"ex(PageInfo::getHasNextPage is not implemented)ex");
 }
 
-std::future<response::Value> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
+std::future<service::ResolverResult> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getHasNextPage(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<response::BooleanType> PageInfo::getHasPreviousPage(service
 	throw std::runtime_error(R"ex(PageInfo::getHasPreviousPage is not implemented)ex");
 }
 
-std::future<response::Value> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
+std::future<service::ResolverResult> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getHasPreviousPage(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> PageInfo::resolveHasPreviousPage(service::ResolverP
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> PageInfo::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> PageInfo::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(PageInfo)gql" }, std::move(params));
 }

--- a/samples/separate/PageInfoObject.cpp
+++ b/samples/separate/PageInfoObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> PageInfo::resolve_typename(service::Resolve
 void AddPageInfoDetails(std::shared_ptr<schema::ObjectType> typePageInfo, const std::shared_ptr<schema::Schema>& schema)
 {
 	typePageInfo->AddFields({
-		std::make_shared<schema::Field>(R"gql(hasNextPage)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(hasPreviousPage)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		schema::Field::Make(R"gql(hasNextPage)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		schema::Field::Make(R"gql(hasPreviousPage)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
 	});
 }
 

--- a/samples/separate/PageInfoObject.cpp
+++ b/samples/separate/PageInfoObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/PageInfoObject.cpp
+++ b/samples/separate/PageInfoObject.cpp
@@ -62,11 +62,11 @@ std::future<response::Value> PageInfo::resolve_typename(service::ResolverParams&
 
 } /* namespace object */
 
-void AddPageInfoDetails(std::shared_ptr<introspection::ObjectType> typePageInfo, const std::shared_ptr<introspection::Schema>& schema)
+void AddPageInfoDetails(std::shared_ptr<schema::ObjectType> typePageInfo, const std::shared_ptr<schema::Schema>& schema)
 {
 	typePageInfo->AddFields({
-		std::make_shared<introspection::Field>("hasNextPage", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<introspection::Field>("hasPreviousPage", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		std::make_shared<schema::Field>(R"gql(hasNextPage)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		std::make_shared<schema::Field>(R"gql(hasPreviousPage)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
 	});
 }
 

--- a/samples/separate/PageInfoObject.h
+++ b/samples/separate/PageInfoObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<response::BooleanType> getHasPreviousPage(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveHasNextPage(service::ResolverParams&& params);
-	std::future<response::Value> resolveHasPreviousPage(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveHasNextPage(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveHasPreviousPage(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/QueryObject.cpp
+++ b/samples/separate/QueryObject.cpp
@@ -34,10 +34,8 @@ Query::Query()
 		{ R"gql(unreadCounts)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCounts(std::move(params)); } },
 		{ R"gql(unreadCountsById)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCountsById(std::move(params)); } }
 	})
-	, _schema(std::make_shared<schema::Schema>())
+	, _schema(GetSchema())
 {
-	introspection::AddTypesToSchema(_schema);
-	today::AddTypesToSchema(_schema);
 }
 
 service::FieldResult<std::shared_ptr<service::Object>> Query::getNode(service::FieldParams&&, response::IdType&&) const

--- a/samples/separate/QueryObject.cpp
+++ b/samples/separate/QueryObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/QueryObject.cpp
+++ b/samples/separate/QueryObject.cpp
@@ -34,7 +34,7 @@ Query::Query()
 		{ R"gql(unreadCounts)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCounts(std::move(params)); } },
 		{ R"gql(unreadCountsById)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCountsById(std::move(params)); } }
 	})
-	, _schema(std::make_shared<introspection::Schema>())
+	, _schema(std::make_shared<schema::Schema>())
 {
 	introspection::AddTypesToSchema(_schema);
 	today::AddTypesToSchema(_schema);
@@ -225,54 +225,56 @@ std::future<response::Value> Query::resolve_typename(service::ResolverParams&& p
 
 std::future<response::Value> Query::resolve_schema(service::ResolverParams&& params)
 {
-	return service::ModifiedResult<service::Object>::convert(std::static_pointer_cast<service::Object>(_schema), std::move(params));
+	return service::ModifiedResult<service::Object>::convert(std::static_pointer_cast<service::Object>(std::make_shared<introspection::Schema>(_schema)), std::move(params));
 }
 
 std::future<response::Value> Query::resolve_type(service::ResolverParams&& params)
 {
 	auto argName = service::ModifiedArgument<response::StringType>::require("name", params.arguments);
+	const auto& baseType = _schema->LookupType(argName);
+	std::shared_ptr<introspection::object::Type> result { baseType ? std::make_shared<introspection::Type>(baseType) : nullptr };
 
-	return service::ModifiedResult<introspection::object::Type>::convert<service::TypeModifier::Nullable>(_schema->LookupType(argName), std::move(params));
+	return service::ModifiedResult<introspection::object::Type>::convert<service::TypeModifier::Nullable>(result, std::move(params));
 }
 
 } /* namespace object */
 
-void AddQueryDetails(std::shared_ptr<introspection::ObjectType> typeQuery, const std::shared_ptr<introspection::Schema>& schema)
+void AddQueryDetails(std::shared_ptr<schema::ObjectType> typeQuery, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeQuery->AddFields({
-		std::make_shared<introspection::Field>("node", R"md([Object Identification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#object-identification))md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("id", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql")
+		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md([Object Identification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#object-identification))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
 		}), schema->LookupType("Node")),
-		std::make_shared<introspection::Field>("appointments", R"md(Appointments [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("first", R"md()md", schema->LookupType("Int"), R"gql()gql"),
-			std::make_shared<introspection::InputValue>("after", R"md()md", schema->LookupType("ItemCursor"), R"gql()gql"),
-			std::make_shared<introspection::InputValue>("last", R"md()md", schema->LookupType("Int"), R"gql()gql"),
-			std::make_shared<introspection::InputValue>("before", R"md()md", schema->LookupType("ItemCursor"), R"gql()gql")
+		std::make_shared<schema::Field>(R"gql(appointments)gql"sv, R"md(Appointments [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
 		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("AppointmentConnection"))),
-		std::make_shared<introspection::Field>("tasks", R"md(Tasks [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("first", R"md()md", schema->LookupType("Int"), R"gql()gql"),
-			std::make_shared<introspection::InputValue>("after", R"md()md", schema->LookupType("ItemCursor"), R"gql()gql"),
-			std::make_shared<introspection::InputValue>("last", R"md()md", schema->LookupType("Int"), R"gql()gql"),
-			std::make_shared<introspection::InputValue>("before", R"md()md", schema->LookupType("ItemCursor"), R"gql()gql")
+		std::make_shared<schema::Field>(R"gql(tasks)gql"sv, R"md(Tasks [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
 		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("TaskConnection"))),
-		std::make_shared<introspection::Field>("unreadCounts", R"md(Folder unread counts [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("first", R"md()md", schema->LookupType("Int"), R"gql()gql"),
-			std::make_shared<introspection::InputValue>("after", R"md()md", schema->LookupType("ItemCursor"), R"gql()gql"),
-			std::make_shared<introspection::InputValue>("last", R"md()md", schema->LookupType("Int"), R"gql()gql"),
-			std::make_shared<introspection::InputValue>("before", R"md()md", schema->LookupType("ItemCursor"), R"gql()gql")
+		std::make_shared<schema::Field>(R"gql(unreadCounts)gql"sv, R"md(Folder unread counts [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
 		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("FolderConnection"))),
-		std::make_shared<introspection::Field>("appointmentsById", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("ids", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql(["ZmFrZUFwcG9pbnRtZW50SWQ="])gql")
+		std::make_shared<schema::Field>(R"gql(appointmentsById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql(["ZmFrZUFwcG9pbnRtZW50SWQ="])gql"sv)
 		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Appointment")))),
-		std::make_shared<introspection::Field>("tasksById", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("ids", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql")
+		std::make_shared<schema::Field>(R"gql(tasksById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
 		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Task")))),
-		std::make_shared<introspection::Field>("unreadCountsById", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("ids", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql")
+		std::make_shared<schema::Field>(R"gql(unreadCountsById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
 		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Folder")))),
-		std::make_shared<introspection::Field>("nested", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType"))),
-		std::make_shared<introspection::Field>("unimplemented", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<introspection::Field>("expensive", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Expensive")))))
+		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType"))),
+		std::make_shared<schema::Field>(R"gql(unimplemented)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		std::make_shared<schema::Field>(R"gql(expensive)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Expensive")))))
 	});
 }
 

--- a/samples/separate/QueryObject.cpp
+++ b/samples/separate/QueryObject.cpp
@@ -43,7 +43,7 @@ service::FieldResult<std::shared_ptr<service::Object>> Query::getNode(service::F
 	throw std::runtime_error(R"ex(Query::getNode is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveNode(service::ResolverParams&& params)
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -58,7 +58,7 @@ service::FieldResult<std::shared_ptr<AppointmentConnection>> Query::getAppointme
 	throw std::runtime_error(R"ex(Query::getAppointments is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveAppointments(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveAppointments(service::ResolverParams&& params)
 {
 	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
@@ -76,7 +76,7 @@ service::FieldResult<std::shared_ptr<TaskConnection>> Query::getTasks(service::F
 	throw std::runtime_error(R"ex(Query::getTasks is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveTasks(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveTasks(service::ResolverParams&& params)
 {
 	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
@@ -94,7 +94,7 @@ service::FieldResult<std::shared_ptr<FolderConnection>> Query::getUnreadCounts(s
 	throw std::runtime_error(R"ex(Query::getUnreadCounts is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveUnreadCounts(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveUnreadCounts(service::ResolverParams&& params)
 {
 	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
@@ -112,7 +112,7 @@ service::FieldResult<std::vector<std::shared_ptr<Appointment>>> Query::getAppoin
 	throw std::runtime_error(R"ex(Query::getAppointmentsById is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveAppointmentsById(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveAppointmentsById(service::ResolverParams&& params)
 {
 	const auto defaultArguments = []()
 	{
@@ -149,7 +149,7 @@ service::FieldResult<std::vector<std::shared_ptr<Task>>> Query::getTasksById(ser
 	throw std::runtime_error(R"ex(Query::getTasksById is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveTasksById(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveTasksById(service::ResolverParams&& params)
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -164,7 +164,7 @@ service::FieldResult<std::vector<std::shared_ptr<Folder>>> Query::getUnreadCount
 	throw std::runtime_error(R"ex(Query::getUnreadCountsById is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveUnreadCountsById(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveUnreadCountsById(service::ResolverParams&& params)
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -179,7 +179,7 @@ service::FieldResult<std::shared_ptr<NestedType>> Query::getNested(service::Fiel
 	throw std::runtime_error(R"ex(Query::getNested is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveNested(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -193,7 +193,7 @@ service::FieldResult<response::StringType> Query::getUnimplemented(service::Fiel
 	throw std::runtime_error(R"ex(Query::getUnimplemented is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveUnimplemented(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveUnimplemented(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getUnimplemented(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -207,7 +207,7 @@ service::FieldResult<std::vector<std::shared_ptr<Expensive>>> Query::getExpensiv
 	throw std::runtime_error(R"ex(Query::getExpensive is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveExpensive(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveExpensive(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getExpensive(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -216,17 +216,17 @@ std::future<response::Value> Query::resolveExpensive(service::ResolverParams&& p
 	return service::ModifiedResult<Expensive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Query::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Query)gql" }, std::move(params));
 }
 
-std::future<response::Value> Query::resolve_schema(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolve_schema(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<service::Object>::convert(std::static_pointer_cast<service::Object>(std::make_shared<introspection::Schema>(_schema)), std::move(params));
 }
 
-std::future<response::Value> Query::resolve_type(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolve_type(service::ResolverParams&& params)
 {
 	auto argName = service::ModifiedArgument<response::StringType>::require("name", params.arguments);
 	const auto& baseType = _schema->LookupType(argName);

--- a/samples/separate/QueryObject.cpp
+++ b/samples/separate/QueryObject.cpp
@@ -240,39 +240,39 @@ std::future<service::ResolverResult> Query::resolve_type(service::ResolverParams
 void AddQueryDetails(std::shared_ptr<schema::ObjectType> typeQuery, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeQuery->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md([Object Identification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#object-identification))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
-		}), schema->LookupType("Node")),
-		std::make_shared<schema::Field>(R"gql(appointments)gql"sv, R"md(Appointments [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("AppointmentConnection"))),
-		std::make_shared<schema::Field>(R"gql(tasks)gql"sv, R"md(Tasks [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("TaskConnection"))),
-		std::make_shared<schema::Field>(R"gql(unreadCounts)gql"sv, R"md(Folder unread counts [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("FolderConnection"))),
-		std::make_shared<schema::Field>(R"gql(appointmentsById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql(["ZmFrZUFwcG9pbnRtZW50SWQ="])gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Appointment")))),
-		std::make_shared<schema::Field>(R"gql(tasksById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Task")))),
-		std::make_shared<schema::Field>(R"gql(unreadCountsById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Folder")))),
-		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType"))),
-		std::make_shared<schema::Field>(R"gql(unimplemented)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<schema::Field>(R"gql(expensive)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Expensive")))))
+		schema::Field::Make(R"gql(node)gql"sv, R"md([Object Identification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#object-identification))md"sv, std::nullopt, schema->LookupType("Node"), {
+			schema::InputValue::Make(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(appointments)gql"sv, R"md(Appointments [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("AppointmentConnection")), {
+			schema::InputValue::Make(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(tasks)gql"sv, R"md(Tasks [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("TaskConnection")), {
+			schema::InputValue::Make(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(unreadCounts)gql"sv, R"md(Folder unread counts [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("FolderConnection")), {
+			schema::InputValue::Make(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(appointmentsById)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Appointment"))), {
+			schema::InputValue::Make(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql(["ZmFrZUFwcG9pbnRtZW50SWQ="])gql"sv)
+		}),
+		schema::Field::Make(R"gql(tasksById)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Task"))), {
+			schema::InputValue::Make(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(unreadCountsById)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Folder"))), {
+			schema::InputValue::Make(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType"))),
+		schema::Field::Make(R"gql(unimplemented)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		schema::Field::Make(R"gql(expensive)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Expensive")))))
 	});
 }
 

--- a/samples/separate/QueryObject.h
+++ b/samples/separate/QueryObject.h
@@ -29,20 +29,20 @@ public:
 	virtual service::FieldResult<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveAppointments(service::ResolverParams&& params);
-	std::future<response::Value> resolveTasks(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnreadCounts(service::ResolverParams&& params);
-	std::future<response::Value> resolveAppointmentsById(service::ResolverParams&& params);
-	std::future<response::Value> resolveTasksById(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnreadCountsById(service::ResolverParams&& params);
-	std::future<response::Value> resolveNested(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnimplemented(service::ResolverParams&& params);
-	std::future<response::Value> resolveExpensive(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveAppointments(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTasks(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnreadCounts(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveAppointmentsById(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTasksById(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnreadCountsById(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNested(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnimplemented(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveExpensive(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
-	std::future<response::Value> resolve_schema(service::ResolverParams&& params);
-	std::future<response::Value> resolve_type(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_schema(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_type(service::ResolverParams&& params);
 
 	std::shared_ptr<schema::Schema> _schema;
 };

--- a/samples/separate/QueryObject.h
+++ b/samples/separate/QueryObject.h
@@ -44,7 +44,7 @@ private:
 	std::future<response::Value> resolve_schema(service::ResolverParams&& params);
 	std::future<response::Value> resolve_type(service::ResolverParams&& params);
 
-	std::shared_ptr<introspection::Schema> _schema;
+	std::shared_ptr<schema::Schema> _schema;
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/SubscriptionObject.cpp
+++ b/samples/separate/SubscriptionObject.cpp
@@ -63,12 +63,12 @@ std::future<response::Value> Subscription::resolve_typename(service::ResolverPar
 
 } /* namespace object */
 
-void AddSubscriptionDetails(std::shared_ptr<introspection::ObjectType> typeSubscription, const std::shared_ptr<introspection::Schema>& schema)
+void AddSubscriptionDetails(std::shared_ptr<schema::ObjectType> typeSubscription, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeSubscription->AddFields({
-		std::make_shared<introspection::Field>("nextAppointmentChange", R"md()md", std::make_optional<response::StringType>(R"md(Need to deprecate a [field](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md"), std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("Appointment")),
-		std::make_shared<introspection::Field>("nodeChange", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>({
-			std::make_shared<introspection::InputValue>("id", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql")
+		std::make_shared<schema::Field>(R"gql(nextAppointmentChange)gql"sv, R"md()md"sv, std::make_optional(R"md(Need to deprecate a [field](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md"sv), std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Appointment")),
+		std::make_shared<schema::Field>(R"gql(nodeChange)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
 		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Node")))
 	});
 }

--- a/samples/separate/SubscriptionObject.cpp
+++ b/samples/separate/SubscriptionObject.cpp
@@ -66,10 +66,10 @@ std::future<service::ResolverResult> Subscription::resolve_typename(service::Res
 void AddSubscriptionDetails(std::shared_ptr<schema::ObjectType> typeSubscription, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeSubscription->AddFields({
-		std::make_shared<schema::Field>(R"gql(nextAppointmentChange)gql"sv, R"md()md"sv, std::make_optional(R"md(Need to deprecate a [field](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md"sv), std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Appointment")),
-		std::make_shared<schema::Field>(R"gql(nodeChange)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Node")))
+		schema::Field::Make(R"gql(nextAppointmentChange)gql"sv, R"md()md"sv, std::make_optional(R"md(Need to deprecate a [field](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md"sv), schema->LookupType("Appointment")),
+		schema::Field::Make(R"gql(nodeChange)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Node")), {
+			schema::InputValue::Make(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
+		})
 	});
 }
 

--- a/samples/separate/SubscriptionObject.cpp
+++ b/samples/separate/SubscriptionObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/SubscriptionObject.cpp
+++ b/samples/separate/SubscriptionObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<Appointment>> Subscription::getNextAppointm
 	throw std::runtime_error(R"ex(Subscription::getNextAppointmentChange is not implemented)ex");
 }
 
-std::future<response::Value> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNextAppointmentChange(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<std::shared_ptr<service::Object>> Subscription::getNodeChan
 	throw std::runtime_error(R"ex(Subscription::getNodeChange is not implemented)ex");
 }
 
-std::future<response::Value> Subscription::resolveNodeChange(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolveNodeChange(service::ResolverParams&& params)
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -56,7 +56,7 @@ std::future<response::Value> Subscription::resolveNodeChange(service::ResolverPa
 	return service::ModifiedResult<service::Object>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Subscription::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Subscription)gql" }, std::move(params));
 }

--- a/samples/separate/SubscriptionObject.h
+++ b/samples/separate/SubscriptionObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<std::shared_ptr<service::Object>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const;
 
 private:
-	std::future<response::Value> resolveNextAppointmentChange(service::ResolverParams&& params);
-	std::future<response::Value> resolveNodeChange(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNextAppointmentChange(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNodeChange(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/TaskConnectionObject.cpp
+++ b/samples/separate/TaskConnectionObject.cpp
@@ -62,11 +62,11 @@ std::future<response::Value> TaskConnection::resolve_typename(service::ResolverP
 
 } /* namespace object */
 
-void AddTaskConnectionDetails(std::shared_ptr<introspection::ObjectType> typeTaskConnection, const std::shared_ptr<introspection::Schema>& schema)
+void AddTaskConnectionDetails(std::shared_ptr<schema::ObjectType> typeTaskConnection, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeTaskConnection->AddFields({
-		std::make_shared<introspection::Field>("pageInfo", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<introspection::Field>("edges", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("TaskEdge")))
+		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("TaskEdge")))
 	});
 }
 

--- a/samples/separate/TaskConnectionObject.cpp
+++ b/samples/separate/TaskConnectionObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/TaskConnectionObject.cpp
+++ b/samples/separate/TaskConnectionObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<PageInfo>> TaskConnection::getPageInfo(serv
 	throw std::runtime_error(R"ex(TaskConnection::getPageInfo is not implemented)ex");
 }
 
-std::future<response::Value> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> Task
 	throw std::runtime_error(R"ex(TaskConnection::getEdges is not implemented)ex");
 }
 
-std::future<response::Value> TaskConnection::resolveEdges(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> TaskConnection::resolveEdges(service::ResolverParam
 	return service::ModifiedResult<TaskEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> TaskConnection::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskConnection::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(TaskConnection)gql" }, std::move(params));
 }

--- a/samples/separate/TaskConnectionObject.cpp
+++ b/samples/separate/TaskConnectionObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> TaskConnection::resolve_typename(service::R
 void AddTaskConnectionDetails(std::shared_ptr<schema::ObjectType> typeTaskConnection, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeTaskConnection->AddFields({
-		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("TaskEdge")))
+		schema::Field::Make(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		schema::Field::Make(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("TaskEdge")))
 	});
 }
 

--- a/samples/separate/TaskConnectionObject.h
+++ b/samples/separate/TaskConnectionObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePageInfo(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveEdges(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/TaskEdgeObject.cpp
+++ b/samples/separate/TaskEdgeObject.cpp
@@ -62,11 +62,11 @@ std::future<response::Value> TaskEdge::resolve_typename(service::ResolverParams&
 
 } /* namespace object */
 
-void AddTaskEdgeDetails(std::shared_ptr<introspection::ObjectType> typeTaskEdge, const std::shared_ptr<introspection::Schema>& schema)
+void AddTaskEdgeDetails(std::shared_ptr<schema::ObjectType> typeTaskEdge, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeTaskEdge->AddFields({
-		std::make_shared<introspection::Field>("node", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("Task")),
-		std::make_shared<introspection::Field>("cursor", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Task")),
+		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 }
 

--- a/samples/separate/TaskEdgeObject.cpp
+++ b/samples/separate/TaskEdgeObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/TaskEdgeObject.cpp
+++ b/samples/separate/TaskEdgeObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> TaskEdge::resolve_typename(service::Resolve
 void AddTaskEdgeDetails(std::shared_ptr<schema::ObjectType> typeTaskEdge, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeTaskEdge->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Task")),
-		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Task")),
+		schema::Field::Make(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 }
 

--- a/samples/separate/TaskEdgeObject.cpp
+++ b/samples/separate/TaskEdgeObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<Task>> TaskEdge::getNode(service::FieldPara
 	throw std::runtime_error(R"ex(TaskEdge::getNode is not implemented)ex");
 }
 
-std::future<response::Value> TaskEdge::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<response::Value> TaskEdge::getCursor(service::FieldParams&&
 	throw std::runtime_error(R"ex(TaskEdge::getCursor is not implemented)ex");
 }
 
-std::future<response::Value> TaskEdge::resolveCursor(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> TaskEdge::resolveCursor(service::ResolverParams&& p
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> TaskEdge::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskEdge::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(TaskEdge)gql" }, std::move(params));
 }

--- a/samples/separate/TaskEdgeObject.h
+++ b/samples/separate/TaskEdgeObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCursor(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/TaskObject.cpp
+++ b/samples/separate/TaskObject.cpp
@@ -82,12 +82,12 @@ std::future<service::ResolverResult> Task::resolve_typename(service::ResolverPar
 void AddTaskDetails(std::shared_ptr<schema::ObjectType> typeTask, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeTask->AddInterfaces({
-		std::static_pointer_cast<schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
+		std::static_pointer_cast<const schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
 	});
 	typeTask->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<schema::Field>(R"gql(title)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(isComplete)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		schema::Field::Make(R"gql(title)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(isComplete)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
 	});
 }
 

--- a/samples/separate/TaskObject.cpp
+++ b/samples/separate/TaskObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate/TaskObject.cpp
+++ b/samples/separate/TaskObject.cpp
@@ -35,7 +35,7 @@ service::FieldResult<response::IdType> Task::getId(service::FieldParams&&) const
 	throw std::runtime_error(R"ex(Task::getId is not implemented)ex");
 }
 
-std::future<response::Value> Task::resolveId(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -49,7 +49,7 @@ service::FieldResult<std::optional<response::StringType>> Task::getTitle(service
 	throw std::runtime_error(R"ex(Task::getTitle is not implemented)ex");
 }
 
-std::future<response::Value> Task::resolveTitle(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolveTitle(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getTitle(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -63,7 +63,7 @@ service::FieldResult<response::BooleanType> Task::getIsComplete(service::FieldPa
 	throw std::runtime_error(R"ex(Task::getIsComplete is not implemented)ex");
 }
 
-std::future<response::Value> Task::resolveIsComplete(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolveIsComplete(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getIsComplete(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -72,7 +72,7 @@ std::future<response::Value> Task::resolveIsComplete(service::ResolverParams&& p
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Task::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Task)gql" }, std::move(params));
 }

--- a/samples/separate/TaskObject.cpp
+++ b/samples/separate/TaskObject.cpp
@@ -79,15 +79,15 @@ std::future<response::Value> Task::resolve_typename(service::ResolverParams&& pa
 
 } /* namespace object */
 
-void AddTaskDetails(std::shared_ptr<introspection::ObjectType> typeTask, const std::shared_ptr<introspection::Schema>& schema)
+void AddTaskDetails(std::shared_ptr<schema::ObjectType> typeTask, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeTask->AddInterfaces({
-		std::static_pointer_cast<introspection::InterfaceType>(schema->LookupType("Node"))
+		std::static_pointer_cast<schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
 	});
 	typeTask->AddFields({
-		std::make_shared<introspection::Field>("id", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<introspection::Field>("title", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<introspection::Field>("isComplete", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		std::make_shared<schema::Field>(R"gql(title)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
+		std::make_shared<schema::Field>(R"gql(isComplete)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
 	});
 }
 

--- a/samples/separate/TaskObject.h
+++ b/samples/separate/TaskObject.h
@@ -23,11 +23,11 @@ public:
 	virtual service::FieldResult<response::BooleanType> getIsComplete(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveId(service::ResolverParams&& params);
-	std::future<response::Value> resolveTitle(service::ResolverParams&& params);
-	std::future<response::Value> resolveIsComplete(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTitle(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveIsComplete(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate/TodaySchema.cpp
+++ b/samples/separate/TodaySchema.cpp
@@ -233,7 +233,7 @@ std::shared_ptr<schema::Schema> GetSchema()
 
 	if (!schema)
 	{
-		schema = std::make_shared<schema::Schema>();
+		schema = std::make_shared<schema::Schema>(false);
 		introspection::AddTypesToSchema(schema);
 		AddTypesToSchema(schema);
 		s_wpSchema = schema;

--- a/samples/separate/TodaySchema.cpp
+++ b/samples/separate/TodaySchema.cpp
@@ -104,47 +104,47 @@ Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<obj
 
 void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 {
-	schema->AddType(R"gql(ItemCursor)gql"sv, std::make_shared<schema::ScalarType>(R"gql(ItemCursor)gql"sv, R"md()md"));
-	schema->AddType(R"gql(DateTime)gql"sv, std::make_shared<schema::ScalarType>(R"gql(DateTime)gql"sv, R"md()md"));
-	auto typeTaskState = std::make_shared<schema::EnumType>(R"gql(TaskState)gql"sv, R"md()md"sv);
+	schema->AddType(R"gql(ItemCursor)gql"sv, schema::ScalarType::Make(R"gql(ItemCursor)gql"sv, R"md()md"));
+	schema->AddType(R"gql(DateTime)gql"sv, schema::ScalarType::Make(R"gql(DateTime)gql"sv, R"md()md"));
+	auto typeTaskState = schema::EnumType::Make(R"gql(TaskState)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(TaskState)gql"sv, typeTaskState);
-	auto typeCompleteTaskInput = std::make_shared<schema::InputObjectType>(R"gql(CompleteTaskInput)gql"sv, R"md()md"sv);
+	auto typeCompleteTaskInput = schema::InputObjectType::Make(R"gql(CompleteTaskInput)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(CompleteTaskInput)gql"sv, typeCompleteTaskInput);
-	auto typeUnionType = std::make_shared<schema::UnionType>(R"gql(UnionType)gql"sv, R"md()md"sv);
+	auto typeUnionType = schema::UnionType::Make(R"gql(UnionType)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(UnionType)gql"sv, typeUnionType);
-	auto typeNode = std::make_shared<schema::InterfaceType>(R"gql(Node)gql"sv, R"md(Node interface for Relay support)md"sv);
+	auto typeNode = schema::InterfaceType::Make(R"gql(Node)gql"sv, R"md(Node interface for Relay support)md"sv);
 	schema->AddType(R"gql(Node)gql"sv, typeNode);
-	auto typeQuery = std::make_shared<schema::ObjectType>(R"gql(Query)gql"sv, R"md(Root Query type)md");
+	auto typeQuery = schema::ObjectType::Make(R"gql(Query)gql"sv, R"md(Root Query type)md");
 	schema->AddType(R"gql(Query)gql"sv, typeQuery);
-	auto typePageInfo = std::make_shared<schema::ObjectType>(R"gql(PageInfo)gql"sv, R"md()md");
+	auto typePageInfo = schema::ObjectType::Make(R"gql(PageInfo)gql"sv, R"md()md");
 	schema->AddType(R"gql(PageInfo)gql"sv, typePageInfo);
-	auto typeAppointmentEdge = std::make_shared<schema::ObjectType>(R"gql(AppointmentEdge)gql"sv, R"md()md");
+	auto typeAppointmentEdge = schema::ObjectType::Make(R"gql(AppointmentEdge)gql"sv, R"md()md");
 	schema->AddType(R"gql(AppointmentEdge)gql"sv, typeAppointmentEdge);
-	auto typeAppointmentConnection = std::make_shared<schema::ObjectType>(R"gql(AppointmentConnection)gql"sv, R"md()md");
+	auto typeAppointmentConnection = schema::ObjectType::Make(R"gql(AppointmentConnection)gql"sv, R"md()md");
 	schema->AddType(R"gql(AppointmentConnection)gql"sv, typeAppointmentConnection);
-	auto typeTaskEdge = std::make_shared<schema::ObjectType>(R"gql(TaskEdge)gql"sv, R"md()md");
+	auto typeTaskEdge = schema::ObjectType::Make(R"gql(TaskEdge)gql"sv, R"md()md");
 	schema->AddType(R"gql(TaskEdge)gql"sv, typeTaskEdge);
-	auto typeTaskConnection = std::make_shared<schema::ObjectType>(R"gql(TaskConnection)gql"sv, R"md()md");
+	auto typeTaskConnection = schema::ObjectType::Make(R"gql(TaskConnection)gql"sv, R"md()md");
 	schema->AddType(R"gql(TaskConnection)gql"sv, typeTaskConnection);
-	auto typeFolderEdge = std::make_shared<schema::ObjectType>(R"gql(FolderEdge)gql"sv, R"md()md");
+	auto typeFolderEdge = schema::ObjectType::Make(R"gql(FolderEdge)gql"sv, R"md()md");
 	schema->AddType(R"gql(FolderEdge)gql"sv, typeFolderEdge);
-	auto typeFolderConnection = std::make_shared<schema::ObjectType>(R"gql(FolderConnection)gql"sv, R"md()md");
+	auto typeFolderConnection = schema::ObjectType::Make(R"gql(FolderConnection)gql"sv, R"md()md");
 	schema->AddType(R"gql(FolderConnection)gql"sv, typeFolderConnection);
-	auto typeCompleteTaskPayload = std::make_shared<schema::ObjectType>(R"gql(CompleteTaskPayload)gql"sv, R"md()md");
+	auto typeCompleteTaskPayload = schema::ObjectType::Make(R"gql(CompleteTaskPayload)gql"sv, R"md()md");
 	schema->AddType(R"gql(CompleteTaskPayload)gql"sv, typeCompleteTaskPayload);
-	auto typeMutation = std::make_shared<schema::ObjectType>(R"gql(Mutation)gql"sv, R"md()md");
+	auto typeMutation = schema::ObjectType::Make(R"gql(Mutation)gql"sv, R"md()md");
 	schema->AddType(R"gql(Mutation)gql"sv, typeMutation);
-	auto typeSubscription = std::make_shared<schema::ObjectType>(R"gql(Subscription)gql"sv, R"md()md");
+	auto typeSubscription = schema::ObjectType::Make(R"gql(Subscription)gql"sv, R"md()md");
 	schema->AddType(R"gql(Subscription)gql"sv, typeSubscription);
-	auto typeAppointment = std::make_shared<schema::ObjectType>(R"gql(Appointment)gql"sv, R"md()md");
+	auto typeAppointment = schema::ObjectType::Make(R"gql(Appointment)gql"sv, R"md()md");
 	schema->AddType(R"gql(Appointment)gql"sv, typeAppointment);
-	auto typeTask = std::make_shared<schema::ObjectType>(R"gql(Task)gql"sv, R"md()md");
+	auto typeTask = schema::ObjectType::Make(R"gql(Task)gql"sv, R"md()md");
 	schema->AddType(R"gql(Task)gql"sv, typeTask);
-	auto typeFolder = std::make_shared<schema::ObjectType>(R"gql(Folder)gql"sv, R"md()md");
+	auto typeFolder = schema::ObjectType::Make(R"gql(Folder)gql"sv, R"md()md");
 	schema->AddType(R"gql(Folder)gql"sv, typeFolder);
-	auto typeNestedType = std::make_shared<schema::ObjectType>(R"gql(NestedType)gql"sv, R"md(Infinitely nestable type which can be used with nested fragments to test directive handling)md");
+	auto typeNestedType = schema::ObjectType::Make(R"gql(NestedType)gql"sv, R"md(Infinitely nestable type which can be used with nested fragments to test directive handling)md");
 	schema->AddType(R"gql(NestedType)gql"sv, typeNestedType);
-	auto typeExpensive = std::make_shared<schema::ObjectType>(R"gql(Expensive)gql"sv, R"md()md");
+	auto typeExpensive = schema::ObjectType::Make(R"gql(Expensive)gql"sv, R"md()md");
 	schema->AddType(R"gql(Expensive)gql"sv, typeExpensive);
 
 	typeTaskState->AddEnumValues({
@@ -155,9 +155,9 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	});
 
 	typeCompleteTaskInput->AddInputValues({
-		std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv),
-		std::make_shared<schema::InputValue>(R"gql(isComplete)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(true)gql"sv),
-		std::make_shared<schema::InputValue>(R"gql(clientMutationId)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
+		schema::InputValue::Make(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv),
+		schema::InputValue::Make(R"gql(isComplete)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(true)gql"sv),
+		schema::InputValue::Make(R"gql(clientMutationId)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
 	});
 
 	typeUnionType->AddPossibleTypes({
@@ -167,7 +167,7 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	});
 
 	typeNode->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
 	});
 
 	AddQueryDetails(typeQuery, schema);
@@ -187,39 +187,39 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	AddNestedTypeDetails(typeNestedType, schema);
 	AddExpensiveDetails(typeExpensive, schema);
 
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(id)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	schema->AddDirective(schema::Directive::Make(R"gql(id)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FIELD_DEFINITION
-	}), std::vector<std::shared_ptr<schema::InputValue>>()));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(subscriptionTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(subscriptionTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::SUBSCRIPTION
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(field)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(queryTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(field)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(queryTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::QUERY
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(query)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fieldTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(query)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(fieldTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FIELD
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(field)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fragmentDefinitionTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(field)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(fragmentDefinitionTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FRAGMENT_DEFINITION
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(fragmentDefinition)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fragmentSpreadTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(fragmentDefinition)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(fragmentSpreadTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FRAGMENT_SPREAD
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(fragmentSpread)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(inlineFragmentTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(fragmentSpread)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(inlineFragmentTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::INLINE_FRAGMENT
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(inlineFragment)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
+	}, {
+		schema::InputValue::Make(R"gql(inlineFragment)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
 
 	schema->AddQueryType(typeQuery);
 	schema->AddMutationType(typeMutation);

--- a/samples/separate/TodaySchema.cpp
+++ b/samples/separate/TodaySchema.cpp
@@ -95,79 +95,79 @@ Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<obj
 		{ "query", query },
 		{ "mutation", mutation },
 		{ "subscription", subscription }
-	})
+	}, nullptr)
 	, _query(std::move(query))
 	, _mutation(std::move(mutation))
 	, _subscription(std::move(subscription))
 {
 }
 
-void AddTypesToSchema(const std::shared_ptr<introspection::Schema>& schema)
+void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 {
-	schema->AddType("ItemCursor", std::make_shared<introspection::ScalarType>("ItemCursor", R"md()md"));
-	schema->AddType("DateTime", std::make_shared<introspection::ScalarType>("DateTime", R"md()md"));
-	auto typeTaskState = std::make_shared<introspection::EnumType>("TaskState", R"md()md");
-	schema->AddType("TaskState", typeTaskState);
-	auto typeCompleteTaskInput = std::make_shared<introspection::InputObjectType>("CompleteTaskInput", R"md()md");
-	schema->AddType("CompleteTaskInput", typeCompleteTaskInput);
-	auto typeUnionType = std::make_shared<introspection::UnionType>("UnionType", R"md()md");
-	schema->AddType("UnionType", typeUnionType);
-	auto typeNode = std::make_shared<introspection::InterfaceType>("Node", R"md(Node interface for Relay support)md");
-	schema->AddType("Node", typeNode);
-	auto typeQuery = std::make_shared<introspection::ObjectType>("Query", R"md(Root Query type)md");
-	schema->AddType("Query", typeQuery);
-	auto typePageInfo = std::make_shared<introspection::ObjectType>("PageInfo", R"md()md");
-	schema->AddType("PageInfo", typePageInfo);
-	auto typeAppointmentEdge = std::make_shared<introspection::ObjectType>("AppointmentEdge", R"md()md");
-	schema->AddType("AppointmentEdge", typeAppointmentEdge);
-	auto typeAppointmentConnection = std::make_shared<introspection::ObjectType>("AppointmentConnection", R"md()md");
-	schema->AddType("AppointmentConnection", typeAppointmentConnection);
-	auto typeTaskEdge = std::make_shared<introspection::ObjectType>("TaskEdge", R"md()md");
-	schema->AddType("TaskEdge", typeTaskEdge);
-	auto typeTaskConnection = std::make_shared<introspection::ObjectType>("TaskConnection", R"md()md");
-	schema->AddType("TaskConnection", typeTaskConnection);
-	auto typeFolderEdge = std::make_shared<introspection::ObjectType>("FolderEdge", R"md()md");
-	schema->AddType("FolderEdge", typeFolderEdge);
-	auto typeFolderConnection = std::make_shared<introspection::ObjectType>("FolderConnection", R"md()md");
-	schema->AddType("FolderConnection", typeFolderConnection);
-	auto typeCompleteTaskPayload = std::make_shared<introspection::ObjectType>("CompleteTaskPayload", R"md()md");
-	schema->AddType("CompleteTaskPayload", typeCompleteTaskPayload);
-	auto typeMutation = std::make_shared<introspection::ObjectType>("Mutation", R"md()md");
-	schema->AddType("Mutation", typeMutation);
-	auto typeSubscription = std::make_shared<introspection::ObjectType>("Subscription", R"md()md");
-	schema->AddType("Subscription", typeSubscription);
-	auto typeAppointment = std::make_shared<introspection::ObjectType>("Appointment", R"md()md");
-	schema->AddType("Appointment", typeAppointment);
-	auto typeTask = std::make_shared<introspection::ObjectType>("Task", R"md()md");
-	schema->AddType("Task", typeTask);
-	auto typeFolder = std::make_shared<introspection::ObjectType>("Folder", R"md()md");
-	schema->AddType("Folder", typeFolder);
-	auto typeNestedType = std::make_shared<introspection::ObjectType>("NestedType", R"md(Infinitely nestable type which can be used with nested fragments to test directive handling)md");
-	schema->AddType("NestedType", typeNestedType);
-	auto typeExpensive = std::make_shared<introspection::ObjectType>("Expensive", R"md()md");
-	schema->AddType("Expensive", typeExpensive);
+	schema->AddType(R"gql(ItemCursor)gql"sv, std::make_shared<schema::ScalarType>(R"gql(ItemCursor)gql"sv, R"md()md"));
+	schema->AddType(R"gql(DateTime)gql"sv, std::make_shared<schema::ScalarType>(R"gql(DateTime)gql"sv, R"md()md"));
+	auto typeTaskState = std::make_shared<schema::EnumType>(R"gql(TaskState)gql"sv, R"md()md"sv);
+	schema->AddType(R"gql(TaskState)gql"sv, typeTaskState);
+	auto typeCompleteTaskInput = std::make_shared<schema::InputObjectType>(R"gql(CompleteTaskInput)gql"sv, R"md()md"sv);
+	schema->AddType(R"gql(CompleteTaskInput)gql"sv, typeCompleteTaskInput);
+	auto typeUnionType = std::make_shared<schema::UnionType>(R"gql(UnionType)gql"sv, R"md()md"sv);
+	schema->AddType(R"gql(UnionType)gql"sv, typeUnionType);
+	auto typeNode = std::make_shared<schema::InterfaceType>(R"gql(Node)gql"sv, R"md(Node interface for Relay support)md"sv);
+	schema->AddType(R"gql(Node)gql"sv, typeNode);
+	auto typeQuery = std::make_shared<schema::ObjectType>(R"gql(Query)gql"sv, R"md(Root Query type)md");
+	schema->AddType(R"gql(Query)gql"sv, typeQuery);
+	auto typePageInfo = std::make_shared<schema::ObjectType>(R"gql(PageInfo)gql"sv, R"md()md");
+	schema->AddType(R"gql(PageInfo)gql"sv, typePageInfo);
+	auto typeAppointmentEdge = std::make_shared<schema::ObjectType>(R"gql(AppointmentEdge)gql"sv, R"md()md");
+	schema->AddType(R"gql(AppointmentEdge)gql"sv, typeAppointmentEdge);
+	auto typeAppointmentConnection = std::make_shared<schema::ObjectType>(R"gql(AppointmentConnection)gql"sv, R"md()md");
+	schema->AddType(R"gql(AppointmentConnection)gql"sv, typeAppointmentConnection);
+	auto typeTaskEdge = std::make_shared<schema::ObjectType>(R"gql(TaskEdge)gql"sv, R"md()md");
+	schema->AddType(R"gql(TaskEdge)gql"sv, typeTaskEdge);
+	auto typeTaskConnection = std::make_shared<schema::ObjectType>(R"gql(TaskConnection)gql"sv, R"md()md");
+	schema->AddType(R"gql(TaskConnection)gql"sv, typeTaskConnection);
+	auto typeFolderEdge = std::make_shared<schema::ObjectType>(R"gql(FolderEdge)gql"sv, R"md()md");
+	schema->AddType(R"gql(FolderEdge)gql"sv, typeFolderEdge);
+	auto typeFolderConnection = std::make_shared<schema::ObjectType>(R"gql(FolderConnection)gql"sv, R"md()md");
+	schema->AddType(R"gql(FolderConnection)gql"sv, typeFolderConnection);
+	auto typeCompleteTaskPayload = std::make_shared<schema::ObjectType>(R"gql(CompleteTaskPayload)gql"sv, R"md()md");
+	schema->AddType(R"gql(CompleteTaskPayload)gql"sv, typeCompleteTaskPayload);
+	auto typeMutation = std::make_shared<schema::ObjectType>(R"gql(Mutation)gql"sv, R"md()md");
+	schema->AddType(R"gql(Mutation)gql"sv, typeMutation);
+	auto typeSubscription = std::make_shared<schema::ObjectType>(R"gql(Subscription)gql"sv, R"md()md");
+	schema->AddType(R"gql(Subscription)gql"sv, typeSubscription);
+	auto typeAppointment = std::make_shared<schema::ObjectType>(R"gql(Appointment)gql"sv, R"md()md");
+	schema->AddType(R"gql(Appointment)gql"sv, typeAppointment);
+	auto typeTask = std::make_shared<schema::ObjectType>(R"gql(Task)gql"sv, R"md()md");
+	schema->AddType(R"gql(Task)gql"sv, typeTask);
+	auto typeFolder = std::make_shared<schema::ObjectType>(R"gql(Folder)gql"sv, R"md()md");
+	schema->AddType(R"gql(Folder)gql"sv, typeFolder);
+	auto typeNestedType = std::make_shared<schema::ObjectType>(R"gql(NestedType)gql"sv, R"md(Infinitely nestable type which can be used with nested fragments to test directive handling)md");
+	schema->AddType(R"gql(NestedType)gql"sv, typeNestedType);
+	auto typeExpensive = std::make_shared<schema::ObjectType>(R"gql(Expensive)gql"sv, R"md()md");
+	schema->AddType(R"gql(Expensive)gql"sv, typeExpensive);
 
 	typeTaskState->AddEnumValues({
-		{ std::string{ service::s_namesTaskState[static_cast<size_t>(today::TaskState::New)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesTaskState[static_cast<size_t>(today::TaskState::Started)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesTaskState[static_cast<size_t>(today::TaskState::Complete)] }, R"md()md", std::nullopt },
-		{ std::string{ service::s_namesTaskState[static_cast<size_t>(today::TaskState::Unassigned)] }, R"md()md", std::make_optional<response::StringType>(R"md(Need to deprecate an [enum value](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md") }
+		{ service::s_namesTaskState[static_cast<size_t>(today::TaskState::New)], R"md()md"sv, std::nullopt },
+		{ service::s_namesTaskState[static_cast<size_t>(today::TaskState::Started)], R"md()md"sv, std::nullopt },
+		{ service::s_namesTaskState[static_cast<size_t>(today::TaskState::Complete)], R"md()md"sv, std::nullopt },
+		{ service::s_namesTaskState[static_cast<size_t>(today::TaskState::Unassigned)], R"md()md"sv, std::make_optional(R"md(Need to deprecate an [enum value](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md"sv) }
 	});
 
 	typeCompleteTaskInput->AddInputValues({
-		std::make_shared<introspection::InputValue>("id", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"),
-		std::make_shared<introspection::InputValue>("isComplete", R"md()md", schema->LookupType("Boolean"), R"gql(true)gql"),
-		std::make_shared<introspection::InputValue>("clientMutationId", R"md()md", schema->LookupType("String"), R"gql()gql")
+		std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv),
+		std::make_shared<schema::InputValue>(R"gql(isComplete)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(true)gql"sv),
+		std::make_shared<schema::InputValue>(R"gql(clientMutationId)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
 	});
 
 	typeUnionType->AddPossibleTypes({
-		schema->LookupType("Appointment"),
-		schema->LookupType("Task"),
-		schema->LookupType("Folder")
+		schema->LookupType(R"gql(Appointment)gql"sv),
+		schema->LookupType(R"gql(Task)gql"sv),
+		schema->LookupType(R"gql(Folder)gql"sv)
 	});
 
 	typeNode->AddFields({
-		std::make_shared<introspection::Field>("id", R"md()md", std::nullopt, std::vector<std::shared_ptr<introspection::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
+		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
 	});
 
 	AddQueryDetails(typeQuery, schema);
@@ -187,38 +187,38 @@ void AddTypesToSchema(const std::shared_ptr<introspection::Schema>& schema)
 	AddNestedTypeDetails(typeNestedType, schema);
 	AddExpensiveDetails(typeExpensive, schema);
 
-	schema->AddDirective(std::make_shared<introspection::Directive>("id", R"md()md", std::vector<response::StringType>({
-		R"gql(FIELD_DEFINITION)gql"
-	}), std::vector<std::shared_ptr<introspection::InputValue>>()));
-	schema->AddDirective(std::make_shared<introspection::Directive>("subscriptionTag", R"md()md", std::vector<response::StringType>({
-		R"gql(SUBSCRIPTION)gql"
-	}), std::vector<std::shared_ptr<introspection::InputValue>>({
-		std::make_shared<introspection::InputValue>("field", R"md()md", schema->LookupType("String"), R"gql()gql")
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(id)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::FIELD_DEFINITION
+	}), std::vector<std::shared_ptr<schema::InputValue>>()));
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(subscriptionTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::SUBSCRIPTION
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(field)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
 	})));
-	schema->AddDirective(std::make_shared<introspection::Directive>("queryTag", R"md()md", std::vector<response::StringType>({
-		R"gql(QUERY)gql"
-	}), std::vector<std::shared_ptr<introspection::InputValue>>({
-		std::make_shared<introspection::InputValue>("query", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql")
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(queryTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::QUERY
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(query)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
 	})));
-	schema->AddDirective(std::make_shared<introspection::Directive>("fieldTag", R"md()md", std::vector<response::StringType>({
-		R"gql(FIELD)gql"
-	}), std::vector<std::shared_ptr<introspection::InputValue>>({
-		std::make_shared<introspection::InputValue>("field", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql")
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fieldTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::FIELD
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(field)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
 	})));
-	schema->AddDirective(std::make_shared<introspection::Directive>("fragmentDefinitionTag", R"md()md", std::vector<response::StringType>({
-		R"gql(FRAGMENT_DEFINITION)gql"
-	}), std::vector<std::shared_ptr<introspection::InputValue>>({
-		std::make_shared<introspection::InputValue>("fragmentDefinition", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql")
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fragmentDefinitionTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::FRAGMENT_DEFINITION
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(fragmentDefinition)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
 	})));
-	schema->AddDirective(std::make_shared<introspection::Directive>("fragmentSpreadTag", R"md()md", std::vector<response::StringType>({
-		R"gql(FRAGMENT_SPREAD)gql"
-	}), std::vector<std::shared_ptr<introspection::InputValue>>({
-		std::make_shared<introspection::InputValue>("fragmentSpread", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql")
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fragmentSpreadTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::FRAGMENT_SPREAD
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(fragmentSpread)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
 	})));
-	schema->AddDirective(std::make_shared<introspection::Directive>("inlineFragmentTag", R"md()md", std::vector<response::StringType>({
-		R"gql(INLINE_FRAGMENT)gql"
-	}), std::vector<std::shared_ptr<introspection::InputValue>>({
-		std::make_shared<introspection::InputValue>("inlineFragment", R"md()md", schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql")
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(inlineFragmentTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::INLINE_FRAGMENT
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(inlineFragment)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
 	})));
 
 	schema->AddQueryType(typeQuery);

--- a/samples/separate/TodaySchema.cpp
+++ b/samples/separate/TodaySchema.cpp
@@ -95,7 +95,7 @@ Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<obj
 		{ "query", query },
 		{ "mutation", mutation },
 		{ "subscription", subscription }
-	}, nullptr)
+	}, GetSchema())
 	, _query(std::move(query))
 	, _mutation(std::move(mutation))
 	, _subscription(std::move(subscription))
@@ -224,6 +224,22 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	schema->AddQueryType(typeQuery);
 	schema->AddMutationType(typeMutation);
 	schema->AddSubscriptionType(typeSubscription);
+}
+
+std::shared_ptr<schema::Schema> GetSchema()
+{
+	static std::weak_ptr<schema::Schema> s_wpSchema;
+	auto schema = s_wpSchema.lock();
+
+	if (!schema)
+	{
+		schema = std::make_shared<schema::Schema>();
+		introspection::AddTypesToSchema(schema);
+		AddTypesToSchema(schema);
+		s_wpSchema = schema;
+	}
+
+	return schema;
 }
 
 } /* namespace today */

--- a/samples/separate/TodaySchema.cpp
+++ b/samples/separate/TodaySchema.cpp
@@ -45,7 +45,7 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Val
 }
 
 template <>
-std::future<response::Value> ModifiedResult<today::TaskState>::convert(service::FieldResult<today::TaskState>&& result, ResolverParams&& params)
+std::future<service::ResolverResult> ModifiedResult<today::TaskState>::convert(service::FieldResult<today::TaskState>&& result, ResolverParams&& params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](today::TaskState&& value, const ResolverParams&)

--- a/samples/separate/TodaySchema.cpp
+++ b/samples/separate/TodaySchema.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <array>

--- a/samples/separate/TodaySchema.h
+++ b/samples/separate/TodaySchema.h
@@ -86,7 +86,7 @@ void AddFolderDetails(std::shared_ptr<schema::ObjectType> typeFolder, const std:
 void AddNestedTypeDetails(std::shared_ptr<schema::ObjectType> typeNestedType, const std::shared_ptr<schema::Schema>& schema);
 void AddExpensiveDetails(std::shared_ptr<schema::ObjectType> typeExpensive, const std::shared_ptr<schema::Schema>& schema);
 
-void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema);
+std::shared_ptr<schema::Schema> GetSchema();
 
 } /* namespace today */
 } /* namespace graphql */

--- a/samples/separate/TodaySchema.h
+++ b/samples/separate/TodaySchema.h
@@ -14,13 +14,6 @@
 #include <vector>
 
 namespace graphql {
-namespace introspection {
-
-class Schema;
-class ObjectType;
-
-} /* namespace introspection */
-
 namespace today {
 
 enum class TaskState

--- a/samples/separate/TodaySchema.h
+++ b/samples/separate/TodaySchema.h
@@ -6,6 +6,7 @@
 #ifndef TODAYSCHEMA_H
 #define TODAYSCHEMA_H
 
+#include "graphqlservice/GraphQLSchema.h"
 #include "graphqlservice/GraphQLService.h"
 
 #include <memory>
@@ -75,24 +76,24 @@ private:
 	std::shared_ptr<object::Subscription> _subscription;
 };
 
-void AddQueryDetails(std::shared_ptr<introspection::ObjectType> typeQuery, const std::shared_ptr<introspection::Schema>& schema);
-void AddPageInfoDetails(std::shared_ptr<introspection::ObjectType> typePageInfo, const std::shared_ptr<introspection::Schema>& schema);
-void AddAppointmentEdgeDetails(std::shared_ptr<introspection::ObjectType> typeAppointmentEdge, const std::shared_ptr<introspection::Schema>& schema);
-void AddAppointmentConnectionDetails(std::shared_ptr<introspection::ObjectType> typeAppointmentConnection, const std::shared_ptr<introspection::Schema>& schema);
-void AddTaskEdgeDetails(std::shared_ptr<introspection::ObjectType> typeTaskEdge, const std::shared_ptr<introspection::Schema>& schema);
-void AddTaskConnectionDetails(std::shared_ptr<introspection::ObjectType> typeTaskConnection, const std::shared_ptr<introspection::Schema>& schema);
-void AddFolderEdgeDetails(std::shared_ptr<introspection::ObjectType> typeFolderEdge, const std::shared_ptr<introspection::Schema>& schema);
-void AddFolderConnectionDetails(std::shared_ptr<introspection::ObjectType> typeFolderConnection, const std::shared_ptr<introspection::Schema>& schema);
-void AddCompleteTaskPayloadDetails(std::shared_ptr<introspection::ObjectType> typeCompleteTaskPayload, const std::shared_ptr<introspection::Schema>& schema);
-void AddMutationDetails(std::shared_ptr<introspection::ObjectType> typeMutation, const std::shared_ptr<introspection::Schema>& schema);
-void AddSubscriptionDetails(std::shared_ptr<introspection::ObjectType> typeSubscription, const std::shared_ptr<introspection::Schema>& schema);
-void AddAppointmentDetails(std::shared_ptr<introspection::ObjectType> typeAppointment, const std::shared_ptr<introspection::Schema>& schema);
-void AddTaskDetails(std::shared_ptr<introspection::ObjectType> typeTask, const std::shared_ptr<introspection::Schema>& schema);
-void AddFolderDetails(std::shared_ptr<introspection::ObjectType> typeFolder, const std::shared_ptr<introspection::Schema>& schema);
-void AddNestedTypeDetails(std::shared_ptr<introspection::ObjectType> typeNestedType, const std::shared_ptr<introspection::Schema>& schema);
-void AddExpensiveDetails(std::shared_ptr<introspection::ObjectType> typeExpensive, const std::shared_ptr<introspection::Schema>& schema);
+void AddQueryDetails(std::shared_ptr<schema::ObjectType> typeQuery, const std::shared_ptr<schema::Schema>& schema);
+void AddPageInfoDetails(std::shared_ptr<schema::ObjectType> typePageInfo, const std::shared_ptr<schema::Schema>& schema);
+void AddAppointmentEdgeDetails(std::shared_ptr<schema::ObjectType> typeAppointmentEdge, const std::shared_ptr<schema::Schema>& schema);
+void AddAppointmentConnectionDetails(std::shared_ptr<schema::ObjectType> typeAppointmentConnection, const std::shared_ptr<schema::Schema>& schema);
+void AddTaskEdgeDetails(std::shared_ptr<schema::ObjectType> typeTaskEdge, const std::shared_ptr<schema::Schema>& schema);
+void AddTaskConnectionDetails(std::shared_ptr<schema::ObjectType> typeTaskConnection, const std::shared_ptr<schema::Schema>& schema);
+void AddFolderEdgeDetails(std::shared_ptr<schema::ObjectType> typeFolderEdge, const std::shared_ptr<schema::Schema>& schema);
+void AddFolderConnectionDetails(std::shared_ptr<schema::ObjectType> typeFolderConnection, const std::shared_ptr<schema::Schema>& schema);
+void AddCompleteTaskPayloadDetails(std::shared_ptr<schema::ObjectType> typeCompleteTaskPayload, const std::shared_ptr<schema::Schema>& schema);
+void AddMutationDetails(std::shared_ptr<schema::ObjectType> typeMutation, const std::shared_ptr<schema::Schema>& schema);
+void AddSubscriptionDetails(std::shared_ptr<schema::ObjectType> typeSubscription, const std::shared_ptr<schema::Schema>& schema);
+void AddAppointmentDetails(std::shared_ptr<schema::ObjectType> typeAppointment, const std::shared_ptr<schema::Schema>& schema);
+void AddTaskDetails(std::shared_ptr<schema::ObjectType> typeTask, const std::shared_ptr<schema::Schema>& schema);
+void AddFolderDetails(std::shared_ptr<schema::ObjectType> typeFolder, const std::shared_ptr<schema::Schema>& schema);
+void AddNestedTypeDetails(std::shared_ptr<schema::ObjectType> typeNestedType, const std::shared_ptr<schema::Schema>& schema);
+void AddExpensiveDetails(std::shared_ptr<schema::ObjectType> typeExpensive, const std::shared_ptr<schema::Schema>& schema);
 
-void AddTypesToSchema(const std::shared_ptr<introspection::Schema>& schema);
+void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema);
 
 } /* namespace today */
 } /* namespace graphql */

--- a/samples/separate_nointrospection/AppointmentConnectionObject.cpp
+++ b/samples/separate_nointrospection/AppointmentConnectionObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/AppointmentConnectionObject.cpp
+++ b/samples/separate_nointrospection/AppointmentConnectionObject.cpp
@@ -62,4 +62,12 @@ std::future<response::Value> AppointmentConnection::resolve_typename(service::Re
 
 } /* namespace object */
 
+void AddAppointmentConnectionDetails(std::shared_ptr<schema::ObjectType> typeAppointmentConnection, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeAppointmentConnection->AddFields({
+		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("AppointmentEdge")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/AppointmentConnectionObject.cpp
+++ b/samples/separate_nointrospection/AppointmentConnectionObject.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+AppointmentConnection::AppointmentConnection()
+	: service::Object({
+		"AppointmentConnection"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(edges)gql"sv, [this](service::ResolverParams&& params) { return resolveEdges(std::move(params)); } },
+		{ R"gql(pageInfo)gql"sv, [this](service::ResolverParams&& params) { return resolvePageInfo(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<PageInfo>> AppointmentConnection::getPageInfo(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(AppointmentConnection::getPageInfo is not implemented)ex");
+}
+
+std::future<response::Value> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> AppointmentConnection::getEdges(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(AppointmentConnection::getEdges is not implemented)ex");
+}
+
+std::future<response::Value> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<AppointmentEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+std::future<response::Value> AppointmentConnection::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(AppointmentConnection)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/AppointmentConnectionObject.cpp
+++ b/samples/separate_nointrospection/AppointmentConnectionObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> AppointmentConnection::resolve_typename(ser
 void AddAppointmentConnectionDetails(std::shared_ptr<schema::ObjectType> typeAppointmentConnection, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeAppointmentConnection->AddFields({
-		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("AppointmentEdge")))
+		schema::Field::Make(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		schema::Field::Make(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("AppointmentEdge")))
 	});
 }
 

--- a/samples/separate_nointrospection/AppointmentConnectionObject.cpp
+++ b/samples/separate_nointrospection/AppointmentConnectionObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<PageInfo>> AppointmentConnection::getPageIn
 	throw std::runtime_error(R"ex(AppointmentConnection::getPageInfo is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>
 	throw std::runtime_error(R"ex(AppointmentConnection::getEdges is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> AppointmentConnection::resolveEdges(service::Resolv
 	return service::ModifiedResult<AppointmentEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> AppointmentConnection::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentConnection::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(AppointmentConnection)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/AppointmentConnectionObject.h
+++ b/samples/separate_nointrospection/AppointmentConnectionObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePageInfo(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveEdges(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/AppointmentConnectionObject.h
+++ b/samples/separate_nointrospection/AppointmentConnectionObject.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef APPOINTMENTCONNECTIONOBJECT_H
+#define APPOINTMENTCONNECTIONOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class AppointmentConnection
+	: public service::Object
+{
+protected:
+	explicit AppointmentConnection();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
+	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // APPOINTMENTCONNECTIONOBJECT_H

--- a/samples/separate_nointrospection/AppointmentEdgeObject.cpp
+++ b/samples/separate_nointrospection/AppointmentEdgeObject.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+AppointmentEdge::AppointmentEdge()
+	: service::Object({
+		"AppointmentEdge"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(cursor)gql"sv, [this](service::ResolverParams&& params) { return resolveCursor(std::move(params)); } },
+		{ R"gql(node)gql"sv, [this](service::ResolverParams&& params) { return resolveNode(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<Appointment>> AppointmentEdge::getNode(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(AppointmentEdge::getNode is not implemented)ex");
+}
+
+std::future<response::Value> AppointmentEdge::resolveNode(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::Value> AppointmentEdge::getCursor(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(AppointmentEdge::getCursor is not implemented)ex");
+}
+
+std::future<response::Value> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> AppointmentEdge::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(AppointmentEdge)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/AppointmentEdgeObject.cpp
+++ b/samples/separate_nointrospection/AppointmentEdgeObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/AppointmentEdgeObject.cpp
+++ b/samples/separate_nointrospection/AppointmentEdgeObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> AppointmentEdge::resolve_typename(service::
 void AddAppointmentEdgeDetails(std::shared_ptr<schema::ObjectType> typeAppointmentEdge, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeAppointmentEdge->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Appointment")),
-		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Appointment")),
+		schema::Field::Make(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 }
 

--- a/samples/separate_nointrospection/AppointmentEdgeObject.cpp
+++ b/samples/separate_nointrospection/AppointmentEdgeObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<Appointment>> AppointmentEdge::getNode(serv
 	throw std::runtime_error(R"ex(AppointmentEdge::getNode is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentEdge::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<response::Value> AppointmentEdge::getCursor(service::FieldP
 	throw std::runtime_error(R"ex(AppointmentEdge::getCursor is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> AppointmentEdge::resolveCursor(service::ResolverPar
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> AppointmentEdge::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentEdge::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(AppointmentEdge)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/AppointmentEdgeObject.cpp
+++ b/samples/separate_nointrospection/AppointmentEdgeObject.cpp
@@ -62,4 +62,12 @@ std::future<response::Value> AppointmentEdge::resolve_typename(service::Resolver
 
 } /* namespace object */
 
+void AddAppointmentEdgeDetails(std::shared_ptr<schema::ObjectType> typeAppointmentEdge, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeAppointmentEdge->AddFields({
+		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Appointment")),
+		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/AppointmentEdgeObject.h
+++ b/samples/separate_nointrospection/AppointmentEdgeObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCursor(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/AppointmentEdgeObject.h
+++ b/samples/separate_nointrospection/AppointmentEdgeObject.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef APPOINTMENTEDGEOBJECT_H
+#define APPOINTMENTEDGEOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class AppointmentEdge
+	: public service::Object
+{
+protected:
+	explicit AppointmentEdge();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveNode(service::ResolverParams&& params);
+	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // APPOINTMENTEDGEOBJECT_H

--- a/samples/separate_nointrospection/AppointmentObject.cpp
+++ b/samples/separate_nointrospection/AppointmentObject.cpp
@@ -112,14 +112,14 @@ std::future<service::ResolverResult> Appointment::resolve_typename(service::Reso
 void AddAppointmentDetails(std::shared_ptr<schema::ObjectType> typeAppointment, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeAppointment->AddInterfaces({
-		std::static_pointer_cast<schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
+		std::static_pointer_cast<const schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
 	});
 	typeAppointment->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<schema::Field>(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("DateTime")),
-		std::make_shared<schema::Field>(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(forceError)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		schema::Field::Make(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("DateTime")),
+		schema::Field::Make(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		schema::Field::Make(R"gql(forceError)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String"))
 	});
 }
 

--- a/samples/separate_nointrospection/AppointmentObject.cpp
+++ b/samples/separate_nointrospection/AppointmentObject.cpp
@@ -23,6 +23,7 @@ Appointment::Appointment()
 		"Appointment"
 	}, {
 		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(forceError)gql"sv, [this](service::ResolverParams&& params) { return resolveForceError(std::move(params)); } },
 		{ R"gql(id)gql"sv, [this](service::ResolverParams&& params) { return resolveId(std::move(params)); } },
 		{ R"gql(isNow)gql"sv, [this](service::ResolverParams&& params) { return resolveIsNow(std::move(params)); } },
 		{ R"gql(subject)gql"sv, [this](service::ResolverParams&& params) { return resolveSubject(std::move(params)); } },
@@ -87,6 +88,20 @@ std::future<response::Value> Appointment::resolveIsNow(service::ResolverParams&&
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
+service::FieldResult<std::optional<response::StringType>> Appointment::getForceError(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Appointment::getForceError is not implemented)ex");
+}
+
+std::future<response::Value> Appointment::resolveForceError(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getForceError(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
 std::future<response::Value> Appointment::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Appointment)gql" }, std::move(params));
@@ -103,7 +118,8 @@ void AddAppointmentDetails(std::shared_ptr<schema::ObjectType> typeAppointment, 
 		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
 		std::make_shared<schema::Field>(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("DateTime")),
 		std::make_shared<schema::Field>(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		std::make_shared<schema::Field>(R"gql(forceError)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
 	});
 }
 

--- a/samples/separate_nointrospection/AppointmentObject.cpp
+++ b/samples/separate_nointrospection/AppointmentObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/AppointmentObject.cpp
+++ b/samples/separate_nointrospection/AppointmentObject.cpp
@@ -94,4 +94,17 @@ std::future<response::Value> Appointment::resolve_typename(service::ResolverPara
 
 } /* namespace object */
 
+void AddAppointmentDetails(std::shared_ptr<schema::ObjectType> typeAppointment, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeAppointment->AddInterfaces({
+		std::static_pointer_cast<schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
+	});
+	typeAppointment->AddFields({
+		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		std::make_shared<schema::Field>(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("DateTime")),
+		std::make_shared<schema::Field>(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
+		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/AppointmentObject.cpp
+++ b/samples/separate_nointrospection/AppointmentObject.cpp
@@ -37,7 +37,7 @@ service::FieldResult<response::IdType> Appointment::getId(service::FieldParams&&
 	throw std::runtime_error(R"ex(Appointment::getId is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveId(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -51,7 +51,7 @@ service::FieldResult<std::optional<response::Value>> Appointment::getWhen(servic
 	throw std::runtime_error(R"ex(Appointment::getWhen is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveWhen(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveWhen(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getWhen(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -65,7 +65,7 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getSubjec
 	throw std::runtime_error(R"ex(Appointment::getSubject is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveSubject(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveSubject(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getSubject(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -79,7 +79,7 @@ service::FieldResult<response::BooleanType> Appointment::getIsNow(service::Field
 	throw std::runtime_error(R"ex(Appointment::getIsNow is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveIsNow(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveIsNow(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getIsNow(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -93,7 +93,7 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getForceE
 	throw std::runtime_error(R"ex(Appointment::getForceError is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveForceError(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveForceError(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getForceError(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -102,7 +102,7 @@ std::future<response::Value> Appointment::resolveForceError(service::ResolverPar
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Appointment::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Appointment)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/AppointmentObject.cpp
+++ b/samples/separate_nointrospection/AppointmentObject.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+Appointment::Appointment()
+	: service::Object({
+		"Node",
+		"UnionType",
+		"Appointment"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(id)gql"sv, [this](service::ResolverParams&& params) { return resolveId(std::move(params)); } },
+		{ R"gql(isNow)gql"sv, [this](service::ResolverParams&& params) { return resolveIsNow(std::move(params)); } },
+		{ R"gql(subject)gql"sv, [this](service::ResolverParams&& params) { return resolveSubject(std::move(params)); } },
+		{ R"gql(when)gql"sv, [this](service::ResolverParams&& params) { return resolveWhen(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<response::IdType> Appointment::getId(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Appointment::getId is not implemented)ex");
+}
+
+std::future<response::Value> Appointment::resolveId(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<response::Value>> Appointment::getWhen(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Appointment::getWhen is not implemented)ex");
+}
+
+std::future<response::Value> Appointment::resolveWhen(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getWhen(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::Value>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<response::StringType>> Appointment::getSubject(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Appointment::getSubject is not implemented)ex");
+}
+
+std::future<response::Value> Appointment::resolveSubject(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getSubject(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::BooleanType> Appointment::getIsNow(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Appointment::getIsNow is not implemented)ex");
+}
+
+std::future<response::Value> Appointment::resolveIsNow(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getIsNow(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Appointment::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Appointment)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/AppointmentObject.h
+++ b/samples/separate_nointrospection/AppointmentObject.h
@@ -22,12 +22,14 @@ public:
 	virtual service::FieldResult<std::optional<response::Value>> getWhen(service::FieldParams&& params) const;
 	virtual service::FieldResult<std::optional<response::StringType>> getSubject(service::FieldParams&& params) const;
 	virtual service::FieldResult<response::BooleanType> getIsNow(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<response::StringType>> getForceError(service::FieldParams&& params) const;
 
 private:
 	std::future<response::Value> resolveId(service::ResolverParams&& params);
 	std::future<response::Value> resolveWhen(service::ResolverParams&& params);
 	std::future<response::Value> resolveSubject(service::ResolverParams&& params);
 	std::future<response::Value> resolveIsNow(service::ResolverParams&& params);
+	std::future<response::Value> resolveForceError(service::ResolverParams&& params);
 
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };

--- a/samples/separate_nointrospection/AppointmentObject.h
+++ b/samples/separate_nointrospection/AppointmentObject.h
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef APPOINTMENTOBJECT_H
+#define APPOINTMENTOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class Appointment
+	: public service::Object
+	, public Node
+{
+protected:
+	explicit Appointment();
+
+public:
+	virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const override;
+	virtual service::FieldResult<std::optional<response::Value>> getWhen(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<response::StringType>> getSubject(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::BooleanType> getIsNow(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveId(service::ResolverParams&& params);
+	std::future<response::Value> resolveWhen(service::ResolverParams&& params);
+	std::future<response::Value> resolveSubject(service::ResolverParams&& params);
+	std::future<response::Value> resolveIsNow(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // APPOINTMENTOBJECT_H

--- a/samples/separate_nointrospection/AppointmentObject.h
+++ b/samples/separate_nointrospection/AppointmentObject.h
@@ -25,13 +25,13 @@ public:
 	virtual service::FieldResult<std::optional<response::StringType>> getForceError(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveId(service::ResolverParams&& params);
-	std::future<response::Value> resolveWhen(service::ResolverParams&& params);
-	std::future<response::Value> resolveSubject(service::ResolverParams&& params);
-	std::future<response::Value> resolveIsNow(service::ResolverParams&& params);
-	std::future<response::Value> resolveForceError(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveWhen(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveSubject(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveIsNow(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveForceError(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/CompleteTaskPayloadObject.cpp
+++ b/samples/separate_nointrospection/CompleteTaskPayloadObject.cpp
@@ -62,4 +62,12 @@ std::future<response::Value> CompleteTaskPayload::resolve_typename(service::Reso
 
 } /* namespace object */
 
+void AddCompleteTaskPayloadDetails(std::shared_ptr<schema::ObjectType> typeCompleteTaskPayload, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeCompleteTaskPayload->AddFields({
+		std::make_shared<schema::Field>(R"gql(task)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Task")),
+		std::make_shared<schema::Field>(R"gql(clientMutationId)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/CompleteTaskPayloadObject.cpp
+++ b/samples/separate_nointrospection/CompleteTaskPayloadObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<Task>> CompleteTaskPayload::getTask(service
 	throw std::runtime_error(R"ex(CompleteTaskPayload::getTask is not implemented)ex");
 }
 
-std::future<response::Value> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
+std::future<service::ResolverResult> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getTask(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<std::optional<response::StringType>> CompleteTaskPayload::g
 	throw std::runtime_error(R"ex(CompleteTaskPayload::getClientMutationId is not implemented)ex");
 }
 
-std::future<response::Value> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
+std::future<service::ResolverResult> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getClientMutationId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> CompleteTaskPayload::resolveClientMutationId(servic
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> CompleteTaskPayload::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> CompleteTaskPayload::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(CompleteTaskPayload)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/CompleteTaskPayloadObject.cpp
+++ b/samples/separate_nointrospection/CompleteTaskPayloadObject.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+CompleteTaskPayload::CompleteTaskPayload()
+	: service::Object({
+		"CompleteTaskPayload"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(clientMutationId)gql"sv, [this](service::ResolverParams&& params) { return resolveClientMutationId(std::move(params)); } },
+		{ R"gql(task)gql"sv, [this](service::ResolverParams&& params) { return resolveTask(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<Task>> CompleteTaskPayload::getTask(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(CompleteTaskPayload::getTask is not implemented)ex");
+}
+
+std::future<response::Value> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getTask(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<response::StringType>> CompleteTaskPayload::getClientMutationId(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(CompleteTaskPayload::getClientMutationId is not implemented)ex");
+}
+
+std::future<response::Value> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getClientMutationId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+std::future<response::Value> CompleteTaskPayload::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(CompleteTaskPayload)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/CompleteTaskPayloadObject.cpp
+++ b/samples/separate_nointrospection/CompleteTaskPayloadObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> CompleteTaskPayload::resolve_typename(servi
 void AddCompleteTaskPayloadDetails(std::shared_ptr<schema::ObjectType> typeCompleteTaskPayload, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeCompleteTaskPayload->AddFields({
-		std::make_shared<schema::Field>(R"gql(task)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Task")),
-		std::make_shared<schema::Field>(R"gql(clientMutationId)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
+		schema::Field::Make(R"gql(task)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Task")),
+		schema::Field::Make(R"gql(clientMutationId)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String"))
 	});
 }
 

--- a/samples/separate_nointrospection/CompleteTaskPayloadObject.cpp
+++ b/samples/separate_nointrospection/CompleteTaskPayloadObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/CompleteTaskPayloadObject.h
+++ b/samples/separate_nointrospection/CompleteTaskPayloadObject.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef COMPLETETASKPAYLOADOBJECT_H
+#define COMPLETETASKPAYLOADOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class CompleteTaskPayload
+	: public service::Object
+{
+protected:
+	explicit CompleteTaskPayload();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<response::StringType>> getClientMutationId(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveTask(service::ResolverParams&& params);
+	std::future<response::Value> resolveClientMutationId(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // COMPLETETASKPAYLOADOBJECT_H

--- a/samples/separate_nointrospection/CompleteTaskPayloadObject.h
+++ b/samples/separate_nointrospection/CompleteTaskPayloadObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<std::optional<response::StringType>> getClientMutationId(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveTask(service::ResolverParams&& params);
-	std::future<response::Value> resolveClientMutationId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTask(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveClientMutationId(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/ExpensiveObject.cpp
+++ b/samples/separate_nointrospection/ExpensiveObject.cpp
@@ -50,7 +50,7 @@ std::future<service::ResolverResult> Expensive::resolve_typename(service::Resolv
 void AddExpensiveDetails(std::shared_ptr<schema::ObjectType> typeExpensive, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeExpensive->AddFields({
-		std::make_shared<schema::Field>(R"gql(order)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
+		schema::Field::Make(R"gql(order)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
 	});
 }
 

--- a/samples/separate_nointrospection/ExpensiveObject.cpp
+++ b/samples/separate_nointrospection/ExpensiveObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/ExpensiveObject.cpp
+++ b/samples/separate_nointrospection/ExpensiveObject.cpp
@@ -31,7 +31,7 @@ service::FieldResult<response::IntType> Expensive::getOrder(service::FieldParams
 	throw std::runtime_error(R"ex(Expensive::getOrder is not implemented)ex");
 }
 
-std::future<response::Value> Expensive::resolveOrder(service::ResolverParams&& params)
+std::future<service::ResolverResult> Expensive::resolveOrder(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getOrder(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -40,7 +40,7 @@ std::future<response::Value> Expensive::resolveOrder(service::ResolverParams&& p
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Expensive::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Expensive::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Expensive)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/ExpensiveObject.cpp
+++ b/samples/separate_nointrospection/ExpensiveObject.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+Expensive::Expensive()
+	: service::Object({
+		"Expensive"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(order)gql"sv, [this](service::ResolverParams&& params) { return resolveOrder(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<response::IntType> Expensive::getOrder(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Expensive::getOrder is not implemented)ex");
+}
+
+std::future<response::Value> Expensive::resolveOrder(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getOrder(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Expensive::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Expensive)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/ExpensiveObject.cpp
+++ b/samples/separate_nointrospection/ExpensiveObject.cpp
@@ -47,4 +47,11 @@ std::future<response::Value> Expensive::resolve_typename(service::ResolverParams
 
 } /* namespace object */
 
+void AddExpensiveDetails(std::shared_ptr<schema::ObjectType> typeExpensive, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeExpensive->AddFields({
+		std::make_shared<schema::Field>(R"gql(order)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/ExpensiveObject.h
+++ b/samples/separate_nointrospection/ExpensiveObject.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef EXPENSIVEOBJECT_H
+#define EXPENSIVEOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class Expensive
+	: public service::Object
+{
+protected:
+	explicit Expensive();
+
+public:
+	virtual service::FieldResult<response::IntType> getOrder(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveOrder(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // EXPENSIVEOBJECT_H

--- a/samples/separate_nointrospection/ExpensiveObject.h
+++ b/samples/separate_nointrospection/ExpensiveObject.h
@@ -20,9 +20,9 @@ public:
 	virtual service::FieldResult<response::IntType> getOrder(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveOrder(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveOrder(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/FolderConnectionObject.cpp
+++ b/samples/separate_nointrospection/FolderConnectionObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> FolderConnection::resolve_typename(service:
 void AddFolderConnectionDetails(std::shared_ptr<schema::ObjectType> typeFolderConnection, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeFolderConnection->AddFields({
-		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("FolderEdge")))
+		schema::Field::Make(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		schema::Field::Make(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("FolderEdge")))
 	});
 }
 

--- a/samples/separate_nointrospection/FolderConnectionObject.cpp
+++ b/samples/separate_nointrospection/FolderConnectionObject.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+FolderConnection::FolderConnection()
+	: service::Object({
+		"FolderConnection"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(edges)gql"sv, [this](service::ResolverParams&& params) { return resolveEdges(std::move(params)); } },
+		{ R"gql(pageInfo)gql"sv, [this](service::ResolverParams&& params) { return resolvePageInfo(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<PageInfo>> FolderConnection::getPageInfo(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(FolderConnection::getPageInfo is not implemented)ex");
+}
+
+std::future<response::Value> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> FolderConnection::getEdges(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(FolderConnection::getEdges is not implemented)ex");
+}
+
+std::future<response::Value> FolderConnection::resolveEdges(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<FolderEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+std::future<response::Value> FolderConnection::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(FolderConnection)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/FolderConnectionObject.cpp
+++ b/samples/separate_nointrospection/FolderConnectionObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/FolderConnectionObject.cpp
+++ b/samples/separate_nointrospection/FolderConnectionObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<PageInfo>> FolderConnection::getPageInfo(se
 	throw std::runtime_error(R"ex(FolderConnection::getPageInfo is not implemented)ex");
 }
 
-std::future<response::Value> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> Fo
 	throw std::runtime_error(R"ex(FolderConnection::getEdges is not implemented)ex");
 }
 
-std::future<response::Value> FolderConnection::resolveEdges(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> FolderConnection::resolveEdges(service::ResolverPar
 	return service::ModifiedResult<FolderEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> FolderConnection::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderConnection::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(FolderConnection)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/FolderConnectionObject.cpp
+++ b/samples/separate_nointrospection/FolderConnectionObject.cpp
@@ -62,4 +62,12 @@ std::future<response::Value> FolderConnection::resolve_typename(service::Resolve
 
 } /* namespace object */
 
+void AddFolderConnectionDetails(std::shared_ptr<schema::ObjectType> typeFolderConnection, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeFolderConnection->AddFields({
+		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("FolderEdge")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/FolderConnectionObject.h
+++ b/samples/separate_nointrospection/FolderConnectionObject.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef FOLDERCONNECTIONOBJECT_H
+#define FOLDERCONNECTIONOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class FolderConnection
+	: public service::Object
+{
+protected:
+	explicit FolderConnection();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
+	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // FOLDERCONNECTIONOBJECT_H

--- a/samples/separate_nointrospection/FolderConnectionObject.h
+++ b/samples/separate_nointrospection/FolderConnectionObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePageInfo(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveEdges(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/FolderEdgeObject.cpp
+++ b/samples/separate_nointrospection/FolderEdgeObject.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+FolderEdge::FolderEdge()
+	: service::Object({
+		"FolderEdge"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(cursor)gql"sv, [this](service::ResolverParams&& params) { return resolveCursor(std::move(params)); } },
+		{ R"gql(node)gql"sv, [this](service::ResolverParams&& params) { return resolveNode(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<Folder>> FolderEdge::getNode(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(FolderEdge::getNode is not implemented)ex");
+}
+
+std::future<response::Value> FolderEdge::resolveNode(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Folder>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::Value> FolderEdge::getCursor(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(FolderEdge::getCursor is not implemented)ex");
+}
+
+std::future<response::Value> FolderEdge::resolveCursor(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> FolderEdge::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(FolderEdge)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/FolderEdgeObject.cpp
+++ b/samples/separate_nointrospection/FolderEdgeObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/FolderEdgeObject.cpp
+++ b/samples/separate_nointrospection/FolderEdgeObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<Folder>> FolderEdge::getNode(service::Field
 	throw std::runtime_error(R"ex(FolderEdge::getNode is not implemented)ex");
 }
 
-std::future<response::Value> FolderEdge::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<response::Value> FolderEdge::getCursor(service::FieldParams
 	throw std::runtime_error(R"ex(FolderEdge::getCursor is not implemented)ex");
 }
 
-std::future<response::Value> FolderEdge::resolveCursor(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> FolderEdge::resolveCursor(service::ResolverParams&&
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> FolderEdge::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderEdge::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(FolderEdge)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/FolderEdgeObject.cpp
+++ b/samples/separate_nointrospection/FolderEdgeObject.cpp
@@ -62,4 +62,12 @@ std::future<response::Value> FolderEdge::resolve_typename(service::ResolverParam
 
 } /* namespace object */
 
+void AddFolderEdgeDetails(std::shared_ptr<schema::ObjectType> typeFolderEdge, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeFolderEdge->AddFields({
+		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Folder")),
+		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/FolderEdgeObject.cpp
+++ b/samples/separate_nointrospection/FolderEdgeObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> FolderEdge::resolve_typename(service::Resol
 void AddFolderEdgeDetails(std::shared_ptr<schema::ObjectType> typeFolderEdge, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeFolderEdge->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Folder")),
-		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Folder")),
+		schema::Field::Make(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 }
 

--- a/samples/separate_nointrospection/FolderEdgeObject.h
+++ b/samples/separate_nointrospection/FolderEdgeObject.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef FOLDEREDGEOBJECT_H
+#define FOLDEREDGEOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class FolderEdge
+	: public service::Object
+{
+protected:
+	explicit FolderEdge();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveNode(service::ResolverParams&& params);
+	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // FOLDEREDGEOBJECT_H

--- a/samples/separate_nointrospection/FolderEdgeObject.h
+++ b/samples/separate_nointrospection/FolderEdgeObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCursor(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/FolderObject.cpp
+++ b/samples/separate_nointrospection/FolderObject.cpp
@@ -82,12 +82,12 @@ std::future<service::ResolverResult> Folder::resolve_typename(service::ResolverP
 void AddFolderDetails(std::shared_ptr<schema::ObjectType> typeFolder, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeFolder->AddInterfaces({
-		std::static_pointer_cast<schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
+		std::static_pointer_cast<const schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
 	});
 	typeFolder->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(unreadCount)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(unreadCount)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
 	});
 }
 

--- a/samples/separate_nointrospection/FolderObject.cpp
+++ b/samples/separate_nointrospection/FolderObject.cpp
@@ -35,7 +35,7 @@ service::FieldResult<response::IdType> Folder::getId(service::FieldParams&&) con
 	throw std::runtime_error(R"ex(Folder::getId is not implemented)ex");
 }
 
-std::future<response::Value> Folder::resolveId(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -49,7 +49,7 @@ service::FieldResult<std::optional<response::StringType>> Folder::getName(servic
 	throw std::runtime_error(R"ex(Folder::getName is not implemented)ex");
 }
 
-std::future<response::Value> Folder::resolveName(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -63,7 +63,7 @@ service::FieldResult<response::IntType> Folder::getUnreadCount(service::FieldPar
 	throw std::runtime_error(R"ex(Folder::getUnreadCount is not implemented)ex");
 }
 
-std::future<response::Value> Folder::resolveUnreadCount(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolveUnreadCount(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getUnreadCount(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -72,7 +72,7 @@ std::future<response::Value> Folder::resolveUnreadCount(service::ResolverParams&
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Folder::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Folder)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/FolderObject.cpp
+++ b/samples/separate_nointrospection/FolderObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/FolderObject.cpp
+++ b/samples/separate_nointrospection/FolderObject.cpp
@@ -79,4 +79,16 @@ std::future<response::Value> Folder::resolve_typename(service::ResolverParams&& 
 
 } /* namespace object */
 
+void AddFolderDetails(std::shared_ptr<schema::ObjectType> typeFolder, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeFolder->AddInterfaces({
+		std::static_pointer_cast<schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
+	});
+	typeFolder->AddFields({
+		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
+		std::make_shared<schema::Field>(R"gql(unreadCount)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/FolderObject.cpp
+++ b/samples/separate_nointrospection/FolderObject.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+Folder::Folder()
+	: service::Object({
+		"Node",
+		"UnionType",
+		"Folder"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(id)gql"sv, [this](service::ResolverParams&& params) { return resolveId(std::move(params)); } },
+		{ R"gql(name)gql"sv, [this](service::ResolverParams&& params) { return resolveName(std::move(params)); } },
+		{ R"gql(unreadCount)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCount(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<response::IdType> Folder::getId(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Folder::getId is not implemented)ex");
+}
+
+std::future<response::Value> Folder::resolveId(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<response::StringType>> Folder::getName(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Folder::getName is not implemented)ex");
+}
+
+std::future<response::Value> Folder::resolveName(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::IntType> Folder::getUnreadCount(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Folder::getUnreadCount is not implemented)ex");
+}
+
+std::future<response::Value> Folder::resolveUnreadCount(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getUnreadCount(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Folder::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Folder)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/FolderObject.h
+++ b/samples/separate_nointrospection/FolderObject.h
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef FOLDEROBJECT_H
+#define FOLDEROBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class Folder
+	: public service::Object
+	, public Node
+{
+protected:
+	explicit Folder();
+
+public:
+	virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const override;
+	virtual service::FieldResult<std::optional<response::StringType>> getName(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::IntType> getUnreadCount(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveId(service::ResolverParams&& params);
+	std::future<response::Value> resolveName(service::ResolverParams&& params);
+	std::future<response::Value> resolveUnreadCount(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // FOLDEROBJECT_H

--- a/samples/separate_nointrospection/FolderObject.h
+++ b/samples/separate_nointrospection/FolderObject.h
@@ -23,11 +23,11 @@ public:
 	virtual service::FieldResult<response::IntType> getUnreadCount(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveId(service::ResolverParams&& params);
-	std::future<response::Value> resolveName(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnreadCount(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveName(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnreadCount(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/MutationObject.cpp
+++ b/samples/separate_nointrospection/MutationObject.cpp
@@ -67,12 +67,12 @@ std::future<service::ResolverResult> Mutation::resolve_typename(service::Resolve
 void AddMutationDetails(std::shared_ptr<schema::ObjectType> typeMutation, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeMutation->AddFields({
-		std::make_shared<schema::Field>(R"gql(completeTask)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(input)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskInput")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskPayload"))),
-		std::make_shared<schema::Field>(R"gql(setFloat)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(value)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")))
+		schema::Field::Make(R"gql(completeTask)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskPayload")), {
+			schema::InputValue::Make(R"gql(input)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskInput")), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(setFloat)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), {
+			schema::InputValue::Make(R"gql(value)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), R"gql()gql"sv)
+		})
 	});
 }
 

--- a/samples/separate_nointrospection/MutationObject.cpp
+++ b/samples/separate_nointrospection/MutationObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<CompleteTaskPayload>> Mutation::applyComple
 	throw std::runtime_error(R"ex(Mutation::applyCompleteTask is not implemented)ex");
 }
 
-std::future<response::Value> Mutation::resolveCompleteTask(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolveCompleteTask(service::ResolverParams&& params)
 {
 	auto argInput = service::ModifiedArgument<today::CompleteTaskInput>::require("input", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -47,7 +47,7 @@ service::FieldResult<response::FloatType> Mutation::applySetFloat(service::Field
 	throw std::runtime_error(R"ex(Mutation::applySetFloat is not implemented)ex");
 }
 
-std::future<response::Value> Mutation::resolveSetFloat(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolveSetFloat(service::ResolverParams&& params)
 {
 	auto argValue = service::ModifiedArgument<response::FloatType>::require("value", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -57,7 +57,7 @@ std::future<response::Value> Mutation::resolveSetFloat(service::ResolverParams&&
 	return service::ModifiedResult<response::FloatType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Mutation::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Mutation)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/MutationObject.cpp
+++ b/samples/separate_nointrospection/MutationObject.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+Mutation::Mutation()
+	: service::Object({
+		"Mutation"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(completeTask)gql"sv, [this](service::ResolverParams&& params) { return resolveCompleteTask(std::move(params)); } },
+		{ R"gql(setFloat)gql"sv, [this](service::ResolverParams&& params) { return resolveSetFloat(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<CompleteTaskPayload>> Mutation::applyCompleteTask(service::FieldParams&&, CompleteTaskInput&&) const
+{
+	throw std::runtime_error(R"ex(Mutation::applyCompleteTask is not implemented)ex");
+}
+
+std::future<response::Value> Mutation::resolveCompleteTask(service::ResolverParams&& params)
+{
+	auto argInput = service::ModifiedArgument<today::CompleteTaskInput>::require("input", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = applyCompleteTask(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argInput));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<CompleteTaskPayload>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::FloatType> Mutation::applySetFloat(service::FieldParams&&, response::FloatType&&) const
+{
+	throw std::runtime_error(R"ex(Mutation::applySetFloat is not implemented)ex");
+}
+
+std::future<response::Value> Mutation::resolveSetFloat(service::ResolverParams&& params)
+{
+	auto argValue = service::ModifiedArgument<response::FloatType>::require("value", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = applySetFloat(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argValue));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::FloatType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Mutation::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Mutation)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/MutationObject.cpp
+++ b/samples/separate_nointrospection/MutationObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/MutationObject.cpp
+++ b/samples/separate_nointrospection/MutationObject.cpp
@@ -64,4 +64,16 @@ std::future<response::Value> Mutation::resolve_typename(service::ResolverParams&
 
 } /* namespace object */
 
+void AddMutationDetails(std::shared_ptr<schema::ObjectType> typeMutation, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeMutation->AddFields({
+		std::make_shared<schema::Field>(R"gql(completeTask)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(input)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskInput")), R"gql()gql"sv)
+		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskPayload"))),
+		std::make_shared<schema::Field>(R"gql(setFloat)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(value)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), R"gql()gql"sv)
+		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/MutationObject.h
+++ b/samples/separate_nointrospection/MutationObject.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef MUTATIONOBJECT_H
+#define MUTATIONOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class Mutation
+	: public service::Object
+{
+protected:
+	explicit Mutation();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const;
+	virtual service::FieldResult<response::FloatType> applySetFloat(service::FieldParams&& params, response::FloatType&& valueArg) const;
+
+private:
+	std::future<response::Value> resolveCompleteTask(service::ResolverParams&& params);
+	std::future<response::Value> resolveSetFloat(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // MUTATIONOBJECT_H

--- a/samples/separate_nointrospection/MutationObject.h
+++ b/samples/separate_nointrospection/MutationObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<response::FloatType> applySetFloat(service::FieldParams&& params, response::FloatType&& valueArg) const;
 
 private:
-	std::future<response::Value> resolveCompleteTask(service::ResolverParams&& params);
-	std::future<response::Value> resolveSetFloat(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCompleteTask(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveSetFloat(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/NestedTypeObject.cpp
+++ b/samples/separate_nointrospection/NestedTypeObject.cpp
@@ -62,4 +62,12 @@ std::future<response::Value> NestedType::resolve_typename(service::ResolverParam
 
 } /* namespace object */
 
+void AddNestedTypeDetails(std::shared_ptr<schema::ObjectType> typeNestedType, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeNestedType->AddFields({
+		std::make_shared<schema::Field>(R"gql(depth)gql"sv, R"md(Depth of the nested element)md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
+		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md(Link to the next level)md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/NestedTypeObject.cpp
+++ b/samples/separate_nointrospection/NestedTypeObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<response::IntType> NestedType::getDepth(service::FieldParam
 	throw std::runtime_error(R"ex(NestedType::getDepth is not implemented)ex");
 }
 
-std::future<response::Value> NestedType::resolveDepth(service::ResolverParams&& params)
+std::future<service::ResolverResult> NestedType::resolveDepth(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDepth(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<std::shared_ptr<NestedType>> NestedType::getNested(service:
 	throw std::runtime_error(R"ex(NestedType::getNested is not implemented)ex");
 }
 
-std::future<response::Value> NestedType::resolveNested(service::ResolverParams&& params)
+std::future<service::ResolverResult> NestedType::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> NestedType::resolveNested(service::ResolverParams&&
 	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> NestedType::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> NestedType::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(NestedType)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/NestedTypeObject.cpp
+++ b/samples/separate_nointrospection/NestedTypeObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/NestedTypeObject.cpp
+++ b/samples/separate_nointrospection/NestedTypeObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> NestedType::resolve_typename(service::Resol
 void AddNestedTypeDetails(std::shared_ptr<schema::ObjectType> typeNestedType, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeNestedType->AddFields({
-		std::make_shared<schema::Field>(R"gql(depth)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
-		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
+		schema::Field::Make(R"gql(depth)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
+		schema::Field::Make(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
 	});
 }
 

--- a/samples/separate_nointrospection/NestedTypeObject.cpp
+++ b/samples/separate_nointrospection/NestedTypeObject.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+NestedType::NestedType()
+	: service::Object({
+		"NestedType"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(depth)gql"sv, [this](service::ResolverParams&& params) { return resolveDepth(std::move(params)); } },
+		{ R"gql(nested)gql"sv, [this](service::ResolverParams&& params) { return resolveNested(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<response::IntType> NestedType::getDepth(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(NestedType::getDepth is not implemented)ex");
+}
+
+std::future<response::Value> NestedType::resolveDepth(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getDepth(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::shared_ptr<NestedType>> NestedType::getNested(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(NestedType::getNested is not implemented)ex");
+}
+
+std::future<response::Value> NestedType::resolveNested(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> NestedType::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(NestedType)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/NestedTypeObject.cpp
+++ b/samples/separate_nointrospection/NestedTypeObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> NestedType::resolve_typename(service::Resol
 void AddNestedTypeDetails(std::shared_ptr<schema::ObjectType> typeNestedType, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeNestedType->AddFields({
-		std::make_shared<schema::Field>(R"gql(depth)gql"sv, R"md(Depth of the nested element)md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
-		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md(Link to the next level)md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
+		std::make_shared<schema::Field>(R"gql(depth)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
+		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
 	});
 }
 

--- a/samples/separate_nointrospection/NestedTypeObject.h
+++ b/samples/separate_nointrospection/NestedTypeObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveDepth(service::ResolverParams&& params);
-	std::future<response::Value> resolveNested(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDepth(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNested(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/NestedTypeObject.h
+++ b/samples/separate_nointrospection/NestedTypeObject.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef NESTEDTYPEOBJECT_H
+#define NESTEDTYPEOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class NestedType
+	: public service::Object
+{
+protected:
+	explicit NestedType();
+
+public:
+	virtual service::FieldResult<response::IntType> getDepth(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveDepth(service::ResolverParams&& params);
+	std::future<response::Value> resolveNested(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // NESTEDTYPEOBJECT_H

--- a/samples/separate_nointrospection/PageInfoObject.cpp
+++ b/samples/separate_nointrospection/PageInfoObject.cpp
@@ -62,4 +62,12 @@ std::future<response::Value> PageInfo::resolve_typename(service::ResolverParams&
 
 } /* namespace object */
 
+void AddPageInfoDetails(std::shared_ptr<schema::ObjectType> typePageInfo, const std::shared_ptr<schema::Schema>& schema)
+{
+	typePageInfo->AddFields({
+		std::make_shared<schema::Field>(R"gql(hasNextPage)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		std::make_shared<schema::Field>(R"gql(hasPreviousPage)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/PageInfoObject.cpp
+++ b/samples/separate_nointrospection/PageInfoObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<response::BooleanType> PageInfo::getHasNextPage(service::Fi
 	throw std::runtime_error(R"ex(PageInfo::getHasNextPage is not implemented)ex");
 }
 
-std::future<response::Value> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
+std::future<service::ResolverResult> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getHasNextPage(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<response::BooleanType> PageInfo::getHasPreviousPage(service
 	throw std::runtime_error(R"ex(PageInfo::getHasPreviousPage is not implemented)ex");
 }
 
-std::future<response::Value> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
+std::future<service::ResolverResult> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getHasPreviousPage(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> PageInfo::resolveHasPreviousPage(service::ResolverP
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> PageInfo::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> PageInfo::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(PageInfo)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/PageInfoObject.cpp
+++ b/samples/separate_nointrospection/PageInfoObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> PageInfo::resolve_typename(service::Resolve
 void AddPageInfoDetails(std::shared_ptr<schema::ObjectType> typePageInfo, const std::shared_ptr<schema::Schema>& schema)
 {
 	typePageInfo->AddFields({
-		std::make_shared<schema::Field>(R"gql(hasNextPage)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(hasPreviousPage)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		schema::Field::Make(R"gql(hasNextPage)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		schema::Field::Make(R"gql(hasPreviousPage)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
 	});
 }
 

--- a/samples/separate_nointrospection/PageInfoObject.cpp
+++ b/samples/separate_nointrospection/PageInfoObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/PageInfoObject.cpp
+++ b/samples/separate_nointrospection/PageInfoObject.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+PageInfo::PageInfo()
+	: service::Object({
+		"PageInfo"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(hasNextPage)gql"sv, [this](service::ResolverParams&& params) { return resolveHasNextPage(std::move(params)); } },
+		{ R"gql(hasPreviousPage)gql"sv, [this](service::ResolverParams&& params) { return resolveHasPreviousPage(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<response::BooleanType> PageInfo::getHasNextPage(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(PageInfo::getHasNextPage is not implemented)ex");
+}
+
+std::future<response::Value> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getHasNextPage(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::BooleanType> PageInfo::getHasPreviousPage(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(PageInfo::getHasPreviousPage is not implemented)ex");
+}
+
+std::future<response::Value> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getHasPreviousPage(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> PageInfo::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(PageInfo)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/PageInfoObject.h
+++ b/samples/separate_nointrospection/PageInfoObject.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef PAGEINFOOBJECT_H
+#define PAGEINFOOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class PageInfo
+	: public service::Object
+{
+protected:
+	explicit PageInfo();
+
+public:
+	virtual service::FieldResult<response::BooleanType> getHasNextPage(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::BooleanType> getHasPreviousPage(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveHasNextPage(service::ResolverParams&& params);
+	std::future<response::Value> resolveHasPreviousPage(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // PAGEINFOOBJECT_H

--- a/samples/separate_nointrospection/PageInfoObject.h
+++ b/samples/separate_nointrospection/PageInfoObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<response::BooleanType> getHasPreviousPage(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveHasNextPage(service::ResolverParams&& params);
-	std::future<response::Value> resolveHasPreviousPage(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveHasNextPage(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveHasPreviousPage(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/QueryObject.cpp
+++ b/samples/separate_nointrospection/QueryObject.cpp
@@ -32,7 +32,10 @@ Query::Query()
 		{ R"gql(unreadCounts)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCounts(std::move(params)); } },
 		{ R"gql(unreadCountsById)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCountsById(std::move(params)); } }
 	})
+	, _schema(std::make_shared<schema::Schema>())
 {
+	introspection::AddTypesToSchema(_schema);
+	today::AddTypesToSchema(_schema);
 }
 
 service::FieldResult<std::shared_ptr<service::Object>> Query::getNode(service::FieldParams&&, response::IdType&&) const
@@ -219,5 +222,44 @@ std::future<response::Value> Query::resolve_typename(service::ResolverParams&& p
 }
 
 } /* namespace object */
+
+void AddQueryDetails(std::shared_ptr<schema::ObjectType> typeQuery, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeQuery->AddFields({
+		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md([Object Identification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#object-identification))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
+		}), schema->LookupType("Node")),
+		std::make_shared<schema::Field>(R"gql(appointments)gql"sv, R"md(Appointments [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("AppointmentConnection"))),
+		std::make_shared<schema::Field>(R"gql(tasks)gql"sv, R"md(Tasks [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("TaskConnection"))),
+		std::make_shared<schema::Field>(R"gql(unreadCounts)gql"sv, R"md(Folder unread counts [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("FolderConnection"))),
+		std::make_shared<schema::Field>(R"gql(appointmentsById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql(["ZmFrZUFwcG9pbnRtZW50SWQ="])gql"sv)
+		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Appointment")))),
+		std::make_shared<schema::Field>(R"gql(tasksById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
+		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Task")))),
+		std::make_shared<schema::Field>(R"gql(unreadCountsById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
+		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Folder")))),
+		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType"))),
+		std::make_shared<schema::Field>(R"gql(unimplemented)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		std::make_shared<schema::Field>(R"gql(expensive)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Expensive")))))
+	});
+}
 
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/QueryObject.cpp
+++ b/samples/separate_nointrospection/QueryObject.cpp
@@ -40,7 +40,7 @@ service::FieldResult<std::shared_ptr<service::Object>> Query::getNode(service::F
 	throw std::runtime_error(R"ex(Query::getNode is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveNode(service::ResolverParams&& params)
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -55,7 +55,7 @@ service::FieldResult<std::shared_ptr<AppointmentConnection>> Query::getAppointme
 	throw std::runtime_error(R"ex(Query::getAppointments is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveAppointments(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveAppointments(service::ResolverParams&& params)
 {
 	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
@@ -73,7 +73,7 @@ service::FieldResult<std::shared_ptr<TaskConnection>> Query::getTasks(service::F
 	throw std::runtime_error(R"ex(Query::getTasks is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveTasks(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveTasks(service::ResolverParams&& params)
 {
 	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
@@ -91,7 +91,7 @@ service::FieldResult<std::shared_ptr<FolderConnection>> Query::getUnreadCounts(s
 	throw std::runtime_error(R"ex(Query::getUnreadCounts is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveUnreadCounts(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveUnreadCounts(service::ResolverParams&& params)
 {
 	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
@@ -109,7 +109,7 @@ service::FieldResult<std::vector<std::shared_ptr<Appointment>>> Query::getAppoin
 	throw std::runtime_error(R"ex(Query::getAppointmentsById is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveAppointmentsById(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveAppointmentsById(service::ResolverParams&& params)
 {
 	const auto defaultArguments = []()
 	{
@@ -146,7 +146,7 @@ service::FieldResult<std::vector<std::shared_ptr<Task>>> Query::getTasksById(ser
 	throw std::runtime_error(R"ex(Query::getTasksById is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveTasksById(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveTasksById(service::ResolverParams&& params)
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -161,7 +161,7 @@ service::FieldResult<std::vector<std::shared_ptr<Folder>>> Query::getUnreadCount
 	throw std::runtime_error(R"ex(Query::getUnreadCountsById is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveUnreadCountsById(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveUnreadCountsById(service::ResolverParams&& params)
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -176,7 +176,7 @@ service::FieldResult<std::shared_ptr<NestedType>> Query::getNested(service::Fiel
 	throw std::runtime_error(R"ex(Query::getNested is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveNested(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -190,7 +190,7 @@ service::FieldResult<response::StringType> Query::getUnimplemented(service::Fiel
 	throw std::runtime_error(R"ex(Query::getUnimplemented is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveUnimplemented(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveUnimplemented(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getUnimplemented(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -204,7 +204,7 @@ service::FieldResult<std::vector<std::shared_ptr<Expensive>>> Query::getExpensiv
 	throw std::runtime_error(R"ex(Query::getExpensive is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveExpensive(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveExpensive(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getExpensive(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -213,7 +213,7 @@ std::future<response::Value> Query::resolveExpensive(service::ResolverParams&& p
 	return service::ModifiedResult<Expensive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Query::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Query)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/QueryObject.cpp
+++ b/samples/separate_nointrospection/QueryObject.cpp
@@ -223,22 +223,22 @@ std::future<service::ResolverResult> Query::resolve_typename(service::ResolverPa
 void AddQueryDetails(std::shared_ptr<schema::ObjectType> typeQuery, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeQuery->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md([Object Identification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#object-identification))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
 			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
 		}), schema->LookupType("Node")),
-		std::make_shared<schema::Field>(R"gql(appointments)gql"sv, R"md(Appointments [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::Field>(R"gql(appointments)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
 			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
 		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("AppointmentConnection"))),
-		std::make_shared<schema::Field>(R"gql(tasks)gql"sv, R"md(Tasks [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::Field>(R"gql(tasks)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
 			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
 		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("TaskConnection"))),
-		std::make_shared<schema::Field>(R"gql(unreadCounts)gql"sv, R"md(Folder unread counts [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::Field>(R"gql(unreadCounts)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
 			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),

--- a/samples/separate_nointrospection/QueryObject.cpp
+++ b/samples/separate_nointrospection/QueryObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/QueryObject.cpp
+++ b/samples/separate_nointrospection/QueryObject.cpp
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+Query::Query()
+	: service::Object({
+		"Query"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(appointments)gql"sv, [this](service::ResolverParams&& params) { return resolveAppointments(std::move(params)); } },
+		{ R"gql(appointmentsById)gql"sv, [this](service::ResolverParams&& params) { return resolveAppointmentsById(std::move(params)); } },
+		{ R"gql(expensive)gql"sv, [this](service::ResolverParams&& params) { return resolveExpensive(std::move(params)); } },
+		{ R"gql(nested)gql"sv, [this](service::ResolverParams&& params) { return resolveNested(std::move(params)); } },
+		{ R"gql(node)gql"sv, [this](service::ResolverParams&& params) { return resolveNode(std::move(params)); } },
+		{ R"gql(tasks)gql"sv, [this](service::ResolverParams&& params) { return resolveTasks(std::move(params)); } },
+		{ R"gql(tasksById)gql"sv, [this](service::ResolverParams&& params) { return resolveTasksById(std::move(params)); } },
+		{ R"gql(unimplemented)gql"sv, [this](service::ResolverParams&& params) { return resolveUnimplemented(std::move(params)); } },
+		{ R"gql(unreadCounts)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCounts(std::move(params)); } },
+		{ R"gql(unreadCountsById)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCountsById(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<service::Object>> Query::getNode(service::FieldParams&&, response::IdType&&) const
+{
+	throw std::runtime_error(R"ex(Query::getNode is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveNode(service::ResolverParams&& params)
+{
+	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argId));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<service::Object>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::shared_ptr<AppointmentConnection>> Query::getAppointments(service::FieldParams&&, std::optional<response::IntType>&&, std::optional<response::Value>&&, std::optional<response::IntType>&&, std::optional<response::Value>&&) const
+{
+	throw std::runtime_error(R"ex(Query::getAppointments is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveAppointments(service::ResolverParams&& params)
+{
+	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
+	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
+	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
+	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getAppointments(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<AppointmentConnection>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::shared_ptr<TaskConnection>> Query::getTasks(service::FieldParams&&, std::optional<response::IntType>&&, std::optional<response::Value>&&, std::optional<response::IntType>&&, std::optional<response::Value>&&) const
+{
+	throw std::runtime_error(R"ex(Query::getTasks is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveTasks(service::ResolverParams&& params)
+{
+	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
+	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
+	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
+	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getTasks(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<TaskConnection>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::shared_ptr<FolderConnection>> Query::getUnreadCounts(service::FieldParams&&, std::optional<response::IntType>&&, std::optional<response::Value>&&, std::optional<response::IntType>&&, std::optional<response::Value>&&) const
+{
+	throw std::runtime_error(R"ex(Query::getUnreadCounts is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveUnreadCounts(service::ResolverParams&& params)
+{
+	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
+	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
+	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
+	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getUnreadCounts(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<FolderConnection>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::vector<std::shared_ptr<Appointment>>> Query::getAppointmentsById(service::FieldParams&&, std::vector<response::IdType>&&) const
+{
+	throw std::runtime_error(R"ex(Query::getAppointmentsById is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveAppointmentsById(service::ResolverParams&& params)
+{
+	const auto defaultArguments = []()
+	{
+		response::Value values(response::Type::Map);
+		response::Value entry;
+
+		entry = []()
+		{
+			response::Value elements(response::Type::List);
+			response::Value entry;
+
+			entry = response::Value(std::string(R"gql(ZmFrZUFwcG9pbnRtZW50SWQ=)gql"));
+			elements.emplace_back(std::move(entry));
+			return elements;
+		}();
+		values.emplace_back("ids", std::move(entry));
+
+		return values;
+	}();
+
+	auto pairIds = service::ModifiedArgument<response::IdType>::find<service::TypeModifier::List>("ids", params.arguments);
+	auto argIds = (pairIds.second
+		? std::move(pairIds.first)
+		: service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", defaultArguments));
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getAppointmentsById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::vector<std::shared_ptr<Task>>> Query::getTasksById(service::FieldParams&&, std::vector<response::IdType>&&) const
+{
+	throw std::runtime_error(R"ex(Query::getTasksById is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveTasksById(service::ResolverParams&& params)
+{
+	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getTasksById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Task>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::vector<std::shared_ptr<Folder>>> Query::getUnreadCountsById(service::FieldParams&&, std::vector<response::IdType>&&) const
+{
+	throw std::runtime_error(R"ex(Query::getUnreadCountsById is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveUnreadCountsById(service::ResolverParams&& params)
+{
+	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getUnreadCountsById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Folder>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::shared_ptr<NestedType>> Query::getNested(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Query::getNested is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveNested(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::StringType> Query::getUnimplemented(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Query::getUnimplemented is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveUnimplemented(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getUnimplemented(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::vector<std::shared_ptr<Expensive>>> Query::getExpensive(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Query::getExpensive is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveExpensive(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getExpensive(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Expensive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Query::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Query)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/QueryObject.cpp
+++ b/samples/separate_nointrospection/QueryObject.cpp
@@ -32,10 +32,7 @@ Query::Query()
 		{ R"gql(unreadCounts)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCounts(std::move(params)); } },
 		{ R"gql(unreadCountsById)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCountsById(std::move(params)); } }
 	})
-	, _schema(std::make_shared<schema::Schema>())
 {
-	introspection::AddTypesToSchema(_schema);
-	today::AddTypesToSchema(_schema);
 }
 
 service::FieldResult<std::shared_ptr<service::Object>> Query::getNode(service::FieldParams&&, response::IdType&&) const

--- a/samples/separate_nointrospection/QueryObject.cpp
+++ b/samples/separate_nointrospection/QueryObject.cpp
@@ -223,39 +223,39 @@ std::future<service::ResolverResult> Query::resolve_typename(service::ResolverPa
 void AddQueryDetails(std::shared_ptr<schema::ObjectType> typeQuery, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeQuery->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
-		}), schema->LookupType("Node")),
-		std::make_shared<schema::Field>(R"gql(appointments)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("AppointmentConnection"))),
-		std::make_shared<schema::Field>(R"gql(tasks)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("TaskConnection"))),
-		std::make_shared<schema::Field>(R"gql(unreadCounts)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("FolderConnection"))),
-		std::make_shared<schema::Field>(R"gql(appointmentsById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql(["ZmFrZUFwcG9pbnRtZW50SWQ="])gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Appointment")))),
-		std::make_shared<schema::Field>(R"gql(tasksById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Task")))),
-		std::make_shared<schema::Field>(R"gql(unreadCountsById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Folder")))),
-		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType"))),
-		std::make_shared<schema::Field>(R"gql(unimplemented)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<schema::Field>(R"gql(expensive)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Expensive")))))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Node"), {
+			schema::InputValue::Make(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(appointments)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("AppointmentConnection")), {
+			schema::InputValue::Make(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(tasks)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("TaskConnection")), {
+			schema::InputValue::Make(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(unreadCounts)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("FolderConnection")), {
+			schema::InputValue::Make(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(appointmentsById)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Appointment"))), {
+			schema::InputValue::Make(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql(["ZmFrZUFwcG9pbnRtZW50SWQ="])gql"sv)
+		}),
+		schema::Field::Make(R"gql(tasksById)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Task"))), {
+			schema::InputValue::Make(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(unreadCountsById)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Folder"))), {
+			schema::InputValue::Make(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType"))),
+		schema::Field::Make(R"gql(unimplemented)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		schema::Field::Make(R"gql(expensive)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Expensive")))))
 	});
 }
 

--- a/samples/separate_nointrospection/QueryObject.h
+++ b/samples/separate_nointrospection/QueryObject.h
@@ -29,18 +29,18 @@ public:
 	virtual service::FieldResult<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveAppointments(service::ResolverParams&& params);
-	std::future<response::Value> resolveTasks(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnreadCounts(service::ResolverParams&& params);
-	std::future<response::Value> resolveAppointmentsById(service::ResolverParams&& params);
-	std::future<response::Value> resolveTasksById(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnreadCountsById(service::ResolverParams&& params);
-	std::future<response::Value> resolveNested(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnimplemented(service::ResolverParams&& params);
-	std::future<response::Value> resolveExpensive(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveAppointments(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTasks(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnreadCounts(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveAppointmentsById(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTasksById(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnreadCountsById(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNested(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnimplemented(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveExpensive(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/QueryObject.h
+++ b/samples/separate_nointrospection/QueryObject.h
@@ -41,8 +41,6 @@ private:
 	std::future<response::Value> resolveExpensive(service::ResolverParams&& params);
 
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
-
-	std::shared_ptr<schema::Schema> _schema;
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/QueryObject.h
+++ b/samples/separate_nointrospection/QueryObject.h
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef QUERYOBJECT_H
+#define QUERYOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class Query
+	: public service::Object
+{
+protected:
+	explicit Query();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<service::Object>> getNode(service::FieldParams&& params, response::IdType&& idArg) const;
+	virtual service::FieldResult<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<response::IntType>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<response::IntType>&& lastArg, std::optional<response::Value>&& beforeArg) const;
+	virtual service::FieldResult<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<response::IntType>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<response::IntType>&& lastArg, std::optional<response::Value>&& beforeArg) const;
+	virtual service::FieldResult<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<response::IntType>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<response::IntType>&& lastArg, std::optional<response::Value>&& beforeArg) const;
+	virtual service::FieldResult<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const;
+	virtual service::FieldResult<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const;
+	virtual service::FieldResult<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const;
+	virtual service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::StringType> getUnimplemented(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveNode(service::ResolverParams&& params);
+	std::future<response::Value> resolveAppointments(service::ResolverParams&& params);
+	std::future<response::Value> resolveTasks(service::ResolverParams&& params);
+	std::future<response::Value> resolveUnreadCounts(service::ResolverParams&& params);
+	std::future<response::Value> resolveAppointmentsById(service::ResolverParams&& params);
+	std::future<response::Value> resolveTasksById(service::ResolverParams&& params);
+	std::future<response::Value> resolveUnreadCountsById(service::ResolverParams&& params);
+	std::future<response::Value> resolveNested(service::ResolverParams&& params);
+	std::future<response::Value> resolveUnimplemented(service::ResolverParams&& params);
+	std::future<response::Value> resolveExpensive(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // QUERYOBJECT_H

--- a/samples/separate_nointrospection/QueryObject.h
+++ b/samples/separate_nointrospection/QueryObject.h
@@ -41,6 +41,8 @@ private:
 	std::future<response::Value> resolveExpensive(service::ResolverParams&& params);
 
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+
+	std::shared_ptr<schema::Schema> _schema;
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/SubscriptionObject.cpp
+++ b/samples/separate_nointrospection/SubscriptionObject.cpp
@@ -66,10 +66,10 @@ std::future<service::ResolverResult> Subscription::resolve_typename(service::Res
 void AddSubscriptionDetails(std::shared_ptr<schema::ObjectType> typeSubscription, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeSubscription->AddFields({
-		std::make_shared<schema::Field>(R"gql(nextAppointmentChange)gql"sv, R"md()md"sv, std::make_optional(R"md(Need to deprecate a [field](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md"sv), std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Appointment")),
-		std::make_shared<schema::Field>(R"gql(nodeChange)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Node")))
+		schema::Field::Make(R"gql(nextAppointmentChange)gql"sv, R"md()md"sv, std::make_optional(R"md(Need to deprecate a [field](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md"sv), schema->LookupType("Appointment")),
+		schema::Field::Make(R"gql(nodeChange)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Node")), {
+			schema::InputValue::Make(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
+		})
 	});
 }
 

--- a/samples/separate_nointrospection/SubscriptionObject.cpp
+++ b/samples/separate_nointrospection/SubscriptionObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/SubscriptionObject.cpp
+++ b/samples/separate_nointrospection/SubscriptionObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<Appointment>> Subscription::getNextAppointm
 	throw std::runtime_error(R"ex(Subscription::getNextAppointmentChange is not implemented)ex");
 }
 
-std::future<response::Value> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNextAppointmentChange(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<std::shared_ptr<service::Object>> Subscription::getNodeChan
 	throw std::runtime_error(R"ex(Subscription::getNodeChange is not implemented)ex");
 }
 
-std::future<response::Value> Subscription::resolveNodeChange(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolveNodeChange(service::ResolverParams&& params)
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -56,7 +56,7 @@ std::future<response::Value> Subscription::resolveNodeChange(service::ResolverPa
 	return service::ModifiedResult<service::Object>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Subscription::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Subscription)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/SubscriptionObject.cpp
+++ b/samples/separate_nointrospection/SubscriptionObject.cpp
@@ -63,4 +63,14 @@ std::future<response::Value> Subscription::resolve_typename(service::ResolverPar
 
 } /* namespace object */
 
+void AddSubscriptionDetails(std::shared_ptr<schema::ObjectType> typeSubscription, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeSubscription->AddFields({
+		std::make_shared<schema::Field>(R"gql(nextAppointmentChange)gql"sv, R"md()md"sv, std::make_optional(R"md(Need to deprecate a [field](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md"sv), std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Appointment")),
+		std::make_shared<schema::Field>(R"gql(nodeChange)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
+		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Node")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/SubscriptionObject.cpp
+++ b/samples/separate_nointrospection/SubscriptionObject.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+Subscription::Subscription()
+	: service::Object({
+		"Subscription"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(nextAppointmentChange)gql"sv, [this](service::ResolverParams&& params) { return resolveNextAppointmentChange(std::move(params)); } },
+		{ R"gql(nodeChange)gql"sv, [this](service::ResolverParams&& params) { return resolveNodeChange(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<Appointment>> Subscription::getNextAppointmentChange(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Subscription::getNextAppointmentChange is not implemented)ex");
+}
+
+std::future<response::Value> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNextAppointmentChange(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::shared_ptr<service::Object>> Subscription::getNodeChange(service::FieldParams&&, response::IdType&&) const
+{
+	throw std::runtime_error(R"ex(Subscription::getNodeChange is not implemented)ex");
+}
+
+std::future<response::Value> Subscription::resolveNodeChange(service::ResolverParams&& params)
+{
+	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNodeChange(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argId));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<service::Object>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Subscription::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Subscription)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/SubscriptionObject.h
+++ b/samples/separate_nointrospection/SubscriptionObject.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef SUBSCRIPTIONOBJECT_H
+#define SUBSCRIPTIONOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class Subscription
+	: public service::Object
+{
+protected:
+	explicit Subscription();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::shared_ptr<service::Object>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const;
+
+private:
+	std::future<response::Value> resolveNextAppointmentChange(service::ResolverParams&& params);
+	std::future<response::Value> resolveNodeChange(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // SUBSCRIPTIONOBJECT_H

--- a/samples/separate_nointrospection/SubscriptionObject.h
+++ b/samples/separate_nointrospection/SubscriptionObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<std::shared_ptr<service::Object>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const;
 
 private:
-	std::future<response::Value> resolveNextAppointmentChange(service::ResolverParams&& params);
-	std::future<response::Value> resolveNodeChange(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNextAppointmentChange(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNodeChange(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/TaskConnectionObject.cpp
+++ b/samples/separate_nointrospection/TaskConnectionObject.cpp
@@ -62,4 +62,12 @@ std::future<response::Value> TaskConnection::resolve_typename(service::ResolverP
 
 } /* namespace object */
 
+void AddTaskConnectionDetails(std::shared_ptr<schema::ObjectType> typeTaskConnection, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeTaskConnection->AddFields({
+		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("TaskEdge")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/TaskConnectionObject.cpp
+++ b/samples/separate_nointrospection/TaskConnectionObject.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+TaskConnection::TaskConnection()
+	: service::Object({
+		"TaskConnection"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(edges)gql"sv, [this](service::ResolverParams&& params) { return resolveEdges(std::move(params)); } },
+		{ R"gql(pageInfo)gql"sv, [this](service::ResolverParams&& params) { return resolvePageInfo(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<PageInfo>> TaskConnection::getPageInfo(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(TaskConnection::getPageInfo is not implemented)ex");
+}
+
+std::future<response::Value> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> TaskConnection::getEdges(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(TaskConnection::getEdges is not implemented)ex");
+}
+
+std::future<response::Value> TaskConnection::resolveEdges(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<TaskEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+std::future<response::Value> TaskConnection::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(TaskConnection)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/TaskConnectionObject.cpp
+++ b/samples/separate_nointrospection/TaskConnectionObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/TaskConnectionObject.cpp
+++ b/samples/separate_nointrospection/TaskConnectionObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<PageInfo>> TaskConnection::getPageInfo(serv
 	throw std::runtime_error(R"ex(TaskConnection::getPageInfo is not implemented)ex");
 }
 
-std::future<response::Value> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> Task
 	throw std::runtime_error(R"ex(TaskConnection::getEdges is not implemented)ex");
 }
 
-std::future<response::Value> TaskConnection::resolveEdges(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> TaskConnection::resolveEdges(service::ResolverParam
 	return service::ModifiedResult<TaskEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> TaskConnection::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskConnection::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(TaskConnection)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/TaskConnectionObject.cpp
+++ b/samples/separate_nointrospection/TaskConnectionObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> TaskConnection::resolve_typename(service::R
 void AddTaskConnectionDetails(std::shared_ptr<schema::ObjectType> typeTaskConnection, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeTaskConnection->AddFields({
-		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("TaskEdge")))
+		schema::Field::Make(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		schema::Field::Make(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("TaskEdge")))
 	});
 }
 

--- a/samples/separate_nointrospection/TaskConnectionObject.h
+++ b/samples/separate_nointrospection/TaskConnectionObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePageInfo(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveEdges(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/TaskConnectionObject.h
+++ b/samples/separate_nointrospection/TaskConnectionObject.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef TASKCONNECTIONOBJECT_H
+#define TASKCONNECTIONOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class TaskConnection
+	: public service::Object
+{
+protected:
+	explicit TaskConnection();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
+	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // TASKCONNECTIONOBJECT_H

--- a/samples/separate_nointrospection/TaskEdgeObject.cpp
+++ b/samples/separate_nointrospection/TaskEdgeObject.cpp
@@ -62,4 +62,12 @@ std::future<response::Value> TaskEdge::resolve_typename(service::ResolverParams&
 
 } /* namespace object */
 
+void AddTaskEdgeDetails(std::shared_ptr<schema::ObjectType> typeTaskEdge, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeTaskEdge->AddFields({
+		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Task")),
+		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/TaskEdgeObject.cpp
+++ b/samples/separate_nointrospection/TaskEdgeObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/TaskEdgeObject.cpp
+++ b/samples/separate_nointrospection/TaskEdgeObject.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+TaskEdge::TaskEdge()
+	: service::Object({
+		"TaskEdge"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(cursor)gql"sv, [this](service::ResolverParams&& params) { return resolveCursor(std::move(params)); } },
+		{ R"gql(node)gql"sv, [this](service::ResolverParams&& params) { return resolveNode(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<Task>> TaskEdge::getNode(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(TaskEdge::getNode is not implemented)ex");
+}
+
+std::future<response::Value> TaskEdge::resolveNode(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::Value> TaskEdge::getCursor(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(TaskEdge::getCursor is not implemented)ex");
+}
+
+std::future<response::Value> TaskEdge::resolveCursor(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> TaskEdge::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(TaskEdge)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/TaskEdgeObject.cpp
+++ b/samples/separate_nointrospection/TaskEdgeObject.cpp
@@ -65,8 +65,8 @@ std::future<service::ResolverResult> TaskEdge::resolve_typename(service::Resolve
 void AddTaskEdgeDetails(std::shared_ptr<schema::ObjectType> typeTaskEdge, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeTaskEdge->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Task")),
-		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Task")),
+		schema::Field::Make(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 }
 

--- a/samples/separate_nointrospection/TaskEdgeObject.cpp
+++ b/samples/separate_nointrospection/TaskEdgeObject.cpp
@@ -32,7 +32,7 @@ service::FieldResult<std::shared_ptr<Task>> TaskEdge::getNode(service::FieldPara
 	throw std::runtime_error(R"ex(TaskEdge::getNode is not implemented)ex");
 }
 
-std::future<response::Value> TaskEdge::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -46,7 +46,7 @@ service::FieldResult<response::Value> TaskEdge::getCursor(service::FieldParams&&
 	throw std::runtime_error(R"ex(TaskEdge::getCursor is not implemented)ex");
 }
 
-std::future<response::Value> TaskEdge::resolveCursor(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -55,7 +55,7 @@ std::future<response::Value> TaskEdge::resolveCursor(service::ResolverParams&& p
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> TaskEdge::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskEdge::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(TaskEdge)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/TaskEdgeObject.h
+++ b/samples/separate_nointrospection/TaskEdgeObject.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef TASKEDGEOBJECT_H
+#define TASKEDGEOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class TaskEdge
+	: public service::Object
+{
+protected:
+	explicit TaskEdge();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveNode(service::ResolverParams&& params);
+	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // TASKEDGEOBJECT_H

--- a/samples/separate_nointrospection/TaskEdgeObject.h
+++ b/samples/separate_nointrospection/TaskEdgeObject.h
@@ -21,10 +21,10 @@ public:
 	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCursor(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/TaskObject.cpp
+++ b/samples/separate_nointrospection/TaskObject.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using namespace std::literals;
+
+namespace graphql::today {
+namespace object {
+
+Task::Task()
+	: service::Object({
+		"Node",
+		"UnionType",
+		"Task"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(id)gql"sv, [this](service::ResolverParams&& params) { return resolveId(std::move(params)); } },
+		{ R"gql(isComplete)gql"sv, [this](service::ResolverParams&& params) { return resolveIsComplete(std::move(params)); } },
+		{ R"gql(title)gql"sv, [this](service::ResolverParams&& params) { return resolveTitle(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<response::IdType> Task::getId(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Task::getId is not implemented)ex");
+}
+
+std::future<response::Value> Task::resolveId(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<response::StringType>> Task::getTitle(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Task::getTitle is not implemented)ex");
+}
+
+std::future<response::Value> Task::resolveTitle(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getTitle(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::BooleanType> Task::getIsComplete(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Task::getIsComplete is not implemented)ex");
+}
+
+std::future<response::Value> Task::resolveIsComplete(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getIsComplete(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Task::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Task)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+} /* namespace graphql::today */

--- a/samples/separate_nointrospection/TaskObject.cpp
+++ b/samples/separate_nointrospection/TaskObject.cpp
@@ -79,4 +79,16 @@ std::future<response::Value> Task::resolve_typename(service::ResolverParams&& pa
 
 } /* namespace object */
 
+void AddTaskDetails(std::shared_ptr<schema::ObjectType> typeTask, const std::shared_ptr<schema::Schema>& schema)
+{
+	typeTask->AddInterfaces({
+		std::static_pointer_cast<schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
+	});
+	typeTask->AddFields({
+		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		std::make_shared<schema::Field>(R"gql(title)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
+		std::make_shared<schema::Field>(R"gql(isComplete)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+	});
+}
+
 } /* namespace graphql::today */

--- a/samples/separate_nointrospection/TaskObject.cpp
+++ b/samples/separate_nointrospection/TaskObject.cpp
@@ -82,12 +82,12 @@ std::future<service::ResolverResult> Task::resolve_typename(service::ResolverPar
 void AddTaskDetails(std::shared_ptr<schema::ObjectType> typeTask, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeTask->AddInterfaces({
-		std::static_pointer_cast<schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
+		std::static_pointer_cast<const schema::InterfaceType>(schema->LookupType(R"gql(Node)gql"sv))
 	});
 	typeTask->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<schema::Field>(R"gql(title)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(isComplete)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		schema::Field::Make(R"gql(title)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(isComplete)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
 	});
 }
 

--- a/samples/separate_nointrospection/TaskObject.cpp
+++ b/samples/separate_nointrospection/TaskObject.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <functional>

--- a/samples/separate_nointrospection/TaskObject.cpp
+++ b/samples/separate_nointrospection/TaskObject.cpp
@@ -35,7 +35,7 @@ service::FieldResult<response::IdType> Task::getId(service::FieldParams&&) const
 	throw std::runtime_error(R"ex(Task::getId is not implemented)ex");
 }
 
-std::future<response::Value> Task::resolveId(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -49,7 +49,7 @@ service::FieldResult<std::optional<response::StringType>> Task::getTitle(service
 	throw std::runtime_error(R"ex(Task::getTitle is not implemented)ex");
 }
 
-std::future<response::Value> Task::resolveTitle(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolveTitle(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getTitle(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -63,7 +63,7 @@ service::FieldResult<response::BooleanType> Task::getIsComplete(service::FieldPa
 	throw std::runtime_error(R"ex(Task::getIsComplete is not implemented)ex");
 }
 
-std::future<response::Value> Task::resolveIsComplete(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolveIsComplete(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getIsComplete(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -72,7 +72,7 @@ std::future<response::Value> Task::resolveIsComplete(service::ResolverParams&& p
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Task::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Task)gql" }, std::move(params));
 }

--- a/samples/separate_nointrospection/TaskObject.h
+++ b/samples/separate_nointrospection/TaskObject.h
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef TASKOBJECT_H
+#define TASKOBJECT_H
+
+#include "TodaySchema.h"
+
+namespace graphql::today::object {
+
+class Task
+	: public service::Object
+	, public Node
+{
+protected:
+	explicit Task();
+
+public:
+	virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const override;
+	virtual service::FieldResult<std::optional<response::StringType>> getTitle(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::BooleanType> getIsComplete(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveId(service::ResolverParams&& params);
+	std::future<response::Value> resolveTitle(service::ResolverParams&& params);
+	std::future<response::Value> resolveIsComplete(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace graphql::today::object */
+
+#endif // TASKOBJECT_H

--- a/samples/separate_nointrospection/TaskObject.h
+++ b/samples/separate_nointrospection/TaskObject.h
@@ -23,11 +23,11 @@ public:
 	virtual service::FieldResult<response::BooleanType> getIsComplete(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveId(service::ResolverParams&& params);
-	std::future<response::Value> resolveTitle(service::ResolverParams&& params);
-	std::future<response::Value> resolveIsComplete(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTitle(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveIsComplete(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace graphql::today::object */

--- a/samples/separate_nointrospection/TodayObjects.h
+++ b/samples/separate_nointrospection/TodayObjects.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef TODAYOBJECTS_H
+#define TODAYOBJECTS_H
+
+#include "TodaySchema.h"
+
+#include "QueryObject.h"
+#include "PageInfoObject.h"
+#include "AppointmentEdgeObject.h"
+#include "AppointmentConnectionObject.h"
+#include "TaskEdgeObject.h"
+#include "TaskConnectionObject.h"
+#include "FolderEdgeObject.h"
+#include "FolderConnectionObject.h"
+#include "CompleteTaskPayloadObject.h"
+#include "MutationObject.h"
+#include "SubscriptionObject.h"
+#include "AppointmentObject.h"
+#include "TaskObject.h"
+#include "FolderObject.h"
+#include "NestedTypeObject.h"
+#include "ExpensiveObject.h"
+
+#endif // TODAYOBJECTS_H

--- a/samples/separate_nointrospection/TodaySchema.cpp
+++ b/samples/separate_nointrospection/TodaySchema.cpp
@@ -104,47 +104,47 @@ Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<obj
 
 void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 {
-	schema->AddType(R"gql(ItemCursor)gql"sv, std::make_shared<schema::ScalarType>(R"gql(ItemCursor)gql"sv, R"md()md"));
-	schema->AddType(R"gql(DateTime)gql"sv, std::make_shared<schema::ScalarType>(R"gql(DateTime)gql"sv, R"md()md"));
-	auto typeTaskState = std::make_shared<schema::EnumType>(R"gql(TaskState)gql"sv, R"md()md"sv);
+	schema->AddType(R"gql(ItemCursor)gql"sv, schema::ScalarType::Make(R"gql(ItemCursor)gql"sv, R"md()md"));
+	schema->AddType(R"gql(DateTime)gql"sv, schema::ScalarType::Make(R"gql(DateTime)gql"sv, R"md()md"));
+	auto typeTaskState = schema::EnumType::Make(R"gql(TaskState)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(TaskState)gql"sv, typeTaskState);
-	auto typeCompleteTaskInput = std::make_shared<schema::InputObjectType>(R"gql(CompleteTaskInput)gql"sv, R"md()md"sv);
+	auto typeCompleteTaskInput = schema::InputObjectType::Make(R"gql(CompleteTaskInput)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(CompleteTaskInput)gql"sv, typeCompleteTaskInput);
-	auto typeUnionType = std::make_shared<schema::UnionType>(R"gql(UnionType)gql"sv, R"md()md"sv);
+	auto typeUnionType = schema::UnionType::Make(R"gql(UnionType)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(UnionType)gql"sv, typeUnionType);
-	auto typeNode = std::make_shared<schema::InterfaceType>(R"gql(Node)gql"sv, R"md()md"sv);
+	auto typeNode = schema::InterfaceType::Make(R"gql(Node)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(Node)gql"sv, typeNode);
-	auto typeQuery = std::make_shared<schema::ObjectType>(R"gql(Query)gql"sv, R"md()md");
+	auto typeQuery = schema::ObjectType::Make(R"gql(Query)gql"sv, R"md()md");
 	schema->AddType(R"gql(Query)gql"sv, typeQuery);
-	auto typePageInfo = std::make_shared<schema::ObjectType>(R"gql(PageInfo)gql"sv, R"md()md");
+	auto typePageInfo = schema::ObjectType::Make(R"gql(PageInfo)gql"sv, R"md()md");
 	schema->AddType(R"gql(PageInfo)gql"sv, typePageInfo);
-	auto typeAppointmentEdge = std::make_shared<schema::ObjectType>(R"gql(AppointmentEdge)gql"sv, R"md()md");
+	auto typeAppointmentEdge = schema::ObjectType::Make(R"gql(AppointmentEdge)gql"sv, R"md()md");
 	schema->AddType(R"gql(AppointmentEdge)gql"sv, typeAppointmentEdge);
-	auto typeAppointmentConnection = std::make_shared<schema::ObjectType>(R"gql(AppointmentConnection)gql"sv, R"md()md");
+	auto typeAppointmentConnection = schema::ObjectType::Make(R"gql(AppointmentConnection)gql"sv, R"md()md");
 	schema->AddType(R"gql(AppointmentConnection)gql"sv, typeAppointmentConnection);
-	auto typeTaskEdge = std::make_shared<schema::ObjectType>(R"gql(TaskEdge)gql"sv, R"md()md");
+	auto typeTaskEdge = schema::ObjectType::Make(R"gql(TaskEdge)gql"sv, R"md()md");
 	schema->AddType(R"gql(TaskEdge)gql"sv, typeTaskEdge);
-	auto typeTaskConnection = std::make_shared<schema::ObjectType>(R"gql(TaskConnection)gql"sv, R"md()md");
+	auto typeTaskConnection = schema::ObjectType::Make(R"gql(TaskConnection)gql"sv, R"md()md");
 	schema->AddType(R"gql(TaskConnection)gql"sv, typeTaskConnection);
-	auto typeFolderEdge = std::make_shared<schema::ObjectType>(R"gql(FolderEdge)gql"sv, R"md()md");
+	auto typeFolderEdge = schema::ObjectType::Make(R"gql(FolderEdge)gql"sv, R"md()md");
 	schema->AddType(R"gql(FolderEdge)gql"sv, typeFolderEdge);
-	auto typeFolderConnection = std::make_shared<schema::ObjectType>(R"gql(FolderConnection)gql"sv, R"md()md");
+	auto typeFolderConnection = schema::ObjectType::Make(R"gql(FolderConnection)gql"sv, R"md()md");
 	schema->AddType(R"gql(FolderConnection)gql"sv, typeFolderConnection);
-	auto typeCompleteTaskPayload = std::make_shared<schema::ObjectType>(R"gql(CompleteTaskPayload)gql"sv, R"md()md");
+	auto typeCompleteTaskPayload = schema::ObjectType::Make(R"gql(CompleteTaskPayload)gql"sv, R"md()md");
 	schema->AddType(R"gql(CompleteTaskPayload)gql"sv, typeCompleteTaskPayload);
-	auto typeMutation = std::make_shared<schema::ObjectType>(R"gql(Mutation)gql"sv, R"md()md");
+	auto typeMutation = schema::ObjectType::Make(R"gql(Mutation)gql"sv, R"md()md");
 	schema->AddType(R"gql(Mutation)gql"sv, typeMutation);
-	auto typeSubscription = std::make_shared<schema::ObjectType>(R"gql(Subscription)gql"sv, R"md()md");
+	auto typeSubscription = schema::ObjectType::Make(R"gql(Subscription)gql"sv, R"md()md");
 	schema->AddType(R"gql(Subscription)gql"sv, typeSubscription);
-	auto typeAppointment = std::make_shared<schema::ObjectType>(R"gql(Appointment)gql"sv, R"md()md");
+	auto typeAppointment = schema::ObjectType::Make(R"gql(Appointment)gql"sv, R"md()md");
 	schema->AddType(R"gql(Appointment)gql"sv, typeAppointment);
-	auto typeTask = std::make_shared<schema::ObjectType>(R"gql(Task)gql"sv, R"md()md");
+	auto typeTask = schema::ObjectType::Make(R"gql(Task)gql"sv, R"md()md");
 	schema->AddType(R"gql(Task)gql"sv, typeTask);
-	auto typeFolder = std::make_shared<schema::ObjectType>(R"gql(Folder)gql"sv, R"md()md");
+	auto typeFolder = schema::ObjectType::Make(R"gql(Folder)gql"sv, R"md()md");
 	schema->AddType(R"gql(Folder)gql"sv, typeFolder);
-	auto typeNestedType = std::make_shared<schema::ObjectType>(R"gql(NestedType)gql"sv, R"md()md");
+	auto typeNestedType = schema::ObjectType::Make(R"gql(NestedType)gql"sv, R"md()md");
 	schema->AddType(R"gql(NestedType)gql"sv, typeNestedType);
-	auto typeExpensive = std::make_shared<schema::ObjectType>(R"gql(Expensive)gql"sv, R"md()md");
+	auto typeExpensive = schema::ObjectType::Make(R"gql(Expensive)gql"sv, R"md()md");
 	schema->AddType(R"gql(Expensive)gql"sv, typeExpensive);
 
 	typeTaskState->AddEnumValues({
@@ -155,9 +155,9 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	});
 
 	typeCompleteTaskInput->AddInputValues({
-		std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv),
-		std::make_shared<schema::InputValue>(R"gql(isComplete)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(true)gql"sv),
-		std::make_shared<schema::InputValue>(R"gql(clientMutationId)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
+		schema::InputValue::Make(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv),
+		schema::InputValue::Make(R"gql(isComplete)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(true)gql"sv),
+		schema::InputValue::Make(R"gql(clientMutationId)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
 	});
 
 	typeUnionType->AddPossibleTypes({
@@ -167,7 +167,7 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	});
 
 	typeNode->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
 	});
 
 	AddQueryDetails(typeQuery, schema);
@@ -187,39 +187,39 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	AddNestedTypeDetails(typeNestedType, schema);
 	AddExpensiveDetails(typeExpensive, schema);
 
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(id)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	schema->AddDirective(schema::Directive::Make(R"gql(id)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FIELD_DEFINITION
-	}), std::vector<std::shared_ptr<schema::InputValue>>()));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(subscriptionTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(subscriptionTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::SUBSCRIPTION
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(field)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(queryTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(field)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(queryTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::QUERY
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(query)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fieldTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(query)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(fieldTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FIELD
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(field)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fragmentDefinitionTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(field)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(fragmentDefinitionTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FRAGMENT_DEFINITION
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(fragmentDefinition)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fragmentSpreadTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(fragmentDefinition)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(fragmentSpreadTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FRAGMENT_SPREAD
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(fragmentSpread)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(inlineFragmentTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(fragmentSpread)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(inlineFragmentTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::INLINE_FRAGMENT
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(inlineFragment)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
+	}, {
+		schema::InputValue::Make(R"gql(inlineFragment)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
 
 	schema->AddQueryType(typeQuery);
 	schema->AddMutationType(typeMutation);

--- a/samples/separate_nointrospection/TodaySchema.cpp
+++ b/samples/separate_nointrospection/TodaySchema.cpp
@@ -95,11 +95,135 @@ Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<obj
 		{ "query", query },
 		{ "mutation", mutation },
 		{ "subscription", subscription }
-	})
+	}, nullptr)
 	, _query(std::move(query))
 	, _mutation(std::move(mutation))
 	, _subscription(std::move(subscription))
 {
+}
+
+void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
+{
+	schema->AddType(R"gql(ItemCursor)gql"sv, std::make_shared<schema::ScalarType>(R"gql(ItemCursor)gql"sv, R"md()md"));
+	schema->AddType(R"gql(DateTime)gql"sv, std::make_shared<schema::ScalarType>(R"gql(DateTime)gql"sv, R"md()md"));
+	auto typeTaskState = std::make_shared<schema::EnumType>(R"gql(TaskState)gql"sv, R"md()md"sv);
+	schema->AddType(R"gql(TaskState)gql"sv, typeTaskState);
+	auto typeCompleteTaskInput = std::make_shared<schema::InputObjectType>(R"gql(CompleteTaskInput)gql"sv, R"md()md"sv);
+	schema->AddType(R"gql(CompleteTaskInput)gql"sv, typeCompleteTaskInput);
+	auto typeUnionType = std::make_shared<schema::UnionType>(R"gql(UnionType)gql"sv, R"md()md"sv);
+	schema->AddType(R"gql(UnionType)gql"sv, typeUnionType);
+	auto typeNode = std::make_shared<schema::InterfaceType>(R"gql(Node)gql"sv, R"md(Node interface for Relay support)md"sv);
+	schema->AddType(R"gql(Node)gql"sv, typeNode);
+	auto typeQuery = std::make_shared<schema::ObjectType>(R"gql(Query)gql"sv, R"md(Root Query type)md");
+	schema->AddType(R"gql(Query)gql"sv, typeQuery);
+	auto typePageInfo = std::make_shared<schema::ObjectType>(R"gql(PageInfo)gql"sv, R"md()md");
+	schema->AddType(R"gql(PageInfo)gql"sv, typePageInfo);
+	auto typeAppointmentEdge = std::make_shared<schema::ObjectType>(R"gql(AppointmentEdge)gql"sv, R"md()md");
+	schema->AddType(R"gql(AppointmentEdge)gql"sv, typeAppointmentEdge);
+	auto typeAppointmentConnection = std::make_shared<schema::ObjectType>(R"gql(AppointmentConnection)gql"sv, R"md()md");
+	schema->AddType(R"gql(AppointmentConnection)gql"sv, typeAppointmentConnection);
+	auto typeTaskEdge = std::make_shared<schema::ObjectType>(R"gql(TaskEdge)gql"sv, R"md()md");
+	schema->AddType(R"gql(TaskEdge)gql"sv, typeTaskEdge);
+	auto typeTaskConnection = std::make_shared<schema::ObjectType>(R"gql(TaskConnection)gql"sv, R"md()md");
+	schema->AddType(R"gql(TaskConnection)gql"sv, typeTaskConnection);
+	auto typeFolderEdge = std::make_shared<schema::ObjectType>(R"gql(FolderEdge)gql"sv, R"md()md");
+	schema->AddType(R"gql(FolderEdge)gql"sv, typeFolderEdge);
+	auto typeFolderConnection = std::make_shared<schema::ObjectType>(R"gql(FolderConnection)gql"sv, R"md()md");
+	schema->AddType(R"gql(FolderConnection)gql"sv, typeFolderConnection);
+	auto typeCompleteTaskPayload = std::make_shared<schema::ObjectType>(R"gql(CompleteTaskPayload)gql"sv, R"md()md");
+	schema->AddType(R"gql(CompleteTaskPayload)gql"sv, typeCompleteTaskPayload);
+	auto typeMutation = std::make_shared<schema::ObjectType>(R"gql(Mutation)gql"sv, R"md()md");
+	schema->AddType(R"gql(Mutation)gql"sv, typeMutation);
+	auto typeSubscription = std::make_shared<schema::ObjectType>(R"gql(Subscription)gql"sv, R"md()md");
+	schema->AddType(R"gql(Subscription)gql"sv, typeSubscription);
+	auto typeAppointment = std::make_shared<schema::ObjectType>(R"gql(Appointment)gql"sv, R"md()md");
+	schema->AddType(R"gql(Appointment)gql"sv, typeAppointment);
+	auto typeTask = std::make_shared<schema::ObjectType>(R"gql(Task)gql"sv, R"md()md");
+	schema->AddType(R"gql(Task)gql"sv, typeTask);
+	auto typeFolder = std::make_shared<schema::ObjectType>(R"gql(Folder)gql"sv, R"md()md");
+	schema->AddType(R"gql(Folder)gql"sv, typeFolder);
+	auto typeNestedType = std::make_shared<schema::ObjectType>(R"gql(NestedType)gql"sv, R"md(Infinitely nestable type which can be used with nested fragments to test directive handling)md");
+	schema->AddType(R"gql(NestedType)gql"sv, typeNestedType);
+	auto typeExpensive = std::make_shared<schema::ObjectType>(R"gql(Expensive)gql"sv, R"md()md");
+	schema->AddType(R"gql(Expensive)gql"sv, typeExpensive);
+
+	typeTaskState->AddEnumValues({
+		{ service::s_namesTaskState[static_cast<size_t>(today::TaskState::New)], R"md()md"sv, std::nullopt },
+		{ service::s_namesTaskState[static_cast<size_t>(today::TaskState::Started)], R"md()md"sv, std::nullopt },
+		{ service::s_namesTaskState[static_cast<size_t>(today::TaskState::Complete)], R"md()md"sv, std::nullopt },
+		{ service::s_namesTaskState[static_cast<size_t>(today::TaskState::Unassigned)], R"md()md"sv, std::make_optional(R"md(Need to deprecate an [enum value](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md"sv) }
+	});
+
+	typeCompleteTaskInput->AddInputValues({
+		std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv),
+		std::make_shared<schema::InputValue>(R"gql(isComplete)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(true)gql"sv),
+		std::make_shared<schema::InputValue>(R"gql(clientMutationId)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
+	});
+
+	typeUnionType->AddPossibleTypes({
+		schema->LookupType(R"gql(Appointment)gql"sv),
+		schema->LookupType(R"gql(Task)gql"sv),
+		schema->LookupType(R"gql(Folder)gql"sv)
+	});
+
+	typeNode->AddFields({
+		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
+	});
+
+	AddQueryDetails(typeQuery, schema);
+	AddPageInfoDetails(typePageInfo, schema);
+	AddAppointmentEdgeDetails(typeAppointmentEdge, schema);
+	AddAppointmentConnectionDetails(typeAppointmentConnection, schema);
+	AddTaskEdgeDetails(typeTaskEdge, schema);
+	AddTaskConnectionDetails(typeTaskConnection, schema);
+	AddFolderEdgeDetails(typeFolderEdge, schema);
+	AddFolderConnectionDetails(typeFolderConnection, schema);
+	AddCompleteTaskPayloadDetails(typeCompleteTaskPayload, schema);
+	AddMutationDetails(typeMutation, schema);
+	AddSubscriptionDetails(typeSubscription, schema);
+	AddAppointmentDetails(typeAppointment, schema);
+	AddTaskDetails(typeTask, schema);
+	AddFolderDetails(typeFolder, schema);
+	AddNestedTypeDetails(typeNestedType, schema);
+	AddExpensiveDetails(typeExpensive, schema);
+
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(id)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::FIELD_DEFINITION
+	}), std::vector<std::shared_ptr<schema::InputValue>>()));
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(subscriptionTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::SUBSCRIPTION
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(field)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
+	})));
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(queryTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::QUERY
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(query)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	})));
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fieldTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::FIELD
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(field)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	})));
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fragmentDefinitionTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::FRAGMENT_DEFINITION
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(fragmentDefinition)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	})));
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fragmentSpreadTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::FRAGMENT_SPREAD
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(fragmentSpread)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	})));
+	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(inlineFragmentTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+		introspection::DirectiveLocation::INLINE_FRAGMENT
+	}), std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::InputValue>(R"gql(inlineFragment)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	})));
+
+	schema->AddQueryType(typeQuery);
+	schema->AddMutationType(typeMutation);
+	schema->AddSubscriptionType(typeSubscription);
 }
 
 } /* namespace today */

--- a/samples/separate_nointrospection/TodaySchema.cpp
+++ b/samples/separate_nointrospection/TodaySchema.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayObjects.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+using namespace std::literals;
+
+namespace graphql {
+namespace service {
+
+static const std::array<std::string_view, 4> s_namesTaskState = {
+	"New",
+	"Started",
+	"Complete",
+	"Unassigned"
+};
+
+template <>
+today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Value& value)
+{
+	if (!value.maybe_enum())
+	{
+		throw service::schema_exception { { "not a valid TaskState value" } };
+	}
+
+	auto itr = std::find(s_namesTaskState.cbegin(), s_namesTaskState.cend(), value.get<response::StringType>());
+
+	if (itr == s_namesTaskState.cend())
+	{
+		throw service::schema_exception { { "not a valid TaskState value" } };
+	}
+
+	return static_cast<today::TaskState>(itr - s_namesTaskState.cbegin());
+}
+
+template <>
+std::future<response::Value> ModifiedResult<today::TaskState>::convert(service::FieldResult<today::TaskState>&& result, ResolverParams&& params)
+{
+	return resolve(std::move(result), std::move(params),
+		[](today::TaskState&& value, const ResolverParams&)
+		{
+			response::Value result(response::Type::EnumValue);
+
+			result.set<response::StringType>(std::string(s_namesTaskState[static_cast<size_t>(value)]));
+
+			return result;
+		});
+}
+
+template <>
+today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(const response::Value& value)
+{
+	const auto defaultValue = []()
+	{
+		response::Value values(response::Type::Map);
+		response::Value entry;
+
+		entry = response::Value(true);
+		values.emplace_back("isComplete", std::move(entry));
+
+		return values;
+	}();
+
+	auto valueId = service::ModifiedArgument<response::IdType>::require("id", value);
+	auto pairIsComplete = service::ModifiedArgument<response::BooleanType>::find<service::TypeModifier::Nullable>("isComplete", value);
+	auto valueIsComplete = (pairIsComplete.second
+		? std::move(pairIsComplete.first)
+		: service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable>("isComplete", defaultValue));
+	auto valueClientMutationId = service::ModifiedArgument<response::StringType>::require<service::TypeModifier::Nullable>("clientMutationId", value);
+
+	return {
+		std::move(valueId),
+		std::move(valueIsComplete),
+		std::move(valueClientMutationId)
+	};
+}
+
+} /* namespace service */
+
+namespace today {
+
+Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<object::Mutation> mutation, std::shared_ptr<object::Subscription> subscription)
+	: service::Request({
+		{ "query", query },
+		{ "mutation", mutation },
+		{ "subscription", subscription }
+	})
+	, _query(std::move(query))
+	, _mutation(std::move(mutation))
+	, _subscription(std::move(subscription))
+{
+}
+
+} /* namespace today */
+} /* namespace graphql */

--- a/samples/separate_nointrospection/TodaySchema.cpp
+++ b/samples/separate_nointrospection/TodaySchema.cpp
@@ -112,9 +112,9 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	schema->AddType(R"gql(CompleteTaskInput)gql"sv, typeCompleteTaskInput);
 	auto typeUnionType = std::make_shared<schema::UnionType>(R"gql(UnionType)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(UnionType)gql"sv, typeUnionType);
-	auto typeNode = std::make_shared<schema::InterfaceType>(R"gql(Node)gql"sv, R"md(Node interface for Relay support)md"sv);
+	auto typeNode = std::make_shared<schema::InterfaceType>(R"gql(Node)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(Node)gql"sv, typeNode);
-	auto typeQuery = std::make_shared<schema::ObjectType>(R"gql(Query)gql"sv, R"md(Root Query type)md");
+	auto typeQuery = std::make_shared<schema::ObjectType>(R"gql(Query)gql"sv, R"md()md");
 	schema->AddType(R"gql(Query)gql"sv, typeQuery);
 	auto typePageInfo = std::make_shared<schema::ObjectType>(R"gql(PageInfo)gql"sv, R"md()md");
 	schema->AddType(R"gql(PageInfo)gql"sv, typePageInfo);
@@ -142,7 +142,7 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	schema->AddType(R"gql(Task)gql"sv, typeTask);
 	auto typeFolder = std::make_shared<schema::ObjectType>(R"gql(Folder)gql"sv, R"md()md");
 	schema->AddType(R"gql(Folder)gql"sv, typeFolder);
-	auto typeNestedType = std::make_shared<schema::ObjectType>(R"gql(NestedType)gql"sv, R"md(Infinitely nestable type which can be used with nested fragments to test directive handling)md");
+	auto typeNestedType = std::make_shared<schema::ObjectType>(R"gql(NestedType)gql"sv, R"md()md");
 	schema->AddType(R"gql(NestedType)gql"sv, typeNestedType);
 	auto typeExpensive = std::make_shared<schema::ObjectType>(R"gql(Expensive)gql"sv, R"md()md");
 	schema->AddType(R"gql(Expensive)gql"sv, typeExpensive);

--- a/samples/separate_nointrospection/TodaySchema.cpp
+++ b/samples/separate_nointrospection/TodaySchema.cpp
@@ -233,7 +233,7 @@ std::shared_ptr<schema::Schema> GetSchema()
 
 	if (!schema)
 	{
-		schema = std::make_shared<schema::Schema>();
+		schema = std::make_shared<schema::Schema>(true);
 		introspection::AddTypesToSchema(schema);
 		AddTypesToSchema(schema);
 		s_wpSchema = schema;

--- a/samples/separate_nointrospection/TodaySchema.cpp
+++ b/samples/separate_nointrospection/TodaySchema.cpp
@@ -95,7 +95,7 @@ Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<obj
 		{ "query", query },
 		{ "mutation", mutation },
 		{ "subscription", subscription }
-	}, nullptr)
+	}, GetSchema())
 	, _query(std::move(query))
 	, _mutation(std::move(mutation))
 	, _subscription(std::move(subscription))
@@ -224,6 +224,22 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	schema->AddQueryType(typeQuery);
 	schema->AddMutationType(typeMutation);
 	schema->AddSubscriptionType(typeSubscription);
+}
+
+std::shared_ptr<schema::Schema> GetSchema()
+{
+	static std::weak_ptr<schema::Schema> s_wpSchema;
+	auto schema = s_wpSchema.lock();
+
+	if (!schema)
+	{
+		schema = std::make_shared<schema::Schema>();
+		introspection::AddTypesToSchema(schema);
+		AddTypesToSchema(schema);
+		s_wpSchema = schema;
+	}
+
+	return schema;
 }
 
 } /* namespace today */

--- a/samples/separate_nointrospection/TodaySchema.cpp
+++ b/samples/separate_nointrospection/TodaySchema.cpp
@@ -45,7 +45,7 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Val
 }
 
 template <>
-std::future<response::Value> ModifiedResult<today::TaskState>::convert(service::FieldResult<today::TaskState>&& result, ResolverParams&& params)
+std::future<service::ResolverResult> ModifiedResult<today::TaskState>::convert(service::FieldResult<today::TaskState>&& result, ResolverParams&& params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](today::TaskState&& value, const ResolverParams&)

--- a/samples/separate_nointrospection/TodaySchema.cpp
+++ b/samples/separate_nointrospection/TodaySchema.cpp
@@ -3,7 +3,7 @@
 
 #include "TodayObjects.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <array>

--- a/samples/separate_nointrospection/TodaySchema.h
+++ b/samples/separate_nointrospection/TodaySchema.h
@@ -6,6 +6,7 @@
 #ifndef TODAYSCHEMA_H
 #define TODAYSCHEMA_H
 
+#include "graphqlservice/GraphQLSchema.h"
 #include "graphqlservice/GraphQLService.h"
 
 #include <memory>
@@ -74,6 +75,25 @@ private:
 	std::shared_ptr<object::Mutation> _mutation;
 	std::shared_ptr<object::Subscription> _subscription;
 };
+
+void AddQueryDetails(std::shared_ptr<schema::ObjectType> typeQuery, const std::shared_ptr<schema::Schema>& schema);
+void AddPageInfoDetails(std::shared_ptr<schema::ObjectType> typePageInfo, const std::shared_ptr<schema::Schema>& schema);
+void AddAppointmentEdgeDetails(std::shared_ptr<schema::ObjectType> typeAppointmentEdge, const std::shared_ptr<schema::Schema>& schema);
+void AddAppointmentConnectionDetails(std::shared_ptr<schema::ObjectType> typeAppointmentConnection, const std::shared_ptr<schema::Schema>& schema);
+void AddTaskEdgeDetails(std::shared_ptr<schema::ObjectType> typeTaskEdge, const std::shared_ptr<schema::Schema>& schema);
+void AddTaskConnectionDetails(std::shared_ptr<schema::ObjectType> typeTaskConnection, const std::shared_ptr<schema::Schema>& schema);
+void AddFolderEdgeDetails(std::shared_ptr<schema::ObjectType> typeFolderEdge, const std::shared_ptr<schema::Schema>& schema);
+void AddFolderConnectionDetails(std::shared_ptr<schema::ObjectType> typeFolderConnection, const std::shared_ptr<schema::Schema>& schema);
+void AddCompleteTaskPayloadDetails(std::shared_ptr<schema::ObjectType> typeCompleteTaskPayload, const std::shared_ptr<schema::Schema>& schema);
+void AddMutationDetails(std::shared_ptr<schema::ObjectType> typeMutation, const std::shared_ptr<schema::Schema>& schema);
+void AddSubscriptionDetails(std::shared_ptr<schema::ObjectType> typeSubscription, const std::shared_ptr<schema::Schema>& schema);
+void AddAppointmentDetails(std::shared_ptr<schema::ObjectType> typeAppointment, const std::shared_ptr<schema::Schema>& schema);
+void AddTaskDetails(std::shared_ptr<schema::ObjectType> typeTask, const std::shared_ptr<schema::Schema>& schema);
+void AddFolderDetails(std::shared_ptr<schema::ObjectType> typeFolder, const std::shared_ptr<schema::Schema>& schema);
+void AddNestedTypeDetails(std::shared_ptr<schema::ObjectType> typeNestedType, const std::shared_ptr<schema::Schema>& schema);
+void AddExpensiveDetails(std::shared_ptr<schema::ObjectType> typeExpensive, const std::shared_ptr<schema::Schema>& schema);
+
+void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema);
 
 } /* namespace today */
 } /* namespace graphql */

--- a/samples/separate_nointrospection/TodaySchema.h
+++ b/samples/separate_nointrospection/TodaySchema.h
@@ -86,7 +86,7 @@ void AddFolderDetails(std::shared_ptr<schema::ObjectType> typeFolder, const std:
 void AddNestedTypeDetails(std::shared_ptr<schema::ObjectType> typeNestedType, const std::shared_ptr<schema::Schema>& schema);
 void AddExpensiveDetails(std::shared_ptr<schema::ObjectType> typeExpensive, const std::shared_ptr<schema::Schema>& schema);
 
-void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema);
+std::shared_ptr<schema::Schema> GetSchema();
 
 } /* namespace today */
 } /* namespace graphql */

--- a/samples/separate_nointrospection/TodaySchema.h
+++ b/samples/separate_nointrospection/TodaySchema.h
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef TODAYSCHEMA_H
+#define TODAYSCHEMA_H
+
+#include "graphqlservice/GraphQLService.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace graphql {
+namespace introspection {
+
+class Schema;
+class ObjectType;
+
+} /* namespace introspection */
+
+namespace today {
+
+enum class TaskState
+{
+	New,
+	Started,
+	Complete,
+	Unassigned
+};
+
+struct CompleteTaskInput
+{
+	response::IdType id;
+	std::optional<response::BooleanType> isComplete;
+	std::optional<response::StringType> clientMutationId;
+};
+
+namespace object {
+
+class Query;
+class PageInfo;
+class AppointmentEdge;
+class AppointmentConnection;
+class TaskEdge;
+class TaskConnection;
+class FolderEdge;
+class FolderConnection;
+class CompleteTaskPayload;
+class Mutation;
+class Subscription;
+class Appointment;
+class Task;
+class Folder;
+class NestedType;
+class Expensive;
+
+} /* namespace object */
+
+struct Node
+{
+	virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const = 0;
+};
+
+class Operations
+	: public service::Request
+{
+public:
+	explicit Operations(std::shared_ptr<object::Query> query, std::shared_ptr<object::Mutation> mutation, std::shared_ptr<object::Subscription> subscription);
+
+private:
+	std::shared_ptr<object::Query> _query;
+	std::shared_ptr<object::Mutation> _mutation;
+	std::shared_ptr<object::Subscription> _subscription;
+};
+
+} /* namespace today */
+} /* namespace graphql */
+
+#endif // TODAYSCHEMA_H

--- a/samples/separate_nointrospection/TodaySchema.h
+++ b/samples/separate_nointrospection/TodaySchema.h
@@ -14,13 +14,6 @@
 #include <vector>
 
 namespace graphql {
-namespace introspection {
-
-class Schema;
-class ObjectType;
-
-} /* namespace introspection */
-
 namespace today {
 
 enum class TaskState

--- a/samples/separate_nointrospection/today_schema_files
+++ b/samples/separate_nointrospection/today_schema_files
@@ -1,0 +1,17 @@
+TodaySchema.cpp
+QueryObject.cpp
+PageInfoObject.cpp
+AppointmentEdgeObject.cpp
+AppointmentConnectionObject.cpp
+TaskEdgeObject.cpp
+TaskConnectionObject.cpp
+FolderEdgeObject.cpp
+FolderConnectionObject.cpp
+CompleteTaskPayloadObject.cpp
+MutationObject.cpp
+SubscriptionObject.cpp
+AppointmentObject.cpp
+TaskObject.cpp
+FolderObject.cpp
+NestedTypeObject.cpp
+ExpensiveObject.cpp

--- a/samples/today/TodayMock.h
+++ b/samples/today/TodayMock.h
@@ -154,6 +154,12 @@ public:
 		return _isNow;
 	}
 
+	service::FieldResult<std::optional<response::StringType>> getForceError(
+		service::FieldParams&&) const final
+	{
+		throw std::runtime_error(R"ex(this error was forced)ex");
+	}
+
 private:
 	response::IdType _id;
 	std::string _when;

--- a/samples/today/benchmark.cpp
+++ b/samples/today/benchmark.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodayMock.h"
+
+#include "graphqlservice/JSONResponse.h"
+
+#include <cstdio>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <stdexcept>
+
+using namespace graphql;
+
+int main(int argc, char** argv)
+{
+	response::IdType binAppointmentId;
+	response::IdType binTaskId;
+	response::IdType binFolderId;
+
+	std::string fakeAppointmentId("fakeAppointmentId");
+	binAppointmentId.resize(fakeAppointmentId.size());
+	std::copy(fakeAppointmentId.cbegin(), fakeAppointmentId.cend(), binAppointmentId.begin());
+
+	std::string fakeTaskId("fakeTaskId");
+	binTaskId.resize(fakeTaskId.size());
+	std::copy(fakeTaskId.cbegin(), fakeTaskId.cend(), binTaskId.begin());
+
+	std::string fakeFolderId("fakeFolderId");
+	binFolderId.resize(fakeFolderId.size());
+	std::copy(fakeFolderId.cbegin(), fakeFolderId.cend(), binFolderId.begin());
+
+	auto query = std::make_shared<today::Query>(
+		[&binAppointmentId]() -> std::vector<std::shared_ptr<today::Appointment>> {
+			std::cout << "Called getAppointments..." << std::endl;
+			return { std::make_shared<today::Appointment>(std::move(binAppointmentId),
+				"tomorrow",
+				"Lunch?",
+				false) };
+		},
+		[&binTaskId]() -> std::vector<std::shared_ptr<today::Task>> {
+			std::cout << "Called getTasks..." << std::endl;
+			return { std::make_shared<today::Task>(std::move(binTaskId), "Don't forget", true) };
+		},
+		[&binFolderId]() -> std::vector<std::shared_ptr<today::Folder>> {
+			std::cout << "Called getUnreadCounts..." << std::endl;
+			return { std::make_shared<today::Folder>(std::move(binFolderId), "\"Fake\" Inbox", 3) };
+		});
+	auto mutation = std::make_shared<today::Mutation>(
+		[](today::CompleteTaskInput&& input) -> std::shared_ptr<today::CompleteTaskPayload> {
+			return std::make_shared<today::CompleteTaskPayload>(
+				std::make_shared<today::Task>(std::move(input.id),
+					"Mutated Task!",
+					*(input.isComplete)),
+				std::move(input.clientMutationId));
+		});
+	auto subscription = std::make_shared<today::Subscription>();
+	auto service = std::make_shared<today::Operations>(query, mutation, subscription);
+
+	std::cout << "Created the service..." << std::endl;
+
+	const size_t iterations = [](const char* arg) noexcept -> size_t {
+		if (arg)
+		{
+			const int parsed = std::atoi(arg);
+
+			if (parsed > 0)
+			{
+				return static_cast<size_t>(parsed);
+			}
+		}
+
+		// Default to 100 iterations
+		return 100;
+	}((argc > 1) ? argv[1] : nullptr);
+
+	for (size_t i = 0; i < iterations; ++i)
+	{
+		try
+		{
+			auto query = R"gql(query {
+				appointments {
+					pageInfo { hasNextPage }
+					edges {
+						node {
+							id
+							when
+							subject
+							isNow
+						}
+					}
+				}
+			})gql"_graphql;
+
+			std::cout << "Executing query..." << std::endl;
+
+			std::cout << response::toJSON(
+				service->resolve(nullptr, query, "", response::Value(response::Type::Map)).get())
+					  << std::endl;
+		}
+		catch (const std::runtime_error& ex)
+		{
+			std::cerr << ex.what() << std::endl;
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/samples/today/benchmark.cpp
+++ b/samples/today/benchmark.cpp
@@ -93,6 +93,11 @@ int main(int argc, char** argv)
 				}
 			})gql"_graphql;
 
+#ifdef NO_INTROSPECTION
+			// TODO: cherry-pick validation support without Introspection
+			query.validated = true;
+#endif // NO_INTROSPECTION
+
 			std::cout << "Executing query..." << std::endl;
 
 			std::cout << response::toJSON(

--- a/samples/today/sample.cpp
+++ b/samples/today/sample.cpp
@@ -82,6 +82,11 @@ int main(int argc, char** argv)
 			return 1;
 		}
 
+#ifdef NO_INTROSPECTION
+		// TODO: cherry-pick validation support without Introspection
+		query.validated = true;
+#endif // NO_INTROSPECTION
+
 		std::cout << "Executing query..." << std::endl;
 
 		std::cout << response::toJSON(service

--- a/samples/unified/TodaySchema.cpp
+++ b/samples/unified/TodaySchema.cpp
@@ -1266,7 +1266,7 @@ std::shared_ptr<schema::Schema> GetSchema()
 
 	if (!schema)
 	{
-		schema = std::make_shared<schema::Schema>();
+		schema = std::make_shared<schema::Schema>(false);
 		introspection::AddTypesToSchema(schema);
 		AddTypesToSchema(schema);
 		s_wpSchema = schema;

--- a/samples/unified/TodaySchema.cpp
+++ b/samples/unified/TodaySchema.cpp
@@ -45,7 +45,7 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Val
 }
 
 template <>
-std::future<response::Value> ModifiedResult<today::TaskState>::convert(service::FieldResult<today::TaskState>&& result, ResolverParams&& params)
+std::future<service::ResolverResult> ModifiedResult<today::TaskState>::convert(service::FieldResult<today::TaskState>&& result, ResolverParams&& params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](today::TaskState&& value, const ResolverParams&)
@@ -118,7 +118,7 @@ service::FieldResult<std::shared_ptr<service::Object>> Query::getNode(service::F
 	throw std::runtime_error(R"ex(Query::getNode is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveNode(service::ResolverParams&& params)
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -133,7 +133,7 @@ service::FieldResult<std::shared_ptr<AppointmentConnection>> Query::getAppointme
 	throw std::runtime_error(R"ex(Query::getAppointments is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveAppointments(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveAppointments(service::ResolverParams&& params)
 {
 	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
@@ -151,7 +151,7 @@ service::FieldResult<std::shared_ptr<TaskConnection>> Query::getTasks(service::F
 	throw std::runtime_error(R"ex(Query::getTasks is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveTasks(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveTasks(service::ResolverParams&& params)
 {
 	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
@@ -169,7 +169,7 @@ service::FieldResult<std::shared_ptr<FolderConnection>> Query::getUnreadCounts(s
 	throw std::runtime_error(R"ex(Query::getUnreadCounts is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveUnreadCounts(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveUnreadCounts(service::ResolverParams&& params)
 {
 	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
@@ -187,7 +187,7 @@ service::FieldResult<std::vector<std::shared_ptr<Appointment>>> Query::getAppoin
 	throw std::runtime_error(R"ex(Query::getAppointmentsById is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveAppointmentsById(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveAppointmentsById(service::ResolverParams&& params)
 {
 	const auto defaultArguments = []()
 	{
@@ -224,7 +224,7 @@ service::FieldResult<std::vector<std::shared_ptr<Task>>> Query::getTasksById(ser
 	throw std::runtime_error(R"ex(Query::getTasksById is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveTasksById(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveTasksById(service::ResolverParams&& params)
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -239,7 +239,7 @@ service::FieldResult<std::vector<std::shared_ptr<Folder>>> Query::getUnreadCount
 	throw std::runtime_error(R"ex(Query::getUnreadCountsById is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveUnreadCountsById(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveUnreadCountsById(service::ResolverParams&& params)
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -254,7 +254,7 @@ service::FieldResult<std::shared_ptr<NestedType>> Query::getNested(service::Fiel
 	throw std::runtime_error(R"ex(Query::getNested is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveNested(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -268,7 +268,7 @@ service::FieldResult<response::StringType> Query::getUnimplemented(service::Fiel
 	throw std::runtime_error(R"ex(Query::getUnimplemented is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveUnimplemented(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveUnimplemented(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getUnimplemented(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -282,7 +282,7 @@ service::FieldResult<std::vector<std::shared_ptr<Expensive>>> Query::getExpensiv
 	throw std::runtime_error(R"ex(Query::getExpensive is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveExpensive(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveExpensive(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getExpensive(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -291,17 +291,17 @@ std::future<response::Value> Query::resolveExpensive(service::ResolverParams&& p
 	return service::ModifiedResult<Expensive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Query::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Query)gql" }, std::move(params));
 }
 
-std::future<response::Value> Query::resolve_schema(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolve_schema(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<service::Object>::convert(std::static_pointer_cast<service::Object>(std::make_shared<introspection::Schema>(_schema)), std::move(params));
 }
 
-std::future<response::Value> Query::resolve_type(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolve_type(service::ResolverParams&& params)
 {
 	auto argName = service::ModifiedArgument<response::StringType>::require("name", params.arguments);
 	const auto& baseType = _schema->LookupType(argName);
@@ -326,7 +326,7 @@ service::FieldResult<response::BooleanType> PageInfo::getHasNextPage(service::Fi
 	throw std::runtime_error(R"ex(PageInfo::getHasNextPage is not implemented)ex");
 }
 
-std::future<response::Value> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
+std::future<service::ResolverResult> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getHasNextPage(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -340,7 +340,7 @@ service::FieldResult<response::BooleanType> PageInfo::getHasPreviousPage(service
 	throw std::runtime_error(R"ex(PageInfo::getHasPreviousPage is not implemented)ex");
 }
 
-std::future<response::Value> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
+std::future<service::ResolverResult> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getHasPreviousPage(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -349,7 +349,7 @@ std::future<response::Value> PageInfo::resolveHasPreviousPage(service::ResolverP
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> PageInfo::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> PageInfo::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(PageInfo)gql" }, std::move(params));
 }
@@ -370,7 +370,7 @@ service::FieldResult<std::shared_ptr<Appointment>> AppointmentEdge::getNode(serv
 	throw std::runtime_error(R"ex(AppointmentEdge::getNode is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentEdge::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -384,7 +384,7 @@ service::FieldResult<response::Value> AppointmentEdge::getCursor(service::FieldP
 	throw std::runtime_error(R"ex(AppointmentEdge::getCursor is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -393,7 +393,7 @@ std::future<response::Value> AppointmentEdge::resolveCursor(service::ResolverPar
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> AppointmentEdge::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentEdge::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(AppointmentEdge)gql" }, std::move(params));
 }
@@ -414,7 +414,7 @@ service::FieldResult<std::shared_ptr<PageInfo>> AppointmentConnection::getPageIn
 	throw std::runtime_error(R"ex(AppointmentConnection::getPageInfo is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -428,7 +428,7 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>
 	throw std::runtime_error(R"ex(AppointmentConnection::getEdges is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -437,7 +437,7 @@ std::future<response::Value> AppointmentConnection::resolveEdges(service::Resolv
 	return service::ModifiedResult<AppointmentEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> AppointmentConnection::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentConnection::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(AppointmentConnection)gql" }, std::move(params));
 }
@@ -458,7 +458,7 @@ service::FieldResult<std::shared_ptr<Task>> TaskEdge::getNode(service::FieldPara
 	throw std::runtime_error(R"ex(TaskEdge::getNode is not implemented)ex");
 }
 
-std::future<response::Value> TaskEdge::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -472,7 +472,7 @@ service::FieldResult<response::Value> TaskEdge::getCursor(service::FieldParams&&
 	throw std::runtime_error(R"ex(TaskEdge::getCursor is not implemented)ex");
 }
 
-std::future<response::Value> TaskEdge::resolveCursor(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -481,7 +481,7 @@ std::future<response::Value> TaskEdge::resolveCursor(service::ResolverParams&& p
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> TaskEdge::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskEdge::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(TaskEdge)gql" }, std::move(params));
 }
@@ -502,7 +502,7 @@ service::FieldResult<std::shared_ptr<PageInfo>> TaskConnection::getPageInfo(serv
 	throw std::runtime_error(R"ex(TaskConnection::getPageInfo is not implemented)ex");
 }
 
-std::future<response::Value> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -516,7 +516,7 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> Task
 	throw std::runtime_error(R"ex(TaskConnection::getEdges is not implemented)ex");
 }
 
-std::future<response::Value> TaskConnection::resolveEdges(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -525,7 +525,7 @@ std::future<response::Value> TaskConnection::resolveEdges(service::ResolverParam
 	return service::ModifiedResult<TaskEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> TaskConnection::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskConnection::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(TaskConnection)gql" }, std::move(params));
 }
@@ -546,7 +546,7 @@ service::FieldResult<std::shared_ptr<Folder>> FolderEdge::getNode(service::Field
 	throw std::runtime_error(R"ex(FolderEdge::getNode is not implemented)ex");
 }
 
-std::future<response::Value> FolderEdge::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -560,7 +560,7 @@ service::FieldResult<response::Value> FolderEdge::getCursor(service::FieldParams
 	throw std::runtime_error(R"ex(FolderEdge::getCursor is not implemented)ex");
 }
 
-std::future<response::Value> FolderEdge::resolveCursor(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -569,7 +569,7 @@ std::future<response::Value> FolderEdge::resolveCursor(service::ResolverParams&&
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> FolderEdge::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderEdge::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(FolderEdge)gql" }, std::move(params));
 }
@@ -590,7 +590,7 @@ service::FieldResult<std::shared_ptr<PageInfo>> FolderConnection::getPageInfo(se
 	throw std::runtime_error(R"ex(FolderConnection::getPageInfo is not implemented)ex");
 }
 
-std::future<response::Value> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -604,7 +604,7 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> Fo
 	throw std::runtime_error(R"ex(FolderConnection::getEdges is not implemented)ex");
 }
 
-std::future<response::Value> FolderConnection::resolveEdges(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -613,7 +613,7 @@ std::future<response::Value> FolderConnection::resolveEdges(service::ResolverPar
 	return service::ModifiedResult<FolderEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> FolderConnection::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderConnection::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(FolderConnection)gql" }, std::move(params));
 }
@@ -634,7 +634,7 @@ service::FieldResult<std::shared_ptr<Task>> CompleteTaskPayload::getTask(service
 	throw std::runtime_error(R"ex(CompleteTaskPayload::getTask is not implemented)ex");
 }
 
-std::future<response::Value> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
+std::future<service::ResolverResult> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getTask(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -648,7 +648,7 @@ service::FieldResult<std::optional<response::StringType>> CompleteTaskPayload::g
 	throw std::runtime_error(R"ex(CompleteTaskPayload::getClientMutationId is not implemented)ex");
 }
 
-std::future<response::Value> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
+std::future<service::ResolverResult> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getClientMutationId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -657,7 +657,7 @@ std::future<response::Value> CompleteTaskPayload::resolveClientMutationId(servic
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> CompleteTaskPayload::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> CompleteTaskPayload::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(CompleteTaskPayload)gql" }, std::move(params));
 }
@@ -678,7 +678,7 @@ service::FieldResult<std::shared_ptr<CompleteTaskPayload>> Mutation::applyComple
 	throw std::runtime_error(R"ex(Mutation::applyCompleteTask is not implemented)ex");
 }
 
-std::future<response::Value> Mutation::resolveCompleteTask(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolveCompleteTask(service::ResolverParams&& params)
 {
 	auto argInput = service::ModifiedArgument<today::CompleteTaskInput>::require("input", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -693,7 +693,7 @@ service::FieldResult<response::FloatType> Mutation::applySetFloat(service::Field
 	throw std::runtime_error(R"ex(Mutation::applySetFloat is not implemented)ex");
 }
 
-std::future<response::Value> Mutation::resolveSetFloat(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolveSetFloat(service::ResolverParams&& params)
 {
 	auto argValue = service::ModifiedArgument<response::FloatType>::require("value", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -703,7 +703,7 @@ std::future<response::Value> Mutation::resolveSetFloat(service::ResolverParams&&
 	return service::ModifiedResult<response::FloatType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Mutation::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Mutation)gql" }, std::move(params));
 }
@@ -724,7 +724,7 @@ service::FieldResult<std::shared_ptr<Appointment>> Subscription::getNextAppointm
 	throw std::runtime_error(R"ex(Subscription::getNextAppointmentChange is not implemented)ex");
 }
 
-std::future<response::Value> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNextAppointmentChange(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -738,7 +738,7 @@ service::FieldResult<std::shared_ptr<service::Object>> Subscription::getNodeChan
 	throw std::runtime_error(R"ex(Subscription::getNodeChange is not implemented)ex");
 }
 
-std::future<response::Value> Subscription::resolveNodeChange(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolveNodeChange(service::ResolverParams&& params)
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -748,7 +748,7 @@ std::future<response::Value> Subscription::resolveNodeChange(service::ResolverPa
 	return service::ModifiedResult<service::Object>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Subscription::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Subscription)gql" }, std::move(params));
 }
@@ -774,7 +774,7 @@ service::FieldResult<response::IdType> Appointment::getId(service::FieldParams&&
 	throw std::runtime_error(R"ex(Appointment::getId is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveId(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -788,7 +788,7 @@ service::FieldResult<std::optional<response::Value>> Appointment::getWhen(servic
 	throw std::runtime_error(R"ex(Appointment::getWhen is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveWhen(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveWhen(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getWhen(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -802,7 +802,7 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getSubjec
 	throw std::runtime_error(R"ex(Appointment::getSubject is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveSubject(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveSubject(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getSubject(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -816,7 +816,7 @@ service::FieldResult<response::BooleanType> Appointment::getIsNow(service::Field
 	throw std::runtime_error(R"ex(Appointment::getIsNow is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveIsNow(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveIsNow(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getIsNow(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -830,7 +830,7 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getForceE
 	throw std::runtime_error(R"ex(Appointment::getForceError is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveForceError(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveForceError(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getForceError(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -839,7 +839,7 @@ std::future<response::Value> Appointment::resolveForceError(service::ResolverPar
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Appointment::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Appointment)gql" }, std::move(params));
 }
@@ -863,7 +863,7 @@ service::FieldResult<response::IdType> Task::getId(service::FieldParams&&) const
 	throw std::runtime_error(R"ex(Task::getId is not implemented)ex");
 }
 
-std::future<response::Value> Task::resolveId(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -877,7 +877,7 @@ service::FieldResult<std::optional<response::StringType>> Task::getTitle(service
 	throw std::runtime_error(R"ex(Task::getTitle is not implemented)ex");
 }
 
-std::future<response::Value> Task::resolveTitle(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolveTitle(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getTitle(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -891,7 +891,7 @@ service::FieldResult<response::BooleanType> Task::getIsComplete(service::FieldPa
 	throw std::runtime_error(R"ex(Task::getIsComplete is not implemented)ex");
 }
 
-std::future<response::Value> Task::resolveIsComplete(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolveIsComplete(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getIsComplete(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -900,7 +900,7 @@ std::future<response::Value> Task::resolveIsComplete(service::ResolverParams&& p
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Task::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Task)gql" }, std::move(params));
 }
@@ -924,7 +924,7 @@ service::FieldResult<response::IdType> Folder::getId(service::FieldParams&&) con
 	throw std::runtime_error(R"ex(Folder::getId is not implemented)ex");
 }
 
-std::future<response::Value> Folder::resolveId(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -938,7 +938,7 @@ service::FieldResult<std::optional<response::StringType>> Folder::getName(servic
 	throw std::runtime_error(R"ex(Folder::getName is not implemented)ex");
 }
 
-std::future<response::Value> Folder::resolveName(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -952,7 +952,7 @@ service::FieldResult<response::IntType> Folder::getUnreadCount(service::FieldPar
 	throw std::runtime_error(R"ex(Folder::getUnreadCount is not implemented)ex");
 }
 
-std::future<response::Value> Folder::resolveUnreadCount(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolveUnreadCount(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getUnreadCount(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -961,7 +961,7 @@ std::future<response::Value> Folder::resolveUnreadCount(service::ResolverParams&
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Folder::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Folder)gql" }, std::move(params));
 }
@@ -982,7 +982,7 @@ service::FieldResult<response::IntType> NestedType::getDepth(service::FieldParam
 	throw std::runtime_error(R"ex(NestedType::getDepth is not implemented)ex");
 }
 
-std::future<response::Value> NestedType::resolveDepth(service::ResolverParams&& params)
+std::future<service::ResolverResult> NestedType::resolveDepth(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDepth(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -996,7 +996,7 @@ service::FieldResult<std::shared_ptr<NestedType>> NestedType::getNested(service:
 	throw std::runtime_error(R"ex(NestedType::getNested is not implemented)ex");
 }
 
-std::future<response::Value> NestedType::resolveNested(service::ResolverParams&& params)
+std::future<service::ResolverResult> NestedType::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -1005,7 +1005,7 @@ std::future<response::Value> NestedType::resolveNested(service::ResolverParams&&
 	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> NestedType::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> NestedType::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(NestedType)gql" }, std::move(params));
 }
@@ -1025,7 +1025,7 @@ service::FieldResult<response::IntType> Expensive::getOrder(service::FieldParams
 	throw std::runtime_error(R"ex(Expensive::getOrder is not implemented)ex");
 }
 
-std::future<response::Value> Expensive::resolveOrder(service::ResolverParams&& params)
+std::future<service::ResolverResult> Expensive::resolveOrder(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getOrder(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -1034,7 +1034,7 @@ std::future<response::Value> Expensive::resolveOrder(service::ResolverParams&& p
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Expensive::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Expensive::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Expensive)gql" }, std::move(params));
 }

--- a/samples/unified/TodaySchema.cpp
+++ b/samples/unified/TodaySchema.cpp
@@ -109,10 +109,8 @@ Query::Query()
 		{ R"gql(unreadCounts)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCounts(std::move(params)); } },
 		{ R"gql(unreadCountsById)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCountsById(std::move(params)); } }
 	})
-	, _schema(std::make_shared<schema::Schema>())
+	, _schema(GetSchema())
 {
-	introspection::AddTypesToSchema(_schema);
-	today::AddTypesToSchema(_schema);
 }
 
 service::FieldResult<std::shared_ptr<service::Object>> Query::getNode(service::FieldParams&&, response::IdType&&) const
@@ -1033,7 +1031,7 @@ Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<obj
 		{ "query", query },
 		{ "mutation", mutation },
 		{ "subscription", subscription }
-	}, nullptr)
+	}, GetSchema())
 	, _query(std::move(query))
 	, _mutation(std::move(mutation))
 	, _subscription(std::move(subscription))
@@ -1259,6 +1257,22 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	schema->AddQueryType(typeQuery);
 	schema->AddMutationType(typeMutation);
 	schema->AddSubscriptionType(typeSubscription);
+}
+
+std::shared_ptr<schema::Schema> GetSchema()
+{
+	static std::weak_ptr<schema::Schema> s_wpSchema;
+	auto schema = s_wpSchema.lock();
+
+	if (!schema)
+	{
+		schema = std::make_shared<schema::Schema>();
+		introspection::AddTypesToSchema(schema);
+		AddTypesToSchema(schema);
+		s_wpSchema = schema;
+	}
+
+	return schema;
 }
 
 } /* namespace today */

--- a/samples/unified/TodaySchema.cpp
+++ b/samples/unified/TodaySchema.cpp
@@ -760,6 +760,7 @@ Appointment::Appointment()
 		"Appointment"
 	}, {
 		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(forceError)gql"sv, [this](service::ResolverParams&& params) { return resolveForceError(std::move(params)); } },
 		{ R"gql(id)gql"sv, [this](service::ResolverParams&& params) { return resolveId(std::move(params)); } },
 		{ R"gql(isNow)gql"sv, [this](service::ResolverParams&& params) { return resolveIsNow(std::move(params)); } },
 		{ R"gql(subject)gql"sv, [this](service::ResolverParams&& params) { return resolveSubject(std::move(params)); } },
@@ -822,6 +823,20 @@ std::future<response::Value> Appointment::resolveIsNow(service::ResolverParams&&
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<response::StringType>> Appointment::getForceError(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Appointment::getForceError is not implemented)ex");
+}
+
+std::future<response::Value> Appointment::resolveForceError(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getForceError(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> Appointment::resolve_typename(service::ResolverParams&& params)
@@ -1194,7 +1209,8 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
 		std::make_shared<schema::Field>(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("DateTime")),
 		std::make_shared<schema::Field>(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		std::make_shared<schema::Field>(R"gql(forceError)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
 	});
 	typeTask->AddInterfaces({
 		typeNode

--- a/samples/unified/TodaySchema.cpp
+++ b/samples/unified/TodaySchema.cpp
@@ -3,7 +3,7 @@
 
 #include "TodaySchema.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <array>

--- a/samples/unified/TodaySchema.cpp
+++ b/samples/unified/TodaySchema.cpp
@@ -1055,47 +1055,47 @@ Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<obj
 
 void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 {
-	schema->AddType(R"gql(ItemCursor)gql"sv, std::make_shared<schema::ScalarType>(R"gql(ItemCursor)gql"sv, R"md()md"));
-	schema->AddType(R"gql(DateTime)gql"sv, std::make_shared<schema::ScalarType>(R"gql(DateTime)gql"sv, R"md()md"));
-	auto typeTaskState = std::make_shared<schema::EnumType>(R"gql(TaskState)gql"sv, R"md()md"sv);
+	schema->AddType(R"gql(ItemCursor)gql"sv, schema::ScalarType::Make(R"gql(ItemCursor)gql"sv, R"md()md"));
+	schema->AddType(R"gql(DateTime)gql"sv, schema::ScalarType::Make(R"gql(DateTime)gql"sv, R"md()md"));
+	auto typeTaskState = schema::EnumType::Make(R"gql(TaskState)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(TaskState)gql"sv, typeTaskState);
-	auto typeCompleteTaskInput = std::make_shared<schema::InputObjectType>(R"gql(CompleteTaskInput)gql"sv, R"md()md"sv);
+	auto typeCompleteTaskInput = schema::InputObjectType::Make(R"gql(CompleteTaskInput)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(CompleteTaskInput)gql"sv, typeCompleteTaskInput);
-	auto typeUnionType = std::make_shared<schema::UnionType>(R"gql(UnionType)gql"sv, R"md()md"sv);
+	auto typeUnionType = schema::UnionType::Make(R"gql(UnionType)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(UnionType)gql"sv, typeUnionType);
-	auto typeNode = std::make_shared<schema::InterfaceType>(R"gql(Node)gql"sv, R"md(Node interface for Relay support)md"sv);
+	auto typeNode = schema::InterfaceType::Make(R"gql(Node)gql"sv, R"md(Node interface for Relay support)md"sv);
 	schema->AddType(R"gql(Node)gql"sv, typeNode);
-	auto typeQuery = std::make_shared<schema::ObjectType>(R"gql(Query)gql"sv, R"md(Root Query type)md");
+	auto typeQuery = schema::ObjectType::Make(R"gql(Query)gql"sv, R"md(Root Query type)md");
 	schema->AddType(R"gql(Query)gql"sv, typeQuery);
-	auto typePageInfo = std::make_shared<schema::ObjectType>(R"gql(PageInfo)gql"sv, R"md()md");
+	auto typePageInfo = schema::ObjectType::Make(R"gql(PageInfo)gql"sv, R"md()md");
 	schema->AddType(R"gql(PageInfo)gql"sv, typePageInfo);
-	auto typeAppointmentEdge = std::make_shared<schema::ObjectType>(R"gql(AppointmentEdge)gql"sv, R"md()md");
+	auto typeAppointmentEdge = schema::ObjectType::Make(R"gql(AppointmentEdge)gql"sv, R"md()md");
 	schema->AddType(R"gql(AppointmentEdge)gql"sv, typeAppointmentEdge);
-	auto typeAppointmentConnection = std::make_shared<schema::ObjectType>(R"gql(AppointmentConnection)gql"sv, R"md()md");
+	auto typeAppointmentConnection = schema::ObjectType::Make(R"gql(AppointmentConnection)gql"sv, R"md()md");
 	schema->AddType(R"gql(AppointmentConnection)gql"sv, typeAppointmentConnection);
-	auto typeTaskEdge = std::make_shared<schema::ObjectType>(R"gql(TaskEdge)gql"sv, R"md()md");
+	auto typeTaskEdge = schema::ObjectType::Make(R"gql(TaskEdge)gql"sv, R"md()md");
 	schema->AddType(R"gql(TaskEdge)gql"sv, typeTaskEdge);
-	auto typeTaskConnection = std::make_shared<schema::ObjectType>(R"gql(TaskConnection)gql"sv, R"md()md");
+	auto typeTaskConnection = schema::ObjectType::Make(R"gql(TaskConnection)gql"sv, R"md()md");
 	schema->AddType(R"gql(TaskConnection)gql"sv, typeTaskConnection);
-	auto typeFolderEdge = std::make_shared<schema::ObjectType>(R"gql(FolderEdge)gql"sv, R"md()md");
+	auto typeFolderEdge = schema::ObjectType::Make(R"gql(FolderEdge)gql"sv, R"md()md");
 	schema->AddType(R"gql(FolderEdge)gql"sv, typeFolderEdge);
-	auto typeFolderConnection = std::make_shared<schema::ObjectType>(R"gql(FolderConnection)gql"sv, R"md()md");
+	auto typeFolderConnection = schema::ObjectType::Make(R"gql(FolderConnection)gql"sv, R"md()md");
 	schema->AddType(R"gql(FolderConnection)gql"sv, typeFolderConnection);
-	auto typeCompleteTaskPayload = std::make_shared<schema::ObjectType>(R"gql(CompleteTaskPayload)gql"sv, R"md()md");
+	auto typeCompleteTaskPayload = schema::ObjectType::Make(R"gql(CompleteTaskPayload)gql"sv, R"md()md");
 	schema->AddType(R"gql(CompleteTaskPayload)gql"sv, typeCompleteTaskPayload);
-	auto typeMutation = std::make_shared<schema::ObjectType>(R"gql(Mutation)gql"sv, R"md()md");
+	auto typeMutation = schema::ObjectType::Make(R"gql(Mutation)gql"sv, R"md()md");
 	schema->AddType(R"gql(Mutation)gql"sv, typeMutation);
-	auto typeSubscription = std::make_shared<schema::ObjectType>(R"gql(Subscription)gql"sv, R"md()md");
+	auto typeSubscription = schema::ObjectType::Make(R"gql(Subscription)gql"sv, R"md()md");
 	schema->AddType(R"gql(Subscription)gql"sv, typeSubscription);
-	auto typeAppointment = std::make_shared<schema::ObjectType>(R"gql(Appointment)gql"sv, R"md()md");
+	auto typeAppointment = schema::ObjectType::Make(R"gql(Appointment)gql"sv, R"md()md");
 	schema->AddType(R"gql(Appointment)gql"sv, typeAppointment);
-	auto typeTask = std::make_shared<schema::ObjectType>(R"gql(Task)gql"sv, R"md()md");
+	auto typeTask = schema::ObjectType::Make(R"gql(Task)gql"sv, R"md()md");
 	schema->AddType(R"gql(Task)gql"sv, typeTask);
-	auto typeFolder = std::make_shared<schema::ObjectType>(R"gql(Folder)gql"sv, R"md()md");
+	auto typeFolder = schema::ObjectType::Make(R"gql(Folder)gql"sv, R"md()md");
 	schema->AddType(R"gql(Folder)gql"sv, typeFolder);
-	auto typeNestedType = std::make_shared<schema::ObjectType>(R"gql(NestedType)gql"sv, R"md(Infinitely nestable type which can be used with nested fragments to test directive handling)md");
+	auto typeNestedType = schema::ObjectType::Make(R"gql(NestedType)gql"sv, R"md(Infinitely nestable type which can be used with nested fragments to test directive handling)md");
 	schema->AddType(R"gql(NestedType)gql"sv, typeNestedType);
-	auto typeExpensive = std::make_shared<schema::ObjectType>(R"gql(Expensive)gql"sv, R"md()md");
+	auto typeExpensive = schema::ObjectType::Make(R"gql(Expensive)gql"sv, R"md()md");
 	schema->AddType(R"gql(Expensive)gql"sv, typeExpensive);
 
 	typeTaskState->AddEnumValues({
@@ -1106,9 +1106,9 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	});
 
 	typeCompleteTaskInput->AddInputValues({
-		std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv),
-		std::make_shared<schema::InputValue>(R"gql(isComplete)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(true)gql"sv),
-		std::make_shared<schema::InputValue>(R"gql(clientMutationId)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
+		schema::InputValue::Make(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv),
+		schema::InputValue::Make(R"gql(isComplete)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(true)gql"sv),
+		schema::InputValue::Make(R"gql(clientMutationId)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
 	});
 
 	typeUnionType->AddPossibleTypes({
@@ -1118,157 +1118,157 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	});
 
 	typeNode->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
 	});
 
 	typeQuery->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md([Object Identification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#object-identification))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
-		}), schema->LookupType("Node")),
-		std::make_shared<schema::Field>(R"gql(appointments)gql"sv, R"md(Appointments [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("AppointmentConnection"))),
-		std::make_shared<schema::Field>(R"gql(tasks)gql"sv, R"md(Tasks [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("TaskConnection"))),
-		std::make_shared<schema::Field>(R"gql(unreadCounts)gql"sv, R"md(Folder unread counts [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("FolderConnection"))),
-		std::make_shared<schema::Field>(R"gql(appointmentsById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql(["ZmFrZUFwcG9pbnRtZW50SWQ="])gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Appointment")))),
-		std::make_shared<schema::Field>(R"gql(tasksById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Task")))),
-		std::make_shared<schema::Field>(R"gql(unreadCountsById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Folder")))),
-		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType"))),
-		std::make_shared<schema::Field>(R"gql(unimplemented)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<schema::Field>(R"gql(expensive)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Expensive")))))
+		schema::Field::Make(R"gql(node)gql"sv, R"md([Object Identification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#object-identification))md"sv, std::nullopt, schema->LookupType("Node"), {
+			schema::InputValue::Make(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(appointments)gql"sv, R"md(Appointments [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("AppointmentConnection")), {
+			schema::InputValue::Make(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(tasks)gql"sv, R"md(Tasks [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("TaskConnection")), {
+			schema::InputValue::Make(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(unreadCounts)gql"sv, R"md(Folder unread counts [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("FolderConnection")), {
+			schema::InputValue::Make(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(appointmentsById)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Appointment"))), {
+			schema::InputValue::Make(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql(["ZmFrZUFwcG9pbnRtZW50SWQ="])gql"sv)
+		}),
+		schema::Field::Make(R"gql(tasksById)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Task"))), {
+			schema::InputValue::Make(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(unreadCountsById)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Folder"))), {
+			schema::InputValue::Make(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType"))),
+		schema::Field::Make(R"gql(unimplemented)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		schema::Field::Make(R"gql(expensive)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Expensive")))))
 	});
 	typePageInfo->AddFields({
-		std::make_shared<schema::Field>(R"gql(hasNextPage)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(hasPreviousPage)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		schema::Field::Make(R"gql(hasNextPage)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		schema::Field::Make(R"gql(hasPreviousPage)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
 	});
 	typeAppointmentEdge->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Appointment")),
-		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Appointment")),
+		schema::Field::Make(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 	typeAppointmentConnection->AddFields({
-		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("AppointmentEdge")))
+		schema::Field::Make(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		schema::Field::Make(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("AppointmentEdge")))
 	});
 	typeTaskEdge->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Task")),
-		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Task")),
+		schema::Field::Make(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 	typeTaskConnection->AddFields({
-		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("TaskEdge")))
+		schema::Field::Make(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		schema::Field::Make(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("TaskEdge")))
 	});
 	typeFolderEdge->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Folder")),
-		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Folder")),
+		schema::Field::Make(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 	typeFolderConnection->AddFields({
-		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("FolderEdge")))
+		schema::Field::Make(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		schema::Field::Make(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("FolderEdge")))
 	});
 	typeCompleteTaskPayload->AddFields({
-		std::make_shared<schema::Field>(R"gql(task)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Task")),
-		std::make_shared<schema::Field>(R"gql(clientMutationId)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
+		schema::Field::Make(R"gql(task)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Task")),
+		schema::Field::Make(R"gql(clientMutationId)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String"))
 	});
 	typeMutation->AddFields({
-		std::make_shared<schema::Field>(R"gql(completeTask)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(input)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskInput")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskPayload"))),
-		std::make_shared<schema::Field>(R"gql(setFloat)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(value)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")))
+		schema::Field::Make(R"gql(completeTask)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskPayload")), {
+			schema::InputValue::Make(R"gql(input)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskInput")), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(setFloat)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), {
+			schema::InputValue::Make(R"gql(value)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), R"gql()gql"sv)
+		})
 	});
 	typeSubscription->AddFields({
-		std::make_shared<schema::Field>(R"gql(nextAppointmentChange)gql"sv, R"md()md"sv, std::make_optional(R"md(Need to deprecate a [field](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md"sv), std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Appointment")),
-		std::make_shared<schema::Field>(R"gql(nodeChange)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Node")))
+		schema::Field::Make(R"gql(nextAppointmentChange)gql"sv, R"md()md"sv, std::make_optional(R"md(Need to deprecate a [field](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md"sv), schema->LookupType("Appointment")),
+		schema::Field::Make(R"gql(nodeChange)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Node")), {
+			schema::InputValue::Make(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
+		})
 	});
 	typeAppointment->AddInterfaces({
 		typeNode
 	});
 	typeAppointment->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<schema::Field>(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("DateTime")),
-		std::make_shared<schema::Field>(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(forceError)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		schema::Field::Make(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("DateTime")),
+		schema::Field::Make(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		schema::Field::Make(R"gql(forceError)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String"))
 	});
 	typeTask->AddInterfaces({
 		typeNode
 	});
 	typeTask->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<schema::Field>(R"gql(title)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(isComplete)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		schema::Field::Make(R"gql(title)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(isComplete)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
 	});
 	typeFolder->AddInterfaces({
 		typeNode
 	});
 	typeFolder->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(unreadCount)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(unreadCount)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
 	});
 	typeNestedType->AddFields({
-		std::make_shared<schema::Field>(R"gql(depth)gql"sv, R"md(Depth of the nested element)md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
-		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md(Link to the next level)md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
+		schema::Field::Make(R"gql(depth)gql"sv, R"md(Depth of the nested element)md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
+		schema::Field::Make(R"gql(nested)gql"sv, R"md(Link to the next level)md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
 	});
 	typeExpensive->AddFields({
-		std::make_shared<schema::Field>(R"gql(order)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
+		schema::Field::Make(R"gql(order)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
 	});
 
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(id)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	schema->AddDirective(schema::Directive::Make(R"gql(id)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FIELD_DEFINITION
-	}), std::vector<std::shared_ptr<schema::InputValue>>()));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(subscriptionTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(subscriptionTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::SUBSCRIPTION
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(field)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(queryTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(field)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(queryTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::QUERY
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(query)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fieldTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(query)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(fieldTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FIELD
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(field)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fragmentDefinitionTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(field)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(fragmentDefinitionTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FRAGMENT_DEFINITION
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(fragmentDefinition)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fragmentSpreadTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(fragmentDefinition)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(fragmentSpreadTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FRAGMENT_SPREAD
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(fragmentSpread)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(inlineFragmentTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(fragmentSpread)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(inlineFragmentTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::INLINE_FRAGMENT
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(inlineFragment)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
+	}, {
+		schema::InputValue::Make(R"gql(inlineFragment)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
 
 	schema->AddQueryType(typeQuery);
 	schema->AddMutationType(typeMutation);

--- a/samples/unified/TodaySchema.h
+++ b/samples/unified/TodaySchema.h
@@ -374,7 +374,7 @@ private:
 	std::shared_ptr<object::Subscription> _subscription;
 };
 
-void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema);
+std::shared_ptr<schema::Schema> GetSchema();
 
 } /* namespace today */
 } /* namespace graphql */

--- a/samples/unified/TodaySchema.h
+++ b/samples/unified/TodaySchema.h
@@ -6,6 +6,7 @@
 #ifndef TODAYSCHEMA_H
 #define TODAYSCHEMA_H
 
+#include "graphqlservice/GraphQLSchema.h"
 #include "graphqlservice/GraphQLService.h"
 
 #include <memory>
@@ -98,7 +99,7 @@ private:
 	std::future<response::Value> resolve_schema(service::ResolverParams&& params);
 	std::future<response::Value> resolve_type(service::ResolverParams&& params);
 
-	std::shared_ptr<introspection::Schema> _schema;
+	std::shared_ptr<schema::Schema> _schema;
 };
 
 class PageInfo
@@ -379,7 +380,7 @@ private:
 	std::shared_ptr<object::Subscription> _subscription;
 };
 
-void AddTypesToSchema(const std::shared_ptr<introspection::Schema>& schema);
+void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema);
 
 } /* namespace today */
 } /* namespace graphql */

--- a/samples/unified/TodaySchema.h
+++ b/samples/unified/TodaySchema.h
@@ -14,12 +14,6 @@
 #include <vector>
 
 namespace graphql {
-namespace introspection {
-
-class Schema;
-
-} /* namespace introspection */
-
 namespace today {
 
 enum class TaskState

--- a/samples/unified/TodaySchema.h
+++ b/samples/unified/TodaySchema.h
@@ -78,20 +78,20 @@ public:
 	virtual service::FieldResult<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveAppointments(service::ResolverParams&& params);
-	std::future<response::Value> resolveTasks(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnreadCounts(service::ResolverParams&& params);
-	std::future<response::Value> resolveAppointmentsById(service::ResolverParams&& params);
-	std::future<response::Value> resolveTasksById(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnreadCountsById(service::ResolverParams&& params);
-	std::future<response::Value> resolveNested(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnimplemented(service::ResolverParams&& params);
-	std::future<response::Value> resolveExpensive(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveAppointments(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTasks(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnreadCounts(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveAppointmentsById(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTasksById(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnreadCountsById(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNested(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnimplemented(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveExpensive(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
-	std::future<response::Value> resolve_schema(service::ResolverParams&& params);
-	std::future<response::Value> resolve_type(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_schema(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_type(service::ResolverParams&& params);
 
 	std::shared_ptr<schema::Schema> _schema;
 };
@@ -107,10 +107,10 @@ public:
 	virtual service::FieldResult<response::BooleanType> getHasPreviousPage(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveHasNextPage(service::ResolverParams&& params);
-	std::future<response::Value> resolveHasPreviousPage(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveHasNextPage(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveHasPreviousPage(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class AppointmentEdge
@@ -124,10 +124,10 @@ public:
 	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCursor(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class AppointmentConnection
@@ -141,10 +141,10 @@ public:
 	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePageInfo(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveEdges(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class TaskEdge
@@ -158,10 +158,10 @@ public:
 	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCursor(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class TaskConnection
@@ -175,10 +175,10 @@ public:
 	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePageInfo(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveEdges(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class FolderEdge
@@ -192,10 +192,10 @@ public:
 	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCursor(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class FolderConnection
@@ -209,10 +209,10 @@ public:
 	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePageInfo(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveEdges(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class CompleteTaskPayload
@@ -226,10 +226,10 @@ public:
 	virtual service::FieldResult<std::optional<response::StringType>> getClientMutationId(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveTask(service::ResolverParams&& params);
-	std::future<response::Value> resolveClientMutationId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTask(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveClientMutationId(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Mutation
@@ -243,10 +243,10 @@ public:
 	virtual service::FieldResult<response::FloatType> applySetFloat(service::FieldParams&& params, response::FloatType&& valueArg) const;
 
 private:
-	std::future<response::Value> resolveCompleteTask(service::ResolverParams&& params);
-	std::future<response::Value> resolveSetFloat(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCompleteTask(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveSetFloat(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Subscription
@@ -260,10 +260,10 @@ public:
 	virtual service::FieldResult<std::shared_ptr<service::Object>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const;
 
 private:
-	std::future<response::Value> resolveNextAppointmentChange(service::ResolverParams&& params);
-	std::future<response::Value> resolveNodeChange(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNextAppointmentChange(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNodeChange(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Appointment
@@ -281,13 +281,13 @@ public:
 	virtual service::FieldResult<std::optional<response::StringType>> getForceError(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveId(service::ResolverParams&& params);
-	std::future<response::Value> resolveWhen(service::ResolverParams&& params);
-	std::future<response::Value> resolveSubject(service::ResolverParams&& params);
-	std::future<response::Value> resolveIsNow(service::ResolverParams&& params);
-	std::future<response::Value> resolveForceError(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveWhen(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveSubject(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveIsNow(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveForceError(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Task
@@ -303,11 +303,11 @@ public:
 	virtual service::FieldResult<response::BooleanType> getIsComplete(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveId(service::ResolverParams&& params);
-	std::future<response::Value> resolveTitle(service::ResolverParams&& params);
-	std::future<response::Value> resolveIsComplete(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTitle(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveIsComplete(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Folder
@@ -323,11 +323,11 @@ public:
 	virtual service::FieldResult<response::IntType> getUnreadCount(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveId(service::ResolverParams&& params);
-	std::future<response::Value> resolveName(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnreadCount(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveName(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnreadCount(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class NestedType
@@ -341,10 +341,10 @@ public:
 	virtual service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveDepth(service::ResolverParams&& params);
-	std::future<response::Value> resolveNested(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDepth(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNested(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Expensive
@@ -357,9 +357,9 @@ public:
 	virtual service::FieldResult<response::IntType> getOrder(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveOrder(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveOrder(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace object */

--- a/samples/unified/TodaySchema.h
+++ b/samples/unified/TodaySchema.h
@@ -278,12 +278,14 @@ public:
 	virtual service::FieldResult<std::optional<response::Value>> getWhen(service::FieldParams&& params) const;
 	virtual service::FieldResult<std::optional<response::StringType>> getSubject(service::FieldParams&& params) const;
 	virtual service::FieldResult<response::BooleanType> getIsNow(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<response::StringType>> getForceError(service::FieldParams&& params) const;
 
 private:
 	std::future<response::Value> resolveId(service::ResolverParams&& params);
 	std::future<response::Value> resolveWhen(service::ResolverParams&& params);
 	std::future<response::Value> resolveSubject(service::ResolverParams&& params);
 	std::future<response::Value> resolveIsNow(service::ResolverParams&& params);
+	std::future<response::Value> resolveForceError(service::ResolverParams&& params);
 
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };

--- a/samples/unified_nointrospection/TodaySchema.cpp
+++ b/samples/unified_nointrospection/TodaySchema.cpp
@@ -1249,7 +1249,7 @@ std::shared_ptr<schema::Schema> GetSchema()
 
 	if (!schema)
 	{
-		schema = std::make_shared<schema::Schema>();
+		schema = std::make_shared<schema::Schema>(true);
 		introspection::AddTypesToSchema(schema);
 		AddTypesToSchema(schema);
 		s_wpSchema = schema;

--- a/samples/unified_nointrospection/TodaySchema.cpp
+++ b/samples/unified_nointrospection/TodaySchema.cpp
@@ -1,0 +1,1025 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "TodaySchema.h"
+
+#include "graphqlservice/Introspection.h"
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+using namespace std::literals;
+
+namespace graphql {
+namespace service {
+
+static const std::array<std::string_view, 4> s_namesTaskState = {
+	"New",
+	"Started",
+	"Complete",
+	"Unassigned"
+};
+
+template <>
+today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Value& value)
+{
+	if (!value.maybe_enum())
+	{
+		throw service::schema_exception { { "not a valid TaskState value" } };
+	}
+
+	auto itr = std::find(s_namesTaskState.cbegin(), s_namesTaskState.cend(), value.get<response::StringType>());
+
+	if (itr == s_namesTaskState.cend())
+	{
+		throw service::schema_exception { { "not a valid TaskState value" } };
+	}
+
+	return static_cast<today::TaskState>(itr - s_namesTaskState.cbegin());
+}
+
+template <>
+std::future<response::Value> ModifiedResult<today::TaskState>::convert(service::FieldResult<today::TaskState>&& result, ResolverParams&& params)
+{
+	return resolve(std::move(result), std::move(params),
+		[](today::TaskState&& value, const ResolverParams&)
+		{
+			response::Value result(response::Type::EnumValue);
+
+			result.set<response::StringType>(std::string(s_namesTaskState[static_cast<size_t>(value)]));
+
+			return result;
+		});
+}
+
+template <>
+today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(const response::Value& value)
+{
+	const auto defaultValue = []()
+	{
+		response::Value values(response::Type::Map);
+		response::Value entry;
+
+		entry = response::Value(true);
+		values.emplace_back("isComplete", std::move(entry));
+
+		return values;
+	}();
+
+	auto valueId = service::ModifiedArgument<response::IdType>::require("id", value);
+	auto pairIsComplete = service::ModifiedArgument<response::BooleanType>::find<service::TypeModifier::Nullable>("isComplete", value);
+	auto valueIsComplete = (pairIsComplete.second
+		? std::move(pairIsComplete.first)
+		: service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable>("isComplete", defaultValue));
+	auto valueClientMutationId = service::ModifiedArgument<response::StringType>::require<service::TypeModifier::Nullable>("clientMutationId", value);
+
+	return {
+		std::move(valueId),
+		std::move(valueIsComplete),
+		std::move(valueClientMutationId)
+	};
+}
+
+} /* namespace service */
+
+namespace today {
+namespace object {
+
+Query::Query()
+	: service::Object({
+		"Query"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(appointments)gql"sv, [this](service::ResolverParams&& params) { return resolveAppointments(std::move(params)); } },
+		{ R"gql(appointmentsById)gql"sv, [this](service::ResolverParams&& params) { return resolveAppointmentsById(std::move(params)); } },
+		{ R"gql(expensive)gql"sv, [this](service::ResolverParams&& params) { return resolveExpensive(std::move(params)); } },
+		{ R"gql(nested)gql"sv, [this](service::ResolverParams&& params) { return resolveNested(std::move(params)); } },
+		{ R"gql(node)gql"sv, [this](service::ResolverParams&& params) { return resolveNode(std::move(params)); } },
+		{ R"gql(tasks)gql"sv, [this](service::ResolverParams&& params) { return resolveTasks(std::move(params)); } },
+		{ R"gql(tasksById)gql"sv, [this](service::ResolverParams&& params) { return resolveTasksById(std::move(params)); } },
+		{ R"gql(unimplemented)gql"sv, [this](service::ResolverParams&& params) { return resolveUnimplemented(std::move(params)); } },
+		{ R"gql(unreadCounts)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCounts(std::move(params)); } },
+		{ R"gql(unreadCountsById)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCountsById(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<service::Object>> Query::getNode(service::FieldParams&&, response::IdType&&) const
+{
+	throw std::runtime_error(R"ex(Query::getNode is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveNode(service::ResolverParams&& params)
+{
+	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argId));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<service::Object>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::shared_ptr<AppointmentConnection>> Query::getAppointments(service::FieldParams&&, std::optional<response::IntType>&&, std::optional<response::Value>&&, std::optional<response::IntType>&&, std::optional<response::Value>&&) const
+{
+	throw std::runtime_error(R"ex(Query::getAppointments is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveAppointments(service::ResolverParams&& params)
+{
+	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
+	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
+	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
+	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getAppointments(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<AppointmentConnection>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::shared_ptr<TaskConnection>> Query::getTasks(service::FieldParams&&, std::optional<response::IntType>&&, std::optional<response::Value>&&, std::optional<response::IntType>&&, std::optional<response::Value>&&) const
+{
+	throw std::runtime_error(R"ex(Query::getTasks is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveTasks(service::ResolverParams&& params)
+{
+	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
+	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
+	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
+	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getTasks(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<TaskConnection>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::shared_ptr<FolderConnection>> Query::getUnreadCounts(service::FieldParams&&, std::optional<response::IntType>&&, std::optional<response::Value>&&, std::optional<response::IntType>&&, std::optional<response::Value>&&) const
+{
+	throw std::runtime_error(R"ex(Query::getUnreadCounts is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveUnreadCounts(service::ResolverParams&& params)
+{
+	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
+	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
+	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
+	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getUnreadCounts(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<FolderConnection>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::vector<std::shared_ptr<Appointment>>> Query::getAppointmentsById(service::FieldParams&&, std::vector<response::IdType>&&) const
+{
+	throw std::runtime_error(R"ex(Query::getAppointmentsById is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveAppointmentsById(service::ResolverParams&& params)
+{
+	const auto defaultArguments = []()
+	{
+		response::Value values(response::Type::Map);
+		response::Value entry;
+
+		entry = []()
+		{
+			response::Value elements(response::Type::List);
+			response::Value entry;
+
+			entry = response::Value(std::string(R"gql(ZmFrZUFwcG9pbnRtZW50SWQ=)gql"));
+			elements.emplace_back(std::move(entry));
+			return elements;
+		}();
+		values.emplace_back("ids", std::move(entry));
+
+		return values;
+	}();
+
+	auto pairIds = service::ModifiedArgument<response::IdType>::find<service::TypeModifier::List>("ids", params.arguments);
+	auto argIds = (pairIds.second
+		? std::move(pairIds.first)
+		: service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", defaultArguments));
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getAppointmentsById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::vector<std::shared_ptr<Task>>> Query::getTasksById(service::FieldParams&&, std::vector<response::IdType>&&) const
+{
+	throw std::runtime_error(R"ex(Query::getTasksById is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveTasksById(service::ResolverParams&& params)
+{
+	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getTasksById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Task>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::vector<std::shared_ptr<Folder>>> Query::getUnreadCountsById(service::FieldParams&&, std::vector<response::IdType>&&) const
+{
+	throw std::runtime_error(R"ex(Query::getUnreadCountsById is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveUnreadCountsById(service::ResolverParams&& params)
+{
+	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getUnreadCountsById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Folder>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::shared_ptr<NestedType>> Query::getNested(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Query::getNested is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveNested(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::StringType> Query::getUnimplemented(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Query::getUnimplemented is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveUnimplemented(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getUnimplemented(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::vector<std::shared_ptr<Expensive>>> Query::getExpensive(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Query::getExpensive is not implemented)ex");
+}
+
+std::future<response::Value> Query::resolveExpensive(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getExpensive(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Expensive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Query::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Query)gql" }, std::move(params));
+}
+
+PageInfo::PageInfo()
+	: service::Object({
+		"PageInfo"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(hasNextPage)gql"sv, [this](service::ResolverParams&& params) { return resolveHasNextPage(std::move(params)); } },
+		{ R"gql(hasPreviousPage)gql"sv, [this](service::ResolverParams&& params) { return resolveHasPreviousPage(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<response::BooleanType> PageInfo::getHasNextPage(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(PageInfo::getHasNextPage is not implemented)ex");
+}
+
+std::future<response::Value> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getHasNextPage(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::BooleanType> PageInfo::getHasPreviousPage(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(PageInfo::getHasPreviousPage is not implemented)ex");
+}
+
+std::future<response::Value> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getHasPreviousPage(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> PageInfo::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(PageInfo)gql" }, std::move(params));
+}
+
+AppointmentEdge::AppointmentEdge()
+	: service::Object({
+		"AppointmentEdge"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(cursor)gql"sv, [this](service::ResolverParams&& params) { return resolveCursor(std::move(params)); } },
+		{ R"gql(node)gql"sv, [this](service::ResolverParams&& params) { return resolveNode(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<Appointment>> AppointmentEdge::getNode(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(AppointmentEdge::getNode is not implemented)ex");
+}
+
+std::future<response::Value> AppointmentEdge::resolveNode(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::Value> AppointmentEdge::getCursor(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(AppointmentEdge::getCursor is not implemented)ex");
+}
+
+std::future<response::Value> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> AppointmentEdge::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(AppointmentEdge)gql" }, std::move(params));
+}
+
+AppointmentConnection::AppointmentConnection()
+	: service::Object({
+		"AppointmentConnection"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(edges)gql"sv, [this](service::ResolverParams&& params) { return resolveEdges(std::move(params)); } },
+		{ R"gql(pageInfo)gql"sv, [this](service::ResolverParams&& params) { return resolvePageInfo(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<PageInfo>> AppointmentConnection::getPageInfo(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(AppointmentConnection::getPageInfo is not implemented)ex");
+}
+
+std::future<response::Value> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> AppointmentConnection::getEdges(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(AppointmentConnection::getEdges is not implemented)ex");
+}
+
+std::future<response::Value> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<AppointmentEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+std::future<response::Value> AppointmentConnection::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(AppointmentConnection)gql" }, std::move(params));
+}
+
+TaskEdge::TaskEdge()
+	: service::Object({
+		"TaskEdge"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(cursor)gql"sv, [this](service::ResolverParams&& params) { return resolveCursor(std::move(params)); } },
+		{ R"gql(node)gql"sv, [this](service::ResolverParams&& params) { return resolveNode(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<Task>> TaskEdge::getNode(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(TaskEdge::getNode is not implemented)ex");
+}
+
+std::future<response::Value> TaskEdge::resolveNode(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::Value> TaskEdge::getCursor(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(TaskEdge::getCursor is not implemented)ex");
+}
+
+std::future<response::Value> TaskEdge::resolveCursor(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> TaskEdge::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(TaskEdge)gql" }, std::move(params));
+}
+
+TaskConnection::TaskConnection()
+	: service::Object({
+		"TaskConnection"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(edges)gql"sv, [this](service::ResolverParams&& params) { return resolveEdges(std::move(params)); } },
+		{ R"gql(pageInfo)gql"sv, [this](service::ResolverParams&& params) { return resolvePageInfo(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<PageInfo>> TaskConnection::getPageInfo(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(TaskConnection::getPageInfo is not implemented)ex");
+}
+
+std::future<response::Value> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> TaskConnection::getEdges(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(TaskConnection::getEdges is not implemented)ex");
+}
+
+std::future<response::Value> TaskConnection::resolveEdges(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<TaskEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+std::future<response::Value> TaskConnection::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(TaskConnection)gql" }, std::move(params));
+}
+
+FolderEdge::FolderEdge()
+	: service::Object({
+		"FolderEdge"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(cursor)gql"sv, [this](service::ResolverParams&& params) { return resolveCursor(std::move(params)); } },
+		{ R"gql(node)gql"sv, [this](service::ResolverParams&& params) { return resolveNode(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<Folder>> FolderEdge::getNode(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(FolderEdge::getNode is not implemented)ex");
+}
+
+std::future<response::Value> FolderEdge::resolveNode(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Folder>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::Value> FolderEdge::getCursor(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(FolderEdge::getCursor is not implemented)ex");
+}
+
+std::future<response::Value> FolderEdge::resolveCursor(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> FolderEdge::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(FolderEdge)gql" }, std::move(params));
+}
+
+FolderConnection::FolderConnection()
+	: service::Object({
+		"FolderConnection"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(edges)gql"sv, [this](service::ResolverParams&& params) { return resolveEdges(std::move(params)); } },
+		{ R"gql(pageInfo)gql"sv, [this](service::ResolverParams&& params) { return resolvePageInfo(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<PageInfo>> FolderConnection::getPageInfo(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(FolderConnection::getPageInfo is not implemented)ex");
+}
+
+std::future<response::Value> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> FolderConnection::getEdges(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(FolderConnection::getEdges is not implemented)ex");
+}
+
+std::future<response::Value> FolderConnection::resolveEdges(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<FolderEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+std::future<response::Value> FolderConnection::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(FolderConnection)gql" }, std::move(params));
+}
+
+CompleteTaskPayload::CompleteTaskPayload()
+	: service::Object({
+		"CompleteTaskPayload"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(clientMutationId)gql"sv, [this](service::ResolverParams&& params) { return resolveClientMutationId(std::move(params)); } },
+		{ R"gql(task)gql"sv, [this](service::ResolverParams&& params) { return resolveTask(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<Task>> CompleteTaskPayload::getTask(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(CompleteTaskPayload::getTask is not implemented)ex");
+}
+
+std::future<response::Value> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getTask(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<response::StringType>> CompleteTaskPayload::getClientMutationId(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(CompleteTaskPayload::getClientMutationId is not implemented)ex");
+}
+
+std::future<response::Value> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getClientMutationId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+std::future<response::Value> CompleteTaskPayload::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(CompleteTaskPayload)gql" }, std::move(params));
+}
+
+Mutation::Mutation()
+	: service::Object({
+		"Mutation"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(completeTask)gql"sv, [this](service::ResolverParams&& params) { return resolveCompleteTask(std::move(params)); } },
+		{ R"gql(setFloat)gql"sv, [this](service::ResolverParams&& params) { return resolveSetFloat(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<CompleteTaskPayload>> Mutation::applyCompleteTask(service::FieldParams&&, CompleteTaskInput&&) const
+{
+	throw std::runtime_error(R"ex(Mutation::applyCompleteTask is not implemented)ex");
+}
+
+std::future<response::Value> Mutation::resolveCompleteTask(service::ResolverParams&& params)
+{
+	auto argInput = service::ModifiedArgument<today::CompleteTaskInput>::require("input", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = applyCompleteTask(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argInput));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<CompleteTaskPayload>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::FloatType> Mutation::applySetFloat(service::FieldParams&&, response::FloatType&&) const
+{
+	throw std::runtime_error(R"ex(Mutation::applySetFloat is not implemented)ex");
+}
+
+std::future<response::Value> Mutation::resolveSetFloat(service::ResolverParams&& params)
+{
+	auto argValue = service::ModifiedArgument<response::FloatType>::require("value", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = applySetFloat(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argValue));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::FloatType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Mutation::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Mutation)gql" }, std::move(params));
+}
+
+Subscription::Subscription()
+	: service::Object({
+		"Subscription"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(nextAppointmentChange)gql"sv, [this](service::ResolverParams&& params) { return resolveNextAppointmentChange(std::move(params)); } },
+		{ R"gql(nodeChange)gql"sv, [this](service::ResolverParams&& params) { return resolveNodeChange(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<std::shared_ptr<Appointment>> Subscription::getNextAppointmentChange(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Subscription::getNextAppointmentChange is not implemented)ex");
+}
+
+std::future<response::Value> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNextAppointmentChange(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::shared_ptr<service::Object>> Subscription::getNodeChange(service::FieldParams&&, response::IdType&&) const
+{
+	throw std::runtime_error(R"ex(Subscription::getNodeChange is not implemented)ex");
+}
+
+std::future<response::Value> Subscription::resolveNodeChange(service::ResolverParams&& params)
+{
+	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNodeChange(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argId));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<service::Object>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Subscription::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Subscription)gql" }, std::move(params));
+}
+
+Appointment::Appointment()
+	: service::Object({
+		"Node",
+		"UnionType",
+		"Appointment"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(id)gql"sv, [this](service::ResolverParams&& params) { return resolveId(std::move(params)); } },
+		{ R"gql(isNow)gql"sv, [this](service::ResolverParams&& params) { return resolveIsNow(std::move(params)); } },
+		{ R"gql(subject)gql"sv, [this](service::ResolverParams&& params) { return resolveSubject(std::move(params)); } },
+		{ R"gql(when)gql"sv, [this](service::ResolverParams&& params) { return resolveWhen(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<response::IdType> Appointment::getId(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Appointment::getId is not implemented)ex");
+}
+
+std::future<response::Value> Appointment::resolveId(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<response::Value>> Appointment::getWhen(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Appointment::getWhen is not implemented)ex");
+}
+
+std::future<response::Value> Appointment::resolveWhen(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getWhen(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::Value>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<response::StringType>> Appointment::getSubject(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Appointment::getSubject is not implemented)ex");
+}
+
+std::future<response::Value> Appointment::resolveSubject(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getSubject(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::BooleanType> Appointment::getIsNow(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Appointment::getIsNow is not implemented)ex");
+}
+
+std::future<response::Value> Appointment::resolveIsNow(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getIsNow(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Appointment::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Appointment)gql" }, std::move(params));
+}
+
+Task::Task()
+	: service::Object({
+		"Node",
+		"UnionType",
+		"Task"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(id)gql"sv, [this](service::ResolverParams&& params) { return resolveId(std::move(params)); } },
+		{ R"gql(isComplete)gql"sv, [this](service::ResolverParams&& params) { return resolveIsComplete(std::move(params)); } },
+		{ R"gql(title)gql"sv, [this](service::ResolverParams&& params) { return resolveTitle(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<response::IdType> Task::getId(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Task::getId is not implemented)ex");
+}
+
+std::future<response::Value> Task::resolveId(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<response::StringType>> Task::getTitle(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Task::getTitle is not implemented)ex");
+}
+
+std::future<response::Value> Task::resolveTitle(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getTitle(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::BooleanType> Task::getIsComplete(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Task::getIsComplete is not implemented)ex");
+}
+
+std::future<response::Value> Task::resolveIsComplete(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getIsComplete(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Task::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Task)gql" }, std::move(params));
+}
+
+Folder::Folder()
+	: service::Object({
+		"Node",
+		"UnionType",
+		"Folder"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(id)gql"sv, [this](service::ResolverParams&& params) { return resolveId(std::move(params)); } },
+		{ R"gql(name)gql"sv, [this](service::ResolverParams&& params) { return resolveName(std::move(params)); } },
+		{ R"gql(unreadCount)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCount(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<response::IdType> Folder::getId(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Folder::getId is not implemented)ex");
+}
+
+std::future<response::Value> Folder::resolveId(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<response::StringType>> Folder::getName(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Folder::getName is not implemented)ex");
+}
+
+std::future<response::Value> Folder::resolveName(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
+}
+
+service::FieldResult<response::IntType> Folder::getUnreadCount(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Folder::getUnreadCount is not implemented)ex");
+}
+
+std::future<response::Value> Folder::resolveUnreadCount(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getUnreadCount(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Folder::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Folder)gql" }, std::move(params));
+}
+
+NestedType::NestedType()
+	: service::Object({
+		"NestedType"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(depth)gql"sv, [this](service::ResolverParams&& params) { return resolveDepth(std::move(params)); } },
+		{ R"gql(nested)gql"sv, [this](service::ResolverParams&& params) { return resolveNested(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<response::IntType> NestedType::getDepth(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(NestedType::getDepth is not implemented)ex");
+}
+
+std::future<response::Value> NestedType::resolveDepth(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getDepth(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::shared_ptr<NestedType>> NestedType::getNested(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(NestedType::getNested is not implemented)ex");
+}
+
+std::future<response::Value> NestedType::resolveNested(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> NestedType::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(NestedType)gql" }, std::move(params));
+}
+
+Expensive::Expensive()
+	: service::Object({
+		"Expensive"
+	}, {
+		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(order)gql"sv, [this](service::ResolverParams&& params) { return resolveOrder(std::move(params)); } }
+	})
+{
+}
+
+service::FieldResult<response::IntType> Expensive::getOrder(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Expensive::getOrder is not implemented)ex");
+}
+
+std::future<response::Value> Expensive::resolveOrder(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getOrder(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
+}
+
+std::future<response::Value> Expensive::resolve_typename(service::ResolverParams&& params)
+{
+	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Expensive)gql" }, std::move(params));
+}
+
+} /* namespace object */
+
+Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<object::Mutation> mutation, std::shared_ptr<object::Subscription> subscription)
+	: service::Request({
+		{ "query", query },
+		{ "mutation", mutation },
+		{ "subscription", subscription }
+	})
+	, _query(std::move(query))
+	, _mutation(std::move(mutation))
+	, _subscription(std::move(subscription))
+{
+}
+
+} /* namespace today */
+} /* namespace graphql */

--- a/samples/unified_nointrospection/TodaySchema.cpp
+++ b/samples/unified_nointrospection/TodaySchema.cpp
@@ -3,7 +3,7 @@
 
 #include "TodaySchema.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <array>

--- a/samples/unified_nointrospection/TodaySchema.cpp
+++ b/samples/unified_nointrospection/TodaySchema.cpp
@@ -1038,47 +1038,47 @@ Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<obj
 
 void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 {
-	schema->AddType(R"gql(ItemCursor)gql"sv, std::make_shared<schema::ScalarType>(R"gql(ItemCursor)gql"sv, R"md()md"));
-	schema->AddType(R"gql(DateTime)gql"sv, std::make_shared<schema::ScalarType>(R"gql(DateTime)gql"sv, R"md()md"));
-	auto typeTaskState = std::make_shared<schema::EnumType>(R"gql(TaskState)gql"sv, R"md()md"sv);
+	schema->AddType(R"gql(ItemCursor)gql"sv, schema::ScalarType::Make(R"gql(ItemCursor)gql"sv, R"md()md"));
+	schema->AddType(R"gql(DateTime)gql"sv, schema::ScalarType::Make(R"gql(DateTime)gql"sv, R"md()md"));
+	auto typeTaskState = schema::EnumType::Make(R"gql(TaskState)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(TaskState)gql"sv, typeTaskState);
-	auto typeCompleteTaskInput = std::make_shared<schema::InputObjectType>(R"gql(CompleteTaskInput)gql"sv, R"md()md"sv);
+	auto typeCompleteTaskInput = schema::InputObjectType::Make(R"gql(CompleteTaskInput)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(CompleteTaskInput)gql"sv, typeCompleteTaskInput);
-	auto typeUnionType = std::make_shared<schema::UnionType>(R"gql(UnionType)gql"sv, R"md()md"sv);
+	auto typeUnionType = schema::UnionType::Make(R"gql(UnionType)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(UnionType)gql"sv, typeUnionType);
-	auto typeNode = std::make_shared<schema::InterfaceType>(R"gql(Node)gql"sv, R"md()md"sv);
+	auto typeNode = schema::InterfaceType::Make(R"gql(Node)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(Node)gql"sv, typeNode);
-	auto typeQuery = std::make_shared<schema::ObjectType>(R"gql(Query)gql"sv, R"md()md");
+	auto typeQuery = schema::ObjectType::Make(R"gql(Query)gql"sv, R"md()md");
 	schema->AddType(R"gql(Query)gql"sv, typeQuery);
-	auto typePageInfo = std::make_shared<schema::ObjectType>(R"gql(PageInfo)gql"sv, R"md()md");
+	auto typePageInfo = schema::ObjectType::Make(R"gql(PageInfo)gql"sv, R"md()md");
 	schema->AddType(R"gql(PageInfo)gql"sv, typePageInfo);
-	auto typeAppointmentEdge = std::make_shared<schema::ObjectType>(R"gql(AppointmentEdge)gql"sv, R"md()md");
+	auto typeAppointmentEdge = schema::ObjectType::Make(R"gql(AppointmentEdge)gql"sv, R"md()md");
 	schema->AddType(R"gql(AppointmentEdge)gql"sv, typeAppointmentEdge);
-	auto typeAppointmentConnection = std::make_shared<schema::ObjectType>(R"gql(AppointmentConnection)gql"sv, R"md()md");
+	auto typeAppointmentConnection = schema::ObjectType::Make(R"gql(AppointmentConnection)gql"sv, R"md()md");
 	schema->AddType(R"gql(AppointmentConnection)gql"sv, typeAppointmentConnection);
-	auto typeTaskEdge = std::make_shared<schema::ObjectType>(R"gql(TaskEdge)gql"sv, R"md()md");
+	auto typeTaskEdge = schema::ObjectType::Make(R"gql(TaskEdge)gql"sv, R"md()md");
 	schema->AddType(R"gql(TaskEdge)gql"sv, typeTaskEdge);
-	auto typeTaskConnection = std::make_shared<schema::ObjectType>(R"gql(TaskConnection)gql"sv, R"md()md");
+	auto typeTaskConnection = schema::ObjectType::Make(R"gql(TaskConnection)gql"sv, R"md()md");
 	schema->AddType(R"gql(TaskConnection)gql"sv, typeTaskConnection);
-	auto typeFolderEdge = std::make_shared<schema::ObjectType>(R"gql(FolderEdge)gql"sv, R"md()md");
+	auto typeFolderEdge = schema::ObjectType::Make(R"gql(FolderEdge)gql"sv, R"md()md");
 	schema->AddType(R"gql(FolderEdge)gql"sv, typeFolderEdge);
-	auto typeFolderConnection = std::make_shared<schema::ObjectType>(R"gql(FolderConnection)gql"sv, R"md()md");
+	auto typeFolderConnection = schema::ObjectType::Make(R"gql(FolderConnection)gql"sv, R"md()md");
 	schema->AddType(R"gql(FolderConnection)gql"sv, typeFolderConnection);
-	auto typeCompleteTaskPayload = std::make_shared<schema::ObjectType>(R"gql(CompleteTaskPayload)gql"sv, R"md()md");
+	auto typeCompleteTaskPayload = schema::ObjectType::Make(R"gql(CompleteTaskPayload)gql"sv, R"md()md");
 	schema->AddType(R"gql(CompleteTaskPayload)gql"sv, typeCompleteTaskPayload);
-	auto typeMutation = std::make_shared<schema::ObjectType>(R"gql(Mutation)gql"sv, R"md()md");
+	auto typeMutation = schema::ObjectType::Make(R"gql(Mutation)gql"sv, R"md()md");
 	schema->AddType(R"gql(Mutation)gql"sv, typeMutation);
-	auto typeSubscription = std::make_shared<schema::ObjectType>(R"gql(Subscription)gql"sv, R"md()md");
+	auto typeSubscription = schema::ObjectType::Make(R"gql(Subscription)gql"sv, R"md()md");
 	schema->AddType(R"gql(Subscription)gql"sv, typeSubscription);
-	auto typeAppointment = std::make_shared<schema::ObjectType>(R"gql(Appointment)gql"sv, R"md()md");
+	auto typeAppointment = schema::ObjectType::Make(R"gql(Appointment)gql"sv, R"md()md");
 	schema->AddType(R"gql(Appointment)gql"sv, typeAppointment);
-	auto typeTask = std::make_shared<schema::ObjectType>(R"gql(Task)gql"sv, R"md()md");
+	auto typeTask = schema::ObjectType::Make(R"gql(Task)gql"sv, R"md()md");
 	schema->AddType(R"gql(Task)gql"sv, typeTask);
-	auto typeFolder = std::make_shared<schema::ObjectType>(R"gql(Folder)gql"sv, R"md()md");
+	auto typeFolder = schema::ObjectType::Make(R"gql(Folder)gql"sv, R"md()md");
 	schema->AddType(R"gql(Folder)gql"sv, typeFolder);
-	auto typeNestedType = std::make_shared<schema::ObjectType>(R"gql(NestedType)gql"sv, R"md()md");
+	auto typeNestedType = schema::ObjectType::Make(R"gql(NestedType)gql"sv, R"md()md");
 	schema->AddType(R"gql(NestedType)gql"sv, typeNestedType);
-	auto typeExpensive = std::make_shared<schema::ObjectType>(R"gql(Expensive)gql"sv, R"md()md");
+	auto typeExpensive = schema::ObjectType::Make(R"gql(Expensive)gql"sv, R"md()md");
 	schema->AddType(R"gql(Expensive)gql"sv, typeExpensive);
 
 	typeTaskState->AddEnumValues({
@@ -1089,9 +1089,9 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	});
 
 	typeCompleteTaskInput->AddInputValues({
-		std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv),
-		std::make_shared<schema::InputValue>(R"gql(isComplete)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(true)gql"sv),
-		std::make_shared<schema::InputValue>(R"gql(clientMutationId)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
+		schema::InputValue::Make(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv),
+		schema::InputValue::Make(R"gql(isComplete)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql(true)gql"sv),
+		schema::InputValue::Make(R"gql(clientMutationId)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
 	});
 
 	typeUnionType->AddPossibleTypes({
@@ -1101,157 +1101,157 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	});
 
 	typeNode->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
 	});
 
 	typeQuery->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
-		}), schema->LookupType("Node")),
-		std::make_shared<schema::Field>(R"gql(appointments)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("AppointmentConnection"))),
-		std::make_shared<schema::Field>(R"gql(tasks)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("TaskConnection"))),
-		std::make_shared<schema::Field>(R"gql(unreadCounts)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("FolderConnection"))),
-		std::make_shared<schema::Field>(R"gql(appointmentsById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql(["ZmFrZUFwcG9pbnRtZW50SWQ="])gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Appointment")))),
-		std::make_shared<schema::Field>(R"gql(tasksById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Task")))),
-		std::make_shared<schema::Field>(R"gql(unreadCountsById)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Folder")))),
-		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType"))),
-		std::make_shared<schema::Field>(R"gql(unimplemented)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<schema::Field>(R"gql(expensive)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Expensive")))))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Node"), {
+			schema::InputValue::Make(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(appointments)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("AppointmentConnection")), {
+			schema::InputValue::Make(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(tasks)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("TaskConnection")), {
+			schema::InputValue::Make(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(unreadCounts)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("FolderConnection")), {
+			schema::InputValue::Make(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(appointmentsById)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Appointment"))), {
+			schema::InputValue::Make(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql(["ZmFrZUFwcG9pbnRtZW50SWQ="])gql"sv)
+		}),
+		schema::Field::Make(R"gql(tasksById)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Task"))), {
+			schema::InputValue::Make(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(unreadCountsById)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Folder"))), {
+			schema::InputValue::Make(R"gql(ids)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType"))),
+		schema::Field::Make(R"gql(unimplemented)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		schema::Field::Make(R"gql(expensive)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Expensive")))))
 	});
 	typePageInfo->AddFields({
-		std::make_shared<schema::Field>(R"gql(hasNextPage)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(hasPreviousPage)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		schema::Field::Make(R"gql(hasNextPage)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		schema::Field::Make(R"gql(hasPreviousPage)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
 	});
 	typeAppointmentEdge->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Appointment")),
-		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Appointment")),
+		schema::Field::Make(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 	typeAppointmentConnection->AddFields({
-		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("AppointmentEdge")))
+		schema::Field::Make(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		schema::Field::Make(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("AppointmentEdge")))
 	});
 	typeTaskEdge->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Task")),
-		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Task")),
+		schema::Field::Make(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 	typeTaskConnection->AddFields({
-		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("TaskEdge")))
+		schema::Field::Make(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		schema::Field::Make(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("TaskEdge")))
 	});
 	typeFolderEdge->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Folder")),
-		std::make_shared<schema::Field>(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
+		schema::Field::Make(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Folder")),
+		schema::Field::Make(R"gql(cursor)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ItemCursor")))
 	});
 	typeFolderConnection->AddFields({
-		std::make_shared<schema::Field>(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
-		std::make_shared<schema::Field>(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("FolderEdge")))
+		schema::Field::Make(R"gql(pageInfo)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("PageInfo"))),
+		schema::Field::Make(R"gql(edges)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("FolderEdge")))
 	});
 	typeCompleteTaskPayload->AddFields({
-		std::make_shared<schema::Field>(R"gql(task)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Task")),
-		std::make_shared<schema::Field>(R"gql(clientMutationId)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
+		schema::Field::Make(R"gql(task)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Task")),
+		schema::Field::Make(R"gql(clientMutationId)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String"))
 	});
 	typeMutation->AddFields({
-		std::make_shared<schema::Field>(R"gql(completeTask)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(input)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskInput")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskPayload"))),
-		std::make_shared<schema::Field>(R"gql(setFloat)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(value)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")))
+		schema::Field::Make(R"gql(completeTask)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskPayload")), {
+			schema::InputValue::Make(R"gql(input)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CompleteTaskInput")), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(setFloat)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), {
+			schema::InputValue::Make(R"gql(value)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Float")), R"gql()gql"sv)
+		})
 	});
 	typeSubscription->AddFields({
-		std::make_shared<schema::Field>(R"gql(nextAppointmentChange)gql"sv, R"md()md"sv, std::make_optional(R"md(Need to deprecate a [field](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md"sv), std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Appointment")),
-		std::make_shared<schema::Field>(R"gql(nodeChange)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Node")))
+		schema::Field::Make(R"gql(nextAppointmentChange)gql"sv, R"md()md"sv, std::make_optional(R"md(Need to deprecate a [field](https://facebook.github.io/graphql/June2018/#sec-Deprecation))md"sv), schema->LookupType("Appointment")),
+		schema::Field::Make(R"gql(nodeChange)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Node")), {
+			schema::InputValue::Make(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
+		})
 	});
 	typeAppointment->AddInterfaces({
 		typeNode
 	});
 	typeAppointment->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<schema::Field>(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("DateTime")),
-		std::make_shared<schema::Field>(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(forceError)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		schema::Field::Make(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("DateTime")),
+		schema::Field::Make(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		schema::Field::Make(R"gql(forceError)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String"))
 	});
 	typeTask->AddInterfaces({
 		typeNode
 	});
 	typeTask->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<schema::Field>(R"gql(title)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(isComplete)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		schema::Field::Make(R"gql(title)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(isComplete)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
 	});
 	typeFolder->AddInterfaces({
 		typeNode
 	});
 	typeFolder->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(unreadCount)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(unreadCount)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
 	});
 	typeNestedType->AddFields({
-		std::make_shared<schema::Field>(R"gql(depth)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
-		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
+		schema::Field::Make(R"gql(depth)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
+		schema::Field::Make(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
 	});
 	typeExpensive->AddFields({
-		std::make_shared<schema::Field>(R"gql(order)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
+		schema::Field::Make(R"gql(order)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
 	});
 
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(id)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	schema->AddDirective(schema::Directive::Make(R"gql(id)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FIELD_DEFINITION
-	}), std::vector<std::shared_ptr<schema::InputValue>>()));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(subscriptionTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(subscriptionTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::SUBSCRIPTION
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(field)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(queryTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(field)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(queryTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::QUERY
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(query)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fieldTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(query)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(fieldTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FIELD
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(field)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fragmentDefinitionTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(field)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(fragmentDefinitionTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FRAGMENT_DEFINITION
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(fragmentDefinition)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(fragmentSpreadTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(fragmentDefinition)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(fragmentSpreadTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::FRAGMENT_SPREAD
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(fragmentSpread)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
-	schema->AddDirective(std::make_shared<schema::Directive>(R"gql(inlineFragmentTag)gql"sv, R"md()md"sv, std::vector<introspection::DirectiveLocation>({
+	}, {
+		schema::InputValue::Make(R"gql(fragmentSpread)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
+	schema->AddDirective(schema::Directive::Make(R"gql(inlineFragmentTag)gql"sv, R"md()md"sv, {
 		introspection::DirectiveLocation::INLINE_FRAGMENT
-	}), std::vector<std::shared_ptr<schema::InputValue>>({
-		std::make_shared<schema::InputValue>(R"gql(inlineFragment)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
-	})));
+	}, {
+		schema::InputValue::Make(R"gql(inlineFragment)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")), R"gql()gql"sv)
+	}));
 
 	schema->AddQueryType(typeQuery);
 	schema->AddMutationType(typeMutation);

--- a/samples/unified_nointrospection/TodaySchema.cpp
+++ b/samples/unified_nointrospection/TodaySchema.cpp
@@ -107,10 +107,7 @@ Query::Query()
 		{ R"gql(unreadCounts)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCounts(std::move(params)); } },
 		{ R"gql(unreadCountsById)gql"sv, [this](service::ResolverParams&& params) { return resolveUnreadCountsById(std::move(params)); } }
 	})
-	, _schema(std::make_shared<schema::Schema>())
 {
-	introspection::AddTypesToSchema(_schema);
-	today::AddTypesToSchema(_schema);
 }
 
 service::FieldResult<std::shared_ptr<service::Object>> Query::getNode(service::FieldParams&&, response::IdType&&) const
@@ -1017,7 +1014,7 @@ Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<obj
 		{ "query", query },
 		{ "mutation", mutation },
 		{ "subscription", subscription }
-	}, nullptr)
+	}, GetSchema())
 	, _query(std::move(query))
 	, _mutation(std::move(mutation))
 	, _subscription(std::move(subscription))
@@ -1243,6 +1240,22 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	schema->AddQueryType(typeQuery);
 	schema->AddMutationType(typeMutation);
 	schema->AddSubscriptionType(typeSubscription);
+}
+
+std::shared_ptr<schema::Schema> GetSchema()
+{
+	static std::weak_ptr<schema::Schema> s_wpSchema;
+	auto schema = s_wpSchema.lock();
+
+	if (!schema)
+	{
+		schema = std::make_shared<schema::Schema>();
+		introspection::AddTypesToSchema(schema);
+		AddTypesToSchema(schema);
+		s_wpSchema = schema;
+	}
+
+	return schema;
 }
 
 } /* namespace today */

--- a/samples/unified_nointrospection/TodaySchema.cpp
+++ b/samples/unified_nointrospection/TodaySchema.cpp
@@ -1046,9 +1046,9 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	schema->AddType(R"gql(CompleteTaskInput)gql"sv, typeCompleteTaskInput);
 	auto typeUnionType = std::make_shared<schema::UnionType>(R"gql(UnionType)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(UnionType)gql"sv, typeUnionType);
-	auto typeNode = std::make_shared<schema::InterfaceType>(R"gql(Node)gql"sv, R"md(Node interface for Relay support)md"sv);
+	auto typeNode = std::make_shared<schema::InterfaceType>(R"gql(Node)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(Node)gql"sv, typeNode);
-	auto typeQuery = std::make_shared<schema::ObjectType>(R"gql(Query)gql"sv, R"md(Root Query type)md");
+	auto typeQuery = std::make_shared<schema::ObjectType>(R"gql(Query)gql"sv, R"md()md");
 	schema->AddType(R"gql(Query)gql"sv, typeQuery);
 	auto typePageInfo = std::make_shared<schema::ObjectType>(R"gql(PageInfo)gql"sv, R"md()md");
 	schema->AddType(R"gql(PageInfo)gql"sv, typePageInfo);
@@ -1076,7 +1076,7 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	schema->AddType(R"gql(Task)gql"sv, typeTask);
 	auto typeFolder = std::make_shared<schema::ObjectType>(R"gql(Folder)gql"sv, R"md()md");
 	schema->AddType(R"gql(Folder)gql"sv, typeFolder);
-	auto typeNestedType = std::make_shared<schema::ObjectType>(R"gql(NestedType)gql"sv, R"md(Infinitely nestable type which can be used with nested fragments to test directive handling)md");
+	auto typeNestedType = std::make_shared<schema::ObjectType>(R"gql(NestedType)gql"sv, R"md()md");
 	schema->AddType(R"gql(NestedType)gql"sv, typeNestedType);
 	auto typeExpensive = std::make_shared<schema::ObjectType>(R"gql(Expensive)gql"sv, R"md()md");
 	schema->AddType(R"gql(Expensive)gql"sv, typeExpensive);
@@ -1105,22 +1105,22 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	});
 
 	typeQuery->AddFields({
-		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md([Object Identification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#object-identification))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::Field>(R"gql(node)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
 			std::make_shared<schema::InputValue>(R"gql(id)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")), R"gql()gql"sv)
 		}), schema->LookupType("Node")),
-		std::make_shared<schema::Field>(R"gql(appointments)gql"sv, R"md(Appointments [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::Field>(R"gql(appointments)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
 			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
 		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("AppointmentConnection"))),
-		std::make_shared<schema::Field>(R"gql(tasks)gql"sv, R"md(Tasks [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::Field>(R"gql(tasks)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
 			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(before)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv)
 		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("TaskConnection"))),
-		std::make_shared<schema::Field>(R"gql(unreadCounts)gql"sv, R"md(Folder unread counts [Connection](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
+		std::make_shared<schema::Field>(R"gql(unreadCounts)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
 			std::make_shared<schema::InputValue>(R"gql(first)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(after)gql"sv, R"md()md"sv, schema->LookupType("ItemCursor"), R"gql()gql"sv),
 			std::make_shared<schema::InputValue>(R"gql(last)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv),
@@ -1212,8 +1212,8 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 		std::make_shared<schema::Field>(R"gql(unreadCount)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))
 	});
 	typeNestedType->AddFields({
-		std::make_shared<schema::Field>(R"gql(depth)gql"sv, R"md(Depth of the nested element)md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
-		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md(Link to the next level)md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
+		std::make_shared<schema::Field>(R"gql(depth)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
+		std::make_shared<schema::Field>(R"gql(nested)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("NestedType")))
 	});
 	typeExpensive->AddFields({
 		std::make_shared<schema::Field>(R"gql(order)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")))

--- a/samples/unified_nointrospection/TodaySchema.cpp
+++ b/samples/unified_nointrospection/TodaySchema.cpp
@@ -743,6 +743,7 @@ Appointment::Appointment()
 		"Appointment"
 	}, {
 		{ R"gql(__typename)gql"sv, [this](service::ResolverParams&& params) { return resolve_typename(std::move(params)); } },
+		{ R"gql(forceError)gql"sv, [this](service::ResolverParams&& params) { return resolveForceError(std::move(params)); } },
 		{ R"gql(id)gql"sv, [this](service::ResolverParams&& params) { return resolveId(std::move(params)); } },
 		{ R"gql(isNow)gql"sv, [this](service::ResolverParams&& params) { return resolveIsNow(std::move(params)); } },
 		{ R"gql(subject)gql"sv, [this](service::ResolverParams&& params) { return resolveSubject(std::move(params)); } },
@@ -805,6 +806,20 @@ std::future<response::Value> Appointment::resolveIsNow(service::ResolverParams&&
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
+}
+
+service::FieldResult<std::optional<response::StringType>> Appointment::getForceError(service::FieldParams&&) const
+{
+	throw std::runtime_error(R"ex(Appointment::getForceError is not implemented)ex");
+}
+
+std::future<response::Value> Appointment::resolveForceError(service::ResolverParams&& params)
+{
+	std::unique_lock resolverLock(_resolverMutex);
+	auto result = getForceError(service::FieldParams(params, std::move(params.fieldDirectives)));
+	resolverLock.unlock();
+
+	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 std::future<response::Value> Appointment::resolve_typename(service::ResolverParams&& params)
@@ -1177,7 +1192,8 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID"))),
 		std::make_shared<schema::Field>(R"gql(when)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("DateTime")),
 		std::make_shared<schema::Field>(R"gql(subject)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		std::make_shared<schema::Field>(R"gql(isNow)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
+		std::make_shared<schema::Field>(R"gql(forceError)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
 	});
 	typeTask->AddInterfaces({
 		typeNode

--- a/samples/unified_nointrospection/TodaySchema.cpp
+++ b/samples/unified_nointrospection/TodaySchema.cpp
@@ -45,7 +45,7 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Val
 }
 
 template <>
-std::future<response::Value> ModifiedResult<today::TaskState>::convert(service::FieldResult<today::TaskState>&& result, ResolverParams&& params)
+std::future<service::ResolverResult> ModifiedResult<today::TaskState>::convert(service::FieldResult<today::TaskState>&& result, ResolverParams&& params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](today::TaskState&& value, const ResolverParams&)
@@ -115,7 +115,7 @@ service::FieldResult<std::shared_ptr<service::Object>> Query::getNode(service::F
 	throw std::runtime_error(R"ex(Query::getNode is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveNode(service::ResolverParams&& params)
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -130,7 +130,7 @@ service::FieldResult<std::shared_ptr<AppointmentConnection>> Query::getAppointme
 	throw std::runtime_error(R"ex(Query::getAppointments is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveAppointments(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveAppointments(service::ResolverParams&& params)
 {
 	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
@@ -148,7 +148,7 @@ service::FieldResult<std::shared_ptr<TaskConnection>> Query::getTasks(service::F
 	throw std::runtime_error(R"ex(Query::getTasks is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveTasks(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveTasks(service::ResolverParams&& params)
 {
 	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
@@ -166,7 +166,7 @@ service::FieldResult<std::shared_ptr<FolderConnection>> Query::getUnreadCounts(s
 	throw std::runtime_error(R"ex(Query::getUnreadCounts is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveUnreadCounts(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveUnreadCounts(service::ResolverParams&& params)
 {
 	auto argFirst = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("first", params.arguments);
 	auto argAfter = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("after", params.arguments);
@@ -184,7 +184,7 @@ service::FieldResult<std::vector<std::shared_ptr<Appointment>>> Query::getAppoin
 	throw std::runtime_error(R"ex(Query::getAppointmentsById is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveAppointmentsById(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveAppointmentsById(service::ResolverParams&& params)
 {
 	const auto defaultArguments = []()
 	{
@@ -221,7 +221,7 @@ service::FieldResult<std::vector<std::shared_ptr<Task>>> Query::getTasksById(ser
 	throw std::runtime_error(R"ex(Query::getTasksById is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveTasksById(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveTasksById(service::ResolverParams&& params)
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -236,7 +236,7 @@ service::FieldResult<std::vector<std::shared_ptr<Folder>>> Query::getUnreadCount
 	throw std::runtime_error(R"ex(Query::getUnreadCountsById is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveUnreadCountsById(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveUnreadCountsById(service::ResolverParams&& params)
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -251,7 +251,7 @@ service::FieldResult<std::shared_ptr<NestedType>> Query::getNested(service::Fiel
 	throw std::runtime_error(R"ex(Query::getNested is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveNested(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -265,7 +265,7 @@ service::FieldResult<response::StringType> Query::getUnimplemented(service::Fiel
 	throw std::runtime_error(R"ex(Query::getUnimplemented is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveUnimplemented(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveUnimplemented(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getUnimplemented(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -279,7 +279,7 @@ service::FieldResult<std::vector<std::shared_ptr<Expensive>>> Query::getExpensiv
 	throw std::runtime_error(R"ex(Query::getExpensive is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveExpensive(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveExpensive(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getExpensive(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -288,7 +288,7 @@ std::future<response::Value> Query::resolveExpensive(service::ResolverParams&& p
 	return service::ModifiedResult<Expensive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Query::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Query)gql" }, std::move(params));
 }
@@ -309,7 +309,7 @@ service::FieldResult<response::BooleanType> PageInfo::getHasNextPage(service::Fi
 	throw std::runtime_error(R"ex(PageInfo::getHasNextPage is not implemented)ex");
 }
 
-std::future<response::Value> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
+std::future<service::ResolverResult> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getHasNextPage(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -323,7 +323,7 @@ service::FieldResult<response::BooleanType> PageInfo::getHasPreviousPage(service
 	throw std::runtime_error(R"ex(PageInfo::getHasPreviousPage is not implemented)ex");
 }
 
-std::future<response::Value> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
+std::future<service::ResolverResult> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getHasPreviousPage(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -332,7 +332,7 @@ std::future<response::Value> PageInfo::resolveHasPreviousPage(service::ResolverP
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> PageInfo::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> PageInfo::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(PageInfo)gql" }, std::move(params));
 }
@@ -353,7 +353,7 @@ service::FieldResult<std::shared_ptr<Appointment>> AppointmentEdge::getNode(serv
 	throw std::runtime_error(R"ex(AppointmentEdge::getNode is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentEdge::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -367,7 +367,7 @@ service::FieldResult<response::Value> AppointmentEdge::getCursor(service::FieldP
 	throw std::runtime_error(R"ex(AppointmentEdge::getCursor is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -376,7 +376,7 @@ std::future<response::Value> AppointmentEdge::resolveCursor(service::ResolverPar
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> AppointmentEdge::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentEdge::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(AppointmentEdge)gql" }, std::move(params));
 }
@@ -397,7 +397,7 @@ service::FieldResult<std::shared_ptr<PageInfo>> AppointmentConnection::getPageIn
 	throw std::runtime_error(R"ex(AppointmentConnection::getPageInfo is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -411,7 +411,7 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>
 	throw std::runtime_error(R"ex(AppointmentConnection::getEdges is not implemented)ex");
 }
 
-std::future<response::Value> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -420,7 +420,7 @@ std::future<response::Value> AppointmentConnection::resolveEdges(service::Resolv
 	return service::ModifiedResult<AppointmentEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> AppointmentConnection::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> AppointmentConnection::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(AppointmentConnection)gql" }, std::move(params));
 }
@@ -441,7 +441,7 @@ service::FieldResult<std::shared_ptr<Task>> TaskEdge::getNode(service::FieldPara
 	throw std::runtime_error(R"ex(TaskEdge::getNode is not implemented)ex");
 }
 
-std::future<response::Value> TaskEdge::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -455,7 +455,7 @@ service::FieldResult<response::Value> TaskEdge::getCursor(service::FieldParams&&
 	throw std::runtime_error(R"ex(TaskEdge::getCursor is not implemented)ex");
 }
 
-std::future<response::Value> TaskEdge::resolveCursor(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -464,7 +464,7 @@ std::future<response::Value> TaskEdge::resolveCursor(service::ResolverParams&& p
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> TaskEdge::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskEdge::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(TaskEdge)gql" }, std::move(params));
 }
@@ -485,7 +485,7 @@ service::FieldResult<std::shared_ptr<PageInfo>> TaskConnection::getPageInfo(serv
 	throw std::runtime_error(R"ex(TaskConnection::getPageInfo is not implemented)ex");
 }
 
-std::future<response::Value> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -499,7 +499,7 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> Task
 	throw std::runtime_error(R"ex(TaskConnection::getEdges is not implemented)ex");
 }
 
-std::future<response::Value> TaskConnection::resolveEdges(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -508,7 +508,7 @@ std::future<response::Value> TaskConnection::resolveEdges(service::ResolverParam
 	return service::ModifiedResult<TaskEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> TaskConnection::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> TaskConnection::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(TaskConnection)gql" }, std::move(params));
 }
@@ -529,7 +529,7 @@ service::FieldResult<std::shared_ptr<Folder>> FolderEdge::getNode(service::Field
 	throw std::runtime_error(R"ex(FolderEdge::getNode is not implemented)ex");
 }
 
-std::future<response::Value> FolderEdge::resolveNode(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -543,7 +543,7 @@ service::FieldResult<response::Value> FolderEdge::getCursor(service::FieldParams
 	throw std::runtime_error(R"ex(FolderEdge::getCursor is not implemented)ex");
 }
 
-std::future<response::Value> FolderEdge::resolveCursor(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -552,7 +552,7 @@ std::future<response::Value> FolderEdge::resolveCursor(service::ResolverParams&&
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> FolderEdge::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderEdge::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(FolderEdge)gql" }, std::move(params));
 }
@@ -573,7 +573,7 @@ service::FieldResult<std::shared_ptr<PageInfo>> FolderConnection::getPageInfo(se
 	throw std::runtime_error(R"ex(FolderConnection::getPageInfo is not implemented)ex");
 }
 
-std::future<response::Value> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -587,7 +587,7 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> Fo
 	throw std::runtime_error(R"ex(FolderConnection::getEdges is not implemented)ex");
 }
 
-std::future<response::Value> FolderConnection::resolveEdges(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -596,7 +596,7 @@ std::future<response::Value> FolderConnection::resolveEdges(service::ResolverPar
 	return service::ModifiedResult<FolderEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> FolderConnection::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> FolderConnection::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(FolderConnection)gql" }, std::move(params));
 }
@@ -617,7 +617,7 @@ service::FieldResult<std::shared_ptr<Task>> CompleteTaskPayload::getTask(service
 	throw std::runtime_error(R"ex(CompleteTaskPayload::getTask is not implemented)ex");
 }
 
-std::future<response::Value> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
+std::future<service::ResolverResult> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getTask(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -631,7 +631,7 @@ service::FieldResult<std::optional<response::StringType>> CompleteTaskPayload::g
 	throw std::runtime_error(R"ex(CompleteTaskPayload::getClientMutationId is not implemented)ex");
 }
 
-std::future<response::Value> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
+std::future<service::ResolverResult> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getClientMutationId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -640,7 +640,7 @@ std::future<response::Value> CompleteTaskPayload::resolveClientMutationId(servic
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> CompleteTaskPayload::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> CompleteTaskPayload::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(CompleteTaskPayload)gql" }, std::move(params));
 }
@@ -661,7 +661,7 @@ service::FieldResult<std::shared_ptr<CompleteTaskPayload>> Mutation::applyComple
 	throw std::runtime_error(R"ex(Mutation::applyCompleteTask is not implemented)ex");
 }
 
-std::future<response::Value> Mutation::resolveCompleteTask(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolveCompleteTask(service::ResolverParams&& params)
 {
 	auto argInput = service::ModifiedArgument<today::CompleteTaskInput>::require("input", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -676,7 +676,7 @@ service::FieldResult<response::FloatType> Mutation::applySetFloat(service::Field
 	throw std::runtime_error(R"ex(Mutation::applySetFloat is not implemented)ex");
 }
 
-std::future<response::Value> Mutation::resolveSetFloat(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolveSetFloat(service::ResolverParams&& params)
 {
 	auto argValue = service::ModifiedArgument<response::FloatType>::require("value", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -686,7 +686,7 @@ std::future<response::Value> Mutation::resolveSetFloat(service::ResolverParams&&
 	return service::ModifiedResult<response::FloatType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Mutation::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Mutation)gql" }, std::move(params));
 }
@@ -707,7 +707,7 @@ service::FieldResult<std::shared_ptr<Appointment>> Subscription::getNextAppointm
 	throw std::runtime_error(R"ex(Subscription::getNextAppointmentChange is not implemented)ex");
 }
 
-std::future<response::Value> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNextAppointmentChange(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -721,7 +721,7 @@ service::FieldResult<std::shared_ptr<service::Object>> Subscription::getNodeChan
 	throw std::runtime_error(R"ex(Subscription::getNodeChange is not implemented)ex");
 }
 
-std::future<response::Value> Subscription::resolveNodeChange(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolveNodeChange(service::ResolverParams&& params)
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -731,7 +731,7 @@ std::future<response::Value> Subscription::resolveNodeChange(service::ResolverPa
 	return service::ModifiedResult<service::Object>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Subscription::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Subscription)gql" }, std::move(params));
 }
@@ -757,7 +757,7 @@ service::FieldResult<response::IdType> Appointment::getId(service::FieldParams&&
 	throw std::runtime_error(R"ex(Appointment::getId is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveId(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -771,7 +771,7 @@ service::FieldResult<std::optional<response::Value>> Appointment::getWhen(servic
 	throw std::runtime_error(R"ex(Appointment::getWhen is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveWhen(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveWhen(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getWhen(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -785,7 +785,7 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getSubjec
 	throw std::runtime_error(R"ex(Appointment::getSubject is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveSubject(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveSubject(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getSubject(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -799,7 +799,7 @@ service::FieldResult<response::BooleanType> Appointment::getIsNow(service::Field
 	throw std::runtime_error(R"ex(Appointment::getIsNow is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveIsNow(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveIsNow(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getIsNow(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -813,7 +813,7 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getForceE
 	throw std::runtime_error(R"ex(Appointment::getForceError is not implemented)ex");
 }
 
-std::future<response::Value> Appointment::resolveForceError(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolveForceError(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getForceError(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -822,7 +822,7 @@ std::future<response::Value> Appointment::resolveForceError(service::ResolverPar
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Appointment::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Appointment::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Appointment)gql" }, std::move(params));
 }
@@ -846,7 +846,7 @@ service::FieldResult<response::IdType> Task::getId(service::FieldParams&&) const
 	throw std::runtime_error(R"ex(Task::getId is not implemented)ex");
 }
 
-std::future<response::Value> Task::resolveId(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -860,7 +860,7 @@ service::FieldResult<std::optional<response::StringType>> Task::getTitle(service
 	throw std::runtime_error(R"ex(Task::getTitle is not implemented)ex");
 }
 
-std::future<response::Value> Task::resolveTitle(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolveTitle(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getTitle(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -874,7 +874,7 @@ service::FieldResult<response::BooleanType> Task::getIsComplete(service::FieldPa
 	throw std::runtime_error(R"ex(Task::getIsComplete is not implemented)ex");
 }
 
-std::future<response::Value> Task::resolveIsComplete(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolveIsComplete(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getIsComplete(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -883,7 +883,7 @@ std::future<response::Value> Task::resolveIsComplete(service::ResolverParams&& p
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Task::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Task::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Task)gql" }, std::move(params));
 }
@@ -907,7 +907,7 @@ service::FieldResult<response::IdType> Folder::getId(service::FieldParams&&) con
 	throw std::runtime_error(R"ex(Folder::getId is not implemented)ex");
 }
 
-std::future<response::Value> Folder::resolveId(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -921,7 +921,7 @@ service::FieldResult<std::optional<response::StringType>> Folder::getName(servic
 	throw std::runtime_error(R"ex(Folder::getName is not implemented)ex");
 }
 
-std::future<response::Value> Folder::resolveName(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -935,7 +935,7 @@ service::FieldResult<response::IntType> Folder::getUnreadCount(service::FieldPar
 	throw std::runtime_error(R"ex(Folder::getUnreadCount is not implemented)ex");
 }
 
-std::future<response::Value> Folder::resolveUnreadCount(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolveUnreadCount(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getUnreadCount(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -944,7 +944,7 @@ std::future<response::Value> Folder::resolveUnreadCount(service::ResolverParams&
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Folder::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Folder::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Folder)gql" }, std::move(params));
 }
@@ -965,7 +965,7 @@ service::FieldResult<response::IntType> NestedType::getDepth(service::FieldParam
 	throw std::runtime_error(R"ex(NestedType::getDepth is not implemented)ex");
 }
 
-std::future<response::Value> NestedType::resolveDepth(service::ResolverParams&& params)
+std::future<service::ResolverResult> NestedType::resolveDepth(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDepth(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -979,7 +979,7 @@ service::FieldResult<std::shared_ptr<NestedType>> NestedType::getNested(service:
 	throw std::runtime_error(R"ex(NestedType::getNested is not implemented)ex");
 }
 
-std::future<response::Value> NestedType::resolveNested(service::ResolverParams&& params)
+std::future<service::ResolverResult> NestedType::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -988,7 +988,7 @@ std::future<response::Value> NestedType::resolveNested(service::ResolverParams&&
 	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> NestedType::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> NestedType::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(NestedType)gql" }, std::move(params));
 }
@@ -1008,7 +1008,7 @@ service::FieldResult<response::IntType> Expensive::getOrder(service::FieldParams
 	throw std::runtime_error(R"ex(Expensive::getOrder is not implemented)ex");
 }
 
-std::future<response::Value> Expensive::resolveOrder(service::ResolverParams&& params)
+std::future<service::ResolverResult> Expensive::resolveOrder(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getOrder(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -1017,7 +1017,7 @@ std::future<response::Value> Expensive::resolveOrder(service::ResolverParams&& p
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Expensive::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Expensive::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Expensive)gql" }, std::move(params));
 }

--- a/samples/unified_nointrospection/TodaySchema.h
+++ b/samples/unified_nointrospection/TodaySchema.h
@@ -274,12 +274,14 @@ public:
 	virtual service::FieldResult<std::optional<response::Value>> getWhen(service::FieldParams&& params) const;
 	virtual service::FieldResult<std::optional<response::StringType>> getSubject(service::FieldParams&& params) const;
 	virtual service::FieldResult<response::BooleanType> getIsNow(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<response::StringType>> getForceError(service::FieldParams&& params) const;
 
 private:
 	std::future<response::Value> resolveId(service::ResolverParams&& params);
 	std::future<response::Value> resolveWhen(service::ResolverParams&& params);
 	std::future<response::Value> resolveSubject(service::ResolverParams&& params);
 	std::future<response::Value> resolveIsNow(service::ResolverParams&& params);
+	std::future<response::Value> resolveForceError(service::ResolverParams&& params);
 
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
 };

--- a/samples/unified_nointrospection/TodaySchema.h
+++ b/samples/unified_nointrospection/TodaySchema.h
@@ -6,6 +6,7 @@
 #ifndef TODAYSCHEMA_H
 #define TODAYSCHEMA_H
 
+#include "graphqlservice/GraphQLSchema.h"
 #include "graphqlservice/GraphQLService.h"
 
 #include <memory>
@@ -95,6 +96,8 @@ private:
 	std::future<response::Value> resolveExpensive(service::ResolverParams&& params);
 
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+
+	std::shared_ptr<schema::Schema> _schema;
 };
 
 class PageInfo
@@ -374,6 +377,8 @@ private:
 	std::shared_ptr<object::Mutation> _mutation;
 	std::shared_ptr<object::Subscription> _subscription;
 };
+
+void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema);
 
 } /* namespace today */
 } /* namespace graphql */

--- a/samples/unified_nointrospection/TodaySchema.h
+++ b/samples/unified_nointrospection/TodaySchema.h
@@ -90,8 +90,6 @@ private:
 	std::future<response::Value> resolveExpensive(service::ResolverParams&& params);
 
 	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
-
-	std::shared_ptr<schema::Schema> _schema;
 };
 
 class PageInfo
@@ -372,7 +370,7 @@ private:
 	std::shared_ptr<object::Subscription> _subscription;
 };
 
-void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema);
+std::shared_ptr<schema::Schema> GetSchema();
 
 } /* namespace today */
 } /* namespace graphql */

--- a/samples/unified_nointrospection/TodaySchema.h
+++ b/samples/unified_nointrospection/TodaySchema.h
@@ -14,12 +14,6 @@
 #include <vector>
 
 namespace graphql {
-namespace introspection {
-
-class Schema;
-
-} /* namespace introspection */
-
 namespace today {
 
 enum class TaskState

--- a/samples/unified_nointrospection/TodaySchema.h
+++ b/samples/unified_nointrospection/TodaySchema.h
@@ -78,18 +78,18 @@ public:
 	virtual service::FieldResult<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveAppointments(service::ResolverParams&& params);
-	std::future<response::Value> resolveTasks(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnreadCounts(service::ResolverParams&& params);
-	std::future<response::Value> resolveAppointmentsById(service::ResolverParams&& params);
-	std::future<response::Value> resolveTasksById(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnreadCountsById(service::ResolverParams&& params);
-	std::future<response::Value> resolveNested(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnimplemented(service::ResolverParams&& params);
-	std::future<response::Value> resolveExpensive(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveAppointments(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTasks(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnreadCounts(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveAppointmentsById(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTasksById(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnreadCountsById(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNested(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnimplemented(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveExpensive(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class PageInfo
@@ -103,10 +103,10 @@ public:
 	virtual service::FieldResult<response::BooleanType> getHasPreviousPage(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveHasNextPage(service::ResolverParams&& params);
-	std::future<response::Value> resolveHasPreviousPage(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveHasNextPage(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveHasPreviousPage(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class AppointmentEdge
@@ -120,10 +120,10 @@ public:
 	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCursor(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class AppointmentConnection
@@ -137,10 +137,10 @@ public:
 	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePageInfo(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveEdges(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class TaskEdge
@@ -154,10 +154,10 @@ public:
 	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCursor(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class TaskConnection
@@ -171,10 +171,10 @@ public:
 	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePageInfo(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveEdges(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class FolderEdge
@@ -188,10 +188,10 @@ public:
 	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNode(service::ResolverParams&& params);
-	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNode(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCursor(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class FolderConnection
@@ -205,10 +205,10 @@ public:
 	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
-	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePageInfo(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveEdges(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class CompleteTaskPayload
@@ -222,10 +222,10 @@ public:
 	virtual service::FieldResult<std::optional<response::StringType>> getClientMutationId(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveTask(service::ResolverParams&& params);
-	std::future<response::Value> resolveClientMutationId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTask(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveClientMutationId(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Mutation
@@ -239,10 +239,10 @@ public:
 	virtual service::FieldResult<response::FloatType> applySetFloat(service::FieldParams&& params, response::FloatType&& valueArg) const;
 
 private:
-	std::future<response::Value> resolveCompleteTask(service::ResolverParams&& params);
-	std::future<response::Value> resolveSetFloat(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCompleteTask(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveSetFloat(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Subscription
@@ -256,10 +256,10 @@ public:
 	virtual service::FieldResult<std::shared_ptr<service::Object>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const;
 
 private:
-	std::future<response::Value> resolveNextAppointmentChange(service::ResolverParams&& params);
-	std::future<response::Value> resolveNodeChange(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNextAppointmentChange(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNodeChange(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Appointment
@@ -277,13 +277,13 @@ public:
 	virtual service::FieldResult<std::optional<response::StringType>> getForceError(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveId(service::ResolverParams&& params);
-	std::future<response::Value> resolveWhen(service::ResolverParams&& params);
-	std::future<response::Value> resolveSubject(service::ResolverParams&& params);
-	std::future<response::Value> resolveIsNow(service::ResolverParams&& params);
-	std::future<response::Value> resolveForceError(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveWhen(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveSubject(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveIsNow(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveForceError(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Task
@@ -299,11 +299,11 @@ public:
 	virtual service::FieldResult<response::BooleanType> getIsComplete(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveId(service::ResolverParams&& params);
-	std::future<response::Value> resolveTitle(service::ResolverParams&& params);
-	std::future<response::Value> resolveIsComplete(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveTitle(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveIsComplete(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Folder
@@ -319,11 +319,11 @@ public:
 	virtual service::FieldResult<response::IntType> getUnreadCount(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveId(service::ResolverParams&& params);
-	std::future<response::Value> resolveName(service::ResolverParams&& params);
-	std::future<response::Value> resolveUnreadCount(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveName(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveUnreadCount(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class NestedType
@@ -337,10 +337,10 @@ public:
 	virtual service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveDepth(service::ResolverParams&& params);
-	std::future<response::Value> resolveNested(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDepth(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNested(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Expensive
@@ -353,9 +353,9 @@ public:
 	virtual service::FieldResult<response::IntType> getOrder(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveOrder(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveOrder(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace object */

--- a/samples/unified_nointrospection/TodaySchema.h
+++ b/samples/unified_nointrospection/TodaySchema.h
@@ -1,0 +1,381 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifndef TODAYSCHEMA_H
+#define TODAYSCHEMA_H
+
+#include "graphqlservice/GraphQLService.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace graphql {
+namespace introspection {
+
+class Schema;
+
+} /* namespace introspection */
+
+namespace today {
+
+enum class TaskState
+{
+	New,
+	Started,
+	Complete,
+	Unassigned
+};
+
+struct CompleteTaskInput
+{
+	response::IdType id;
+	std::optional<response::BooleanType> isComplete;
+	std::optional<response::StringType> clientMutationId;
+};
+
+namespace object {
+
+class Query;
+class PageInfo;
+class AppointmentEdge;
+class AppointmentConnection;
+class TaskEdge;
+class TaskConnection;
+class FolderEdge;
+class FolderConnection;
+class CompleteTaskPayload;
+class Mutation;
+class Subscription;
+class Appointment;
+class Task;
+class Folder;
+class NestedType;
+class Expensive;
+
+} /* namespace object */
+
+struct Node
+{
+	virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const = 0;
+};
+
+namespace object {
+
+class Query
+	: public service::Object
+{
+protected:
+	explicit Query();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<service::Object>> getNode(service::FieldParams&& params, response::IdType&& idArg) const;
+	virtual service::FieldResult<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<response::IntType>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<response::IntType>&& lastArg, std::optional<response::Value>&& beforeArg) const;
+	virtual service::FieldResult<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<response::IntType>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<response::IntType>&& lastArg, std::optional<response::Value>&& beforeArg) const;
+	virtual service::FieldResult<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<response::IntType>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<response::IntType>&& lastArg, std::optional<response::Value>&& beforeArg) const;
+	virtual service::FieldResult<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const;
+	virtual service::FieldResult<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const;
+	virtual service::FieldResult<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const;
+	virtual service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::StringType> getUnimplemented(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveNode(service::ResolverParams&& params);
+	std::future<response::Value> resolveAppointments(service::ResolverParams&& params);
+	std::future<response::Value> resolveTasks(service::ResolverParams&& params);
+	std::future<response::Value> resolveUnreadCounts(service::ResolverParams&& params);
+	std::future<response::Value> resolveAppointmentsById(service::ResolverParams&& params);
+	std::future<response::Value> resolveTasksById(service::ResolverParams&& params);
+	std::future<response::Value> resolveUnreadCountsById(service::ResolverParams&& params);
+	std::future<response::Value> resolveNested(service::ResolverParams&& params);
+	std::future<response::Value> resolveUnimplemented(service::ResolverParams&& params);
+	std::future<response::Value> resolveExpensive(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class PageInfo
+	: public service::Object
+{
+protected:
+	explicit PageInfo();
+
+public:
+	virtual service::FieldResult<response::BooleanType> getHasNextPage(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::BooleanType> getHasPreviousPage(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveHasNextPage(service::ResolverParams&& params);
+	std::future<response::Value> resolveHasPreviousPage(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class AppointmentEdge
+	: public service::Object
+{
+protected:
+	explicit AppointmentEdge();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveNode(service::ResolverParams&& params);
+	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class AppointmentConnection
+	: public service::Object
+{
+protected:
+	explicit AppointmentConnection();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
+	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class TaskEdge
+	: public service::Object
+{
+protected:
+	explicit TaskEdge();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveNode(service::ResolverParams&& params);
+	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class TaskConnection
+	: public service::Object
+{
+protected:
+	explicit TaskConnection();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
+	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class FolderEdge
+	: public service::Object
+{
+protected:
+	explicit FolderEdge();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveNode(service::ResolverParams&& params);
+	std::future<response::Value> resolveCursor(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class FolderConnection
+	: public service::Object
+{
+protected:
+	explicit FolderConnection();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolvePageInfo(service::ResolverParams&& params);
+	std::future<response::Value> resolveEdges(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class CompleteTaskPayload
+	: public service::Object
+{
+protected:
+	explicit CompleteTaskPayload();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<response::StringType>> getClientMutationId(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveTask(service::ResolverParams&& params);
+	std::future<response::Value> resolveClientMutationId(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class Mutation
+	: public service::Object
+{
+protected:
+	explicit Mutation();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const;
+	virtual service::FieldResult<response::FloatType> applySetFloat(service::FieldParams&& params, response::FloatType&& valueArg) const;
+
+private:
+	std::future<response::Value> resolveCompleteTask(service::ResolverParams&& params);
+	std::future<response::Value> resolveSetFloat(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class Subscription
+	: public service::Object
+{
+protected:
+	explicit Subscription();
+
+public:
+	virtual service::FieldResult<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::shared_ptr<service::Object>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const;
+
+private:
+	std::future<response::Value> resolveNextAppointmentChange(service::ResolverParams&& params);
+	std::future<response::Value> resolveNodeChange(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class Appointment
+	: public service::Object
+	, public Node
+{
+protected:
+	explicit Appointment();
+
+public:
+	virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const override;
+	virtual service::FieldResult<std::optional<response::Value>> getWhen(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::optional<response::StringType>> getSubject(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::BooleanType> getIsNow(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveId(service::ResolverParams&& params);
+	std::future<response::Value> resolveWhen(service::ResolverParams&& params);
+	std::future<response::Value> resolveSubject(service::ResolverParams&& params);
+	std::future<response::Value> resolveIsNow(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class Task
+	: public service::Object
+	, public Node
+{
+protected:
+	explicit Task();
+
+public:
+	virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const override;
+	virtual service::FieldResult<std::optional<response::StringType>> getTitle(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::BooleanType> getIsComplete(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveId(service::ResolverParams&& params);
+	std::future<response::Value> resolveTitle(service::ResolverParams&& params);
+	std::future<response::Value> resolveIsComplete(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class Folder
+	: public service::Object
+	, public Node
+{
+protected:
+	explicit Folder();
+
+public:
+	virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const override;
+	virtual service::FieldResult<std::optional<response::StringType>> getName(service::FieldParams&& params) const;
+	virtual service::FieldResult<response::IntType> getUnreadCount(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveId(service::ResolverParams&& params);
+	std::future<response::Value> resolveName(service::ResolverParams&& params);
+	std::future<response::Value> resolveUnreadCount(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class NestedType
+	: public service::Object
+{
+protected:
+	explicit NestedType();
+
+public:
+	virtual service::FieldResult<response::IntType> getDepth(service::FieldParams&& params) const;
+	virtual service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveDepth(service::ResolverParams&& params);
+	std::future<response::Value> resolveNested(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+class Expensive
+	: public service::Object
+{
+protected:
+	explicit Expensive();
+
+public:
+	virtual service::FieldResult<response::IntType> getOrder(service::FieldParams&& params) const;
+
+private:
+	std::future<response::Value> resolveOrder(service::ResolverParams&& params);
+
+	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+};
+
+} /* namespace object */
+
+class Operations
+	: public service::Request
+{
+public:
+	explicit Operations(std::shared_ptr<object::Query> query, std::shared_ptr<object::Mutation> mutation, std::shared_ptr<object::Subscription> subscription);
+
+private:
+	std::shared_ptr<object::Query> _query;
+	std::shared_ptr<object::Mutation> _mutation;
+	std::shared_ptr<object::Subscription> _subscription;
+};
+
+} /* namespace today */
+} /* namespace graphql */
+
+#endif // TODAYSCHEMA_H

--- a/samples/validation/ValidationSchema.cpp
+++ b/samples/validation/ValidationSchema.cpp
@@ -3,7 +3,7 @@
 
 #include "ValidationSchema.h"
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 #include <algorithm>
 #include <array>

--- a/samples/validation/ValidationSchema.cpp
+++ b/samples/validation/ValidationSchema.cpp
@@ -846,41 +846,41 @@ Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<obj
 
 void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 {
-	auto typeDogCommand = std::make_shared<schema::EnumType>(R"gql(DogCommand)gql"sv, R"md()md"sv);
+	auto typeDogCommand = schema::EnumType::Make(R"gql(DogCommand)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(DogCommand)gql"sv, typeDogCommand);
-	auto typeCatCommand = std::make_shared<schema::EnumType>(R"gql(CatCommand)gql"sv, R"md()md"sv);
+	auto typeCatCommand = schema::EnumType::Make(R"gql(CatCommand)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(CatCommand)gql"sv, typeCatCommand);
-	auto typeComplexInput = std::make_shared<schema::InputObjectType>(R"gql(ComplexInput)gql"sv, R"md([Example 155](http://spec.graphql.org/June2018/#example-f3185))md"sv);
+	auto typeComplexInput = schema::InputObjectType::Make(R"gql(ComplexInput)gql"sv, R"md([Example 155](http://spec.graphql.org/June2018/#example-f3185))md"sv);
 	schema->AddType(R"gql(ComplexInput)gql"sv, typeComplexInput);
-	auto typeCatOrDog = std::make_shared<schema::UnionType>(R"gql(CatOrDog)gql"sv, R"md()md"sv);
+	auto typeCatOrDog = schema::UnionType::Make(R"gql(CatOrDog)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(CatOrDog)gql"sv, typeCatOrDog);
-	auto typeDogOrHuman = std::make_shared<schema::UnionType>(R"gql(DogOrHuman)gql"sv, R"md()md"sv);
+	auto typeDogOrHuman = schema::UnionType::Make(R"gql(DogOrHuman)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(DogOrHuman)gql"sv, typeDogOrHuman);
-	auto typeHumanOrAlien = std::make_shared<schema::UnionType>(R"gql(HumanOrAlien)gql"sv, R"md()md"sv);
+	auto typeHumanOrAlien = schema::UnionType::Make(R"gql(HumanOrAlien)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(HumanOrAlien)gql"sv, typeHumanOrAlien);
-	auto typeSentient = std::make_shared<schema::InterfaceType>(R"gql(Sentient)gql"sv, R"md()md"sv);
+	auto typeSentient = schema::InterfaceType::Make(R"gql(Sentient)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(Sentient)gql"sv, typeSentient);
-	auto typePet = std::make_shared<schema::InterfaceType>(R"gql(Pet)gql"sv, R"md()md"sv);
+	auto typePet = schema::InterfaceType::Make(R"gql(Pet)gql"sv, R"md()md"sv);
 	schema->AddType(R"gql(Pet)gql"sv, typePet);
-	auto typeQuery = std::make_shared<schema::ObjectType>(R"gql(Query)gql"sv, R"md(GraphQL validation [sample](http://spec.graphql.org/June2018/#example-26a9d))md");
+	auto typeQuery = schema::ObjectType::Make(R"gql(Query)gql"sv, R"md(GraphQL validation [sample](http://spec.graphql.org/June2018/#example-26a9d))md");
 	schema->AddType(R"gql(Query)gql"sv, typeQuery);
-	auto typeDog = std::make_shared<schema::ObjectType>(R"gql(Dog)gql"sv, R"md()md");
+	auto typeDog = schema::ObjectType::Make(R"gql(Dog)gql"sv, R"md()md");
 	schema->AddType(R"gql(Dog)gql"sv, typeDog);
-	auto typeAlien = std::make_shared<schema::ObjectType>(R"gql(Alien)gql"sv, R"md()md");
+	auto typeAlien = schema::ObjectType::Make(R"gql(Alien)gql"sv, R"md()md");
 	schema->AddType(R"gql(Alien)gql"sv, typeAlien);
-	auto typeHuman = std::make_shared<schema::ObjectType>(R"gql(Human)gql"sv, R"md()md");
+	auto typeHuman = schema::ObjectType::Make(R"gql(Human)gql"sv, R"md()md");
 	schema->AddType(R"gql(Human)gql"sv, typeHuman);
-	auto typeCat = std::make_shared<schema::ObjectType>(R"gql(Cat)gql"sv, R"md()md");
+	auto typeCat = schema::ObjectType::Make(R"gql(Cat)gql"sv, R"md()md");
 	schema->AddType(R"gql(Cat)gql"sv, typeCat);
-	auto typeMutation = std::make_shared<schema::ObjectType>(R"gql(Mutation)gql"sv, R"md(Support for [Counter Example 94](http://spec.graphql.org/June2018/#example-77c2e))md");
+	auto typeMutation = schema::ObjectType::Make(R"gql(Mutation)gql"sv, R"md(Support for [Counter Example 94](http://spec.graphql.org/June2018/#example-77c2e))md");
 	schema->AddType(R"gql(Mutation)gql"sv, typeMutation);
-	auto typeMutateDogResult = std::make_shared<schema::ObjectType>(R"gql(MutateDogResult)gql"sv, R"md(Support for [Counter Example 94](http://spec.graphql.org/June2018/#example-77c2e))md");
+	auto typeMutateDogResult = schema::ObjectType::Make(R"gql(MutateDogResult)gql"sv, R"md(Support for [Counter Example 94](http://spec.graphql.org/June2018/#example-77c2e))md");
 	schema->AddType(R"gql(MutateDogResult)gql"sv, typeMutateDogResult);
-	auto typeSubscription = std::make_shared<schema::ObjectType>(R"gql(Subscription)gql"sv, R"md(Support for [Example 97](http://spec.graphql.org/June2018/#example-5bbc3) - [Counter Example 101](http://spec.graphql.org/June2018/#example-2353b))md");
+	auto typeSubscription = schema::ObjectType::Make(R"gql(Subscription)gql"sv, R"md(Support for [Example 97](http://spec.graphql.org/June2018/#example-5bbc3) - [Counter Example 101](http://spec.graphql.org/June2018/#example-2353b))md");
 	schema->AddType(R"gql(Subscription)gql"sv, typeSubscription);
-	auto typeMessage = std::make_shared<schema::ObjectType>(R"gql(Message)gql"sv, R"md(Support for [Example 97](http://spec.graphql.org/June2018/#example-5bbc3) - [Counter Example 101](http://spec.graphql.org/June2018/#example-2353b))md");
+	auto typeMessage = schema::ObjectType::Make(R"gql(Message)gql"sv, R"md(Support for [Example 97](http://spec.graphql.org/June2018/#example-5bbc3) - [Counter Example 101](http://spec.graphql.org/June2018/#example-2353b))md");
 	schema->AddType(R"gql(Message)gql"sv, typeMessage);
-	auto typeArguments = std::make_shared<schema::ObjectType>(R"gql(Arguments)gql"sv, R"md(Support for [Example 120](http://spec.graphql.org/June2018/#example-1891c))md");
+	auto typeArguments = schema::ObjectType::Make(R"gql(Arguments)gql"sv, R"md(Support for [Example 120](http://spec.graphql.org/June2018/#example-1891c))md");
 	schema->AddType(R"gql(Arguments)gql"sv, typeArguments);
 
 	typeDogCommand->AddEnumValues({
@@ -893,8 +893,8 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	});
 
 	typeComplexInput->AddInputValues({
-		std::make_shared<schema::InputValue>(R"gql(name)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv),
-		std::make_shared<schema::InputValue>(R"gql(owner)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
+		schema::InputValue::Make(R"gql(name)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv),
+		schema::InputValue::Make(R"gql(owner)gql"sv, R"md()md"sv, schema->LookupType("String"), R"gql()gql"sv)
 	});
 
 	typeCatOrDog->AddPossibleTypes({
@@ -911,105 +911,105 @@ void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema)
 	});
 
 	typeSentient->AddFields({
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")))
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")))
 	});
 	typePet->AddFields({
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")))
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String")))
 	});
 
 	typeQuery->AddFields({
-		std::make_shared<schema::Field>(R"gql(dog)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Dog")),
-		std::make_shared<schema::Field>(R"gql(human)gql"sv, R"md(Support for [Counter Example 116](http://spec.graphql.org/June2018/#example-77c2e))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Human")),
-		std::make_shared<schema::Field>(R"gql(pet)gql"sv, R"md(Support for [Counter Example 116](http://spec.graphql.org/June2018/#example-77c2e))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Pet")),
-		std::make_shared<schema::Field>(R"gql(catOrDog)gql"sv, R"md(Support for [Counter Example 116](http://spec.graphql.org/June2018/#example-77c2e))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("CatOrDog")),
-		std::make_shared<schema::Field>(R"gql(arguments)gql"sv, R"md(Support for [Example 120](http://spec.graphql.org/June2018/#example-1891c))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Arguments")),
-		std::make_shared<schema::Field>(R"gql(findDog)gql"sv, R"md([Example 155](http://spec.graphql.org/June2018/#example-f3185))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(complex)gql"sv, R"md()md"sv, schema->LookupType("ComplexInput"), R"gql()gql"sv)
-		}), schema->LookupType("Dog")),
-		std::make_shared<schema::Field>(R"gql(booleanList)gql"sv, R"md([Example 155](http://spec.graphql.org/June2018/#example-f3185))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(booleanListArg)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))), R"gql()gql"sv)
-		}), schema->LookupType("Boolean"))
+		schema::Field::Make(R"gql(dog)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Dog")),
+		schema::Field::Make(R"gql(human)gql"sv, R"md(Support for [Counter Example 116](http://spec.graphql.org/June2018/#example-77c2e))md"sv, std::nullopt, schema->LookupType("Human")),
+		schema::Field::Make(R"gql(pet)gql"sv, R"md(Support for [Counter Example 116](http://spec.graphql.org/June2018/#example-77c2e))md"sv, std::nullopt, schema->LookupType("Pet")),
+		schema::Field::Make(R"gql(catOrDog)gql"sv, R"md(Support for [Counter Example 116](http://spec.graphql.org/June2018/#example-77c2e))md"sv, std::nullopt, schema->LookupType("CatOrDog")),
+		schema::Field::Make(R"gql(arguments)gql"sv, R"md(Support for [Example 120](http://spec.graphql.org/June2018/#example-1891c))md"sv, std::nullopt, schema->LookupType("Arguments")),
+		schema::Field::Make(R"gql(findDog)gql"sv, R"md([Example 155](http://spec.graphql.org/June2018/#example-f3185))md"sv, std::nullopt, schema->LookupType("Dog"), {
+			schema::InputValue::Make(R"gql(complex)gql"sv, R"md()md"sv, schema->LookupType("ComplexInput"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(booleanList)gql"sv, R"md([Example 155](http://spec.graphql.org/June2018/#example-f3185))md"sv, std::nullopt, schema->LookupType("Boolean"), {
+			schema::InputValue::Make(R"gql(booleanListArg)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))), R"gql()gql"sv)
+		})
 	});
 	typeDog->AddInterfaces({
 		typePet
 	});
 	typeDog->AddFields({
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<schema::Field>(R"gql(nickname)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(barkVolume)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Int")),
-		std::make_shared<schema::Field>(R"gql(doesKnowCommand)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(dogCommand)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("DogCommand")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(isHousetrained)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(atOtherHomes)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(owner)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Human"))
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		schema::Field::Make(R"gql(nickname)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(barkVolume)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Int")),
+		schema::Field::Make(R"gql(doesKnowCommand)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), {
+			schema::InputValue::Make(R"gql(dogCommand)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("DogCommand")), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(isHousetrained)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), {
+			schema::InputValue::Make(R"gql(atOtherHomes)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(owner)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Human"))
 	});
 	typeAlien->AddInterfaces({
 		typeSentient
 	});
 	typeAlien->AddFields({
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<schema::Field>(R"gql(homePlanet)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String"))
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		schema::Field::Make(R"gql(homePlanet)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String"))
 	});
 	typeHuman->AddInterfaces({
 		typeSentient
 	});
 	typeHuman->AddFields({
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<schema::Field>(R"gql(pets)gql"sv, R"md(Support for [Counter Example 136](http://spec.graphql.org/June2018/#example-6bbad))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Pet")))))
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		schema::Field::Make(R"gql(pets)gql"sv, R"md(Support for [Counter Example 136](http://spec.graphql.org/June2018/#example-6bbad))md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Pet")))))
 	});
 	typeCat->AddInterfaces({
 		typePet
 	});
 	typeCat->AddFields({
-		std::make_shared<schema::Field>(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
-		std::make_shared<schema::Field>(R"gql(nickname)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(doesKnowCommand)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(catCommand)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CatCommand")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(meowVolume)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("Int"))
+		schema::Field::Make(R"gql(name)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("String"))),
+		schema::Field::Make(R"gql(nickname)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(doesKnowCommand)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), {
+			schema::InputValue::Make(R"gql(catCommand)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("CatCommand")), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(meowVolume)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Int"))
 	});
 	typeMutation->AddFields({
-		std::make_shared<schema::Field>(R"gql(mutateDog)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("MutateDogResult"))
+		schema::Field::Make(R"gql(mutateDog)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("MutateDogResult"))
 	});
 	typeMutateDogResult->AddFields({
-		std::make_shared<schema::Field>(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
+		schema::Field::Make(R"gql(id)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
 	});
 	typeSubscription->AddFields({
-		std::make_shared<schema::Field>(R"gql(newMessage)gql"sv, R"md(Support for [Example 97](http://spec.graphql.org/June2018/#example-5bbc3) - [Counter Example 101](http://spec.graphql.org/June2018/#example-2353b))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Message"))),
-		std::make_shared<schema::Field>(R"gql(disallowedSecondRootField)gql"sv, R"md(Support for [Counter Example 99](http://spec.graphql.org/June2018/#example-3997d) - [Counter Example 100](http://spec.graphql.org/June2018/#example-18466))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		schema::Field::Make(R"gql(newMessage)gql"sv, R"md(Support for [Example 97](http://spec.graphql.org/June2018/#example-5bbc3) - [Counter Example 101](http://spec.graphql.org/June2018/#example-2353b))md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Message"))),
+		schema::Field::Make(R"gql(disallowedSecondRootField)gql"sv, R"md(Support for [Counter Example 99](http://spec.graphql.org/June2018/#example-3997d) - [Counter Example 100](http://spec.graphql.org/June2018/#example-18466))md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
 	});
 	typeMessage->AddFields({
-		std::make_shared<schema::Field>(R"gql(body)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->LookupType("String")),
-		std::make_shared<schema::Field>(R"gql(sender)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>(), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
+		schema::Field::Make(R"gql(body)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("String")),
+		schema::Field::Make(R"gql(sender)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("ID")))
 	});
 	typeArguments->AddFields({
-		std::make_shared<schema::Field>(R"gql(multipleReqs)gql"sv, R"md(Support for [Example 121](http://spec.graphql.org/June2018/#example-18fab))md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(x)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")), R"gql()gql"sv),
-			std::make_shared<schema::InputValue>(R"gql(y)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int"))),
-		std::make_shared<schema::Field>(R"gql(booleanArgField)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(booleanArg)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql()gql"sv)
-		}), schema->LookupType("Boolean")),
-		std::make_shared<schema::Field>(R"gql(floatArgField)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(floatArg)gql"sv, R"md()md"sv, schema->LookupType("Float"), R"gql()gql"sv)
-		}), schema->LookupType("Float")),
-		std::make_shared<schema::Field>(R"gql(intArgField)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(intArg)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv)
-		}), schema->LookupType("Int")),
-		std::make_shared<schema::Field>(R"gql(nonNullBooleanArgField)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(nonNullBooleanArg)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(nonNullBooleanListField)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(nonNullBooleanListArg)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))),
-		std::make_shared<schema::Field>(R"gql(booleanListArgField)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(booleanListArg)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Boolean"))), R"gql()gql"sv)
-		}), schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Boolean"))),
-		std::make_shared<schema::Field>(R"gql(optionalNonNullBooleanArgField)gql"sv, R"md()md"sv, std::nullopt, std::vector<std::shared_ptr<schema::InputValue>>({
-			std::make_shared<schema::InputValue>(R"gql(optionalBooleanArg)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), R"gql(false)gql"sv)
-		}), schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")))
+		schema::Field::Make(R"gql(multipleReqs)gql"sv, R"md(Support for [Example 121](http://spec.graphql.org/June2018/#example-18fab))md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")), {
+			schema::InputValue::Make(R"gql(x)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")), R"gql()gql"sv),
+			schema::InputValue::Make(R"gql(y)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Int")), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(booleanArgField)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Boolean"), {
+			schema::InputValue::Make(R"gql(booleanArg)gql"sv, R"md()md"sv, schema->LookupType("Boolean"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(floatArgField)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Float"), {
+			schema::InputValue::Make(R"gql(floatArg)gql"sv, R"md()md"sv, schema->LookupType("Float"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(intArgField)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType("Int"), {
+			schema::InputValue::Make(R"gql(intArg)gql"sv, R"md()md"sv, schema->LookupType("Int"), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(nonNullBooleanArgField)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), {
+			schema::InputValue::Make(R"gql(nonNullBooleanArg)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(nonNullBooleanListField)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))), {
+			schema::InputValue::Make(R"gql(nonNullBooleanListArg)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::LIST, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean"))), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(booleanListArgField)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Boolean")), {
+			schema::InputValue::Make(R"gql(booleanListArg)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->WrapType(introspection::TypeKind::LIST, schema->LookupType("Boolean"))), R"gql()gql"sv)
+		}),
+		schema::Field::Make(R"gql(optionalNonNullBooleanArgField)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), {
+			schema::InputValue::Make(R"gql(optionalBooleanArg)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType("Boolean")), R"gql(false)gql"sv)
+		})
 	});
 
 	schema->AddQueryType(typeQuery);

--- a/samples/validation/ValidationSchema.cpp
+++ b/samples/validation/ValidationSchema.cpp
@@ -44,7 +44,7 @@ validation::DogCommand ModifiedArgument<validation::DogCommand>::convert(const r
 }
 
 template <>
-std::future<response::Value> ModifiedResult<validation::DogCommand>::convert(service::FieldResult<validation::DogCommand>&& result, ResolverParams&& params)
+std::future<service::ResolverResult> ModifiedResult<validation::DogCommand>::convert(service::FieldResult<validation::DogCommand>&& result, ResolverParams&& params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](validation::DogCommand&& value, const ResolverParams&)
@@ -80,7 +80,7 @@ validation::CatCommand ModifiedArgument<validation::CatCommand>::convert(const r
 }
 
 template <>
-std::future<response::Value> ModifiedResult<validation::CatCommand>::convert(service::FieldResult<validation::CatCommand>&& result, ResolverParams&& params)
+std::future<service::ResolverResult> ModifiedResult<validation::CatCommand>::convert(service::FieldResult<validation::CatCommand>&& result, ResolverParams&& params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](validation::CatCommand&& value, const ResolverParams&)
@@ -134,7 +134,7 @@ service::FieldResult<std::shared_ptr<Dog>> Query::getDog(service::FieldParams&&)
 	throw std::runtime_error(R"ex(Query::getDog is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveDog(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveDog(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDog(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -148,7 +148,7 @@ service::FieldResult<std::shared_ptr<Human>> Query::getHuman(service::FieldParam
 	throw std::runtime_error(R"ex(Query::getHuman is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveHuman(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveHuman(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getHuman(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -162,7 +162,7 @@ service::FieldResult<std::shared_ptr<service::Object>> Query::getPet(service::Fi
 	throw std::runtime_error(R"ex(Query::getPet is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolvePet(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolvePet(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPet(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -176,7 +176,7 @@ service::FieldResult<std::shared_ptr<service::Object>> Query::getCatOrDog(servic
 	throw std::runtime_error(R"ex(Query::getCatOrDog is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveCatOrDog(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveCatOrDog(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getCatOrDog(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -190,7 +190,7 @@ service::FieldResult<std::shared_ptr<Arguments>> Query::getArguments(service::Fi
 	throw std::runtime_error(R"ex(Query::getArguments is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveArguments(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveArguments(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getArguments(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -204,7 +204,7 @@ service::FieldResult<std::shared_ptr<Dog>> Query::getFindDog(service::FieldParam
 	throw std::runtime_error(R"ex(Query::getFindDog is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveFindDog(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveFindDog(service::ResolverParams&& params)
 {
 	auto argComplex = service::ModifiedArgument<validation::ComplexInput>::require<service::TypeModifier::Nullable>("complex", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -219,7 +219,7 @@ service::FieldResult<std::optional<response::BooleanType>> Query::getBooleanList
 	throw std::runtime_error(R"ex(Query::getBooleanList is not implemented)ex");
 }
 
-std::future<response::Value> Query::resolveBooleanList(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolveBooleanList(service::ResolverParams&& params)
 {
 	auto argBooleanListArg = service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable, service::TypeModifier::List>("booleanListArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -229,17 +229,17 @@ std::future<response::Value> Query::resolveBooleanList(service::ResolverParams&&
 	return service::ModifiedResult<response::BooleanType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Query::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Query)gql" }, std::move(params));
 }
 
-std::future<response::Value> Query::resolve_schema(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolve_schema(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<service::Object>::convert(std::static_pointer_cast<service::Object>(std::make_shared<introspection::Schema>(_schema)), std::move(params));
 }
 
-std::future<response::Value> Query::resolve_type(service::ResolverParams&& params)
+std::future<service::ResolverResult> Query::resolve_type(service::ResolverParams&& params)
 {
 	auto argName = service::ModifiedArgument<response::StringType>::require("name", params.arguments);
 	const auto& baseType = _schema->LookupType(argName);
@@ -271,7 +271,7 @@ service::FieldResult<response::StringType> Dog::getName(service::FieldParams&&) 
 	throw std::runtime_error(R"ex(Dog::getName is not implemented)ex");
 }
 
-std::future<response::Value> Dog::resolveName(service::ResolverParams&& params)
+std::future<service::ResolverResult> Dog::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -285,7 +285,7 @@ service::FieldResult<std::optional<response::StringType>> Dog::getNickname(servi
 	throw std::runtime_error(R"ex(Dog::getNickname is not implemented)ex");
 }
 
-std::future<response::Value> Dog::resolveNickname(service::ResolverParams&& params)
+std::future<service::ResolverResult> Dog::resolveNickname(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNickname(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -299,7 +299,7 @@ service::FieldResult<std::optional<response::IntType>> Dog::getBarkVolume(servic
 	throw std::runtime_error(R"ex(Dog::getBarkVolume is not implemented)ex");
 }
 
-std::future<response::Value> Dog::resolveBarkVolume(service::ResolverParams&& params)
+std::future<service::ResolverResult> Dog::resolveBarkVolume(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getBarkVolume(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -313,7 +313,7 @@ service::FieldResult<response::BooleanType> Dog::getDoesKnowCommand(service::Fie
 	throw std::runtime_error(R"ex(Dog::getDoesKnowCommand is not implemented)ex");
 }
 
-std::future<response::Value> Dog::resolveDoesKnowCommand(service::ResolverParams&& params)
+std::future<service::ResolverResult> Dog::resolveDoesKnowCommand(service::ResolverParams&& params)
 {
 	auto argDogCommand = service::ModifiedArgument<DogCommand>::require("dogCommand", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -328,7 +328,7 @@ service::FieldResult<response::BooleanType> Dog::getIsHousetrained(service::Fiel
 	throw std::runtime_error(R"ex(Dog::getIsHousetrained is not implemented)ex");
 }
 
-std::future<response::Value> Dog::resolveIsHousetrained(service::ResolverParams&& params)
+std::future<service::ResolverResult> Dog::resolveIsHousetrained(service::ResolverParams&& params)
 {
 	auto argAtOtherHomes = service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable>("atOtherHomes", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -343,7 +343,7 @@ service::FieldResult<std::shared_ptr<Human>> Dog::getOwner(service::FieldParams&
 	throw std::runtime_error(R"ex(Dog::getOwner is not implemented)ex");
 }
 
-std::future<response::Value> Dog::resolveOwner(service::ResolverParams&& params)
+std::future<service::ResolverResult> Dog::resolveOwner(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getOwner(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -352,7 +352,7 @@ std::future<response::Value> Dog::resolveOwner(service::ResolverParams&& params)
 	return service::ModifiedResult<Human>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Dog::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Dog::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Dog)gql" }, std::move(params));
 }
@@ -375,7 +375,7 @@ service::FieldResult<response::StringType> Alien::getName(service::FieldParams&&
 	throw std::runtime_error(R"ex(Alien::getName is not implemented)ex");
 }
 
-std::future<response::Value> Alien::resolveName(service::ResolverParams&& params)
+std::future<service::ResolverResult> Alien::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -389,7 +389,7 @@ service::FieldResult<std::optional<response::StringType>> Alien::getHomePlanet(s
 	throw std::runtime_error(R"ex(Alien::getHomePlanet is not implemented)ex");
 }
 
-std::future<response::Value> Alien::resolveHomePlanet(service::ResolverParams&& params)
+std::future<service::ResolverResult> Alien::resolveHomePlanet(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getHomePlanet(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -398,7 +398,7 @@ std::future<response::Value> Alien::resolveHomePlanet(service::ResolverParams&& 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Alien::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Alien::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Alien)gql" }, std::move(params));
 }
@@ -422,7 +422,7 @@ service::FieldResult<response::StringType> Human::getName(service::FieldParams&&
 	throw std::runtime_error(R"ex(Human::getName is not implemented)ex");
 }
 
-std::future<response::Value> Human::resolveName(service::ResolverParams&& params)
+std::future<service::ResolverResult> Human::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -436,7 +436,7 @@ service::FieldResult<std::vector<std::shared_ptr<service::Object>>> Human::getPe
 	throw std::runtime_error(R"ex(Human::getPets is not implemented)ex");
 }
 
-std::future<response::Value> Human::resolvePets(service::ResolverParams&& params)
+std::future<service::ResolverResult> Human::resolvePets(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getPets(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -445,7 +445,7 @@ std::future<response::Value> Human::resolvePets(service::ResolverParams&& params
 	return service::ModifiedResult<service::Object>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Human::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Human::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Human)gql" }, std::move(params));
 }
@@ -470,7 +470,7 @@ service::FieldResult<response::StringType> Cat::getName(service::FieldParams&&) 
 	throw std::runtime_error(R"ex(Cat::getName is not implemented)ex");
 }
 
-std::future<response::Value> Cat::resolveName(service::ResolverParams&& params)
+std::future<service::ResolverResult> Cat::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -484,7 +484,7 @@ service::FieldResult<std::optional<response::StringType>> Cat::getNickname(servi
 	throw std::runtime_error(R"ex(Cat::getNickname is not implemented)ex");
 }
 
-std::future<response::Value> Cat::resolveNickname(service::ResolverParams&& params)
+std::future<service::ResolverResult> Cat::resolveNickname(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNickname(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -498,7 +498,7 @@ service::FieldResult<response::BooleanType> Cat::getDoesKnowCommand(service::Fie
 	throw std::runtime_error(R"ex(Cat::getDoesKnowCommand is not implemented)ex");
 }
 
-std::future<response::Value> Cat::resolveDoesKnowCommand(service::ResolverParams&& params)
+std::future<service::ResolverResult> Cat::resolveDoesKnowCommand(service::ResolverParams&& params)
 {
 	auto argCatCommand = service::ModifiedArgument<CatCommand>::require("catCommand", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -513,7 +513,7 @@ service::FieldResult<std::optional<response::IntType>> Cat::getMeowVolume(servic
 	throw std::runtime_error(R"ex(Cat::getMeowVolume is not implemented)ex");
 }
 
-std::future<response::Value> Cat::resolveMeowVolume(service::ResolverParams&& params)
+std::future<service::ResolverResult> Cat::resolveMeowVolume(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getMeowVolume(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -522,7 +522,7 @@ std::future<response::Value> Cat::resolveMeowVolume(service::ResolverParams&& pa
 	return service::ModifiedResult<response::IntType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Cat::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Cat::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Cat)gql" }, std::move(params));
 }
@@ -542,7 +542,7 @@ service::FieldResult<std::shared_ptr<MutateDogResult>> Mutation::applyMutateDog(
 	throw std::runtime_error(R"ex(Mutation::applyMutateDog is not implemented)ex");
 }
 
-std::future<response::Value> Mutation::resolveMutateDog(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolveMutateDog(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = applyMutateDog(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -551,7 +551,7 @@ std::future<response::Value> Mutation::resolveMutateDog(service::ResolverParams&
 	return service::ModifiedResult<MutateDogResult>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Mutation::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Mutation::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Mutation)gql" }, std::move(params));
 }
@@ -571,7 +571,7 @@ service::FieldResult<response::IdType> MutateDogResult::getId(service::FieldPara
 	throw std::runtime_error(R"ex(MutateDogResult::getId is not implemented)ex");
 }
 
-std::future<response::Value> MutateDogResult::resolveId(service::ResolverParams&& params)
+std::future<service::ResolverResult> MutateDogResult::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -580,7 +580,7 @@ std::future<response::Value> MutateDogResult::resolveId(service::ResolverParams&
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> MutateDogResult::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> MutateDogResult::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(MutateDogResult)gql" }, std::move(params));
 }
@@ -601,7 +601,7 @@ service::FieldResult<std::shared_ptr<Message>> Subscription::getNewMessage(servi
 	throw std::runtime_error(R"ex(Subscription::getNewMessage is not implemented)ex");
 }
 
-std::future<response::Value> Subscription::resolveNewMessage(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolveNewMessage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getNewMessage(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -615,7 +615,7 @@ service::FieldResult<response::BooleanType> Subscription::getDisallowedSecondRoo
 	throw std::runtime_error(R"ex(Subscription::getDisallowedSecondRootField is not implemented)ex");
 }
 
-std::future<response::Value> Subscription::resolveDisallowedSecondRootField(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolveDisallowedSecondRootField(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getDisallowedSecondRootField(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -624,7 +624,7 @@ std::future<response::Value> Subscription::resolveDisallowedSecondRootField(serv
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Subscription::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Subscription::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Subscription)gql" }, std::move(params));
 }
@@ -645,7 +645,7 @@ service::FieldResult<std::optional<response::StringType>> Message::getBody(servi
 	throw std::runtime_error(R"ex(Message::getBody is not implemented)ex");
 }
 
-std::future<response::Value> Message::resolveBody(service::ResolverParams&& params)
+std::future<service::ResolverResult> Message::resolveBody(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getBody(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -659,7 +659,7 @@ service::FieldResult<response::IdType> Message::getSender(service::FieldParams&&
 	throw std::runtime_error(R"ex(Message::getSender is not implemented)ex");
 }
 
-std::future<response::Value> Message::resolveSender(service::ResolverParams&& params)
+std::future<service::ResolverResult> Message::resolveSender(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
 	auto result = getSender(service::FieldParams(params, std::move(params.fieldDirectives)));
@@ -668,7 +668,7 @@ std::future<response::Value> Message::resolveSender(service::ResolverParams&& pa
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Message::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Message::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Message)gql" }, std::move(params));
 }
@@ -695,7 +695,7 @@ service::FieldResult<response::IntType> Arguments::getMultipleReqs(service::Fiel
 	throw std::runtime_error(R"ex(Arguments::getMultipleReqs is not implemented)ex");
 }
 
-std::future<response::Value> Arguments::resolveMultipleReqs(service::ResolverParams&& params)
+std::future<service::ResolverResult> Arguments::resolveMultipleReqs(service::ResolverParams&& params)
 {
 	auto argX = service::ModifiedArgument<response::IntType>::require("x", params.arguments);
 	auto argY = service::ModifiedArgument<response::IntType>::require("y", params.arguments);
@@ -711,7 +711,7 @@ service::FieldResult<std::optional<response::BooleanType>> Arguments::getBoolean
 	throw std::runtime_error(R"ex(Arguments::getBooleanArgField is not implemented)ex");
 }
 
-std::future<response::Value> Arguments::resolveBooleanArgField(service::ResolverParams&& params)
+std::future<service::ResolverResult> Arguments::resolveBooleanArgField(service::ResolverParams&& params)
 {
 	auto argBooleanArg = service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable>("booleanArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -726,7 +726,7 @@ service::FieldResult<std::optional<response::FloatType>> Arguments::getFloatArgF
 	throw std::runtime_error(R"ex(Arguments::getFloatArgField is not implemented)ex");
 }
 
-std::future<response::Value> Arguments::resolveFloatArgField(service::ResolverParams&& params)
+std::future<service::ResolverResult> Arguments::resolveFloatArgField(service::ResolverParams&& params)
 {
 	auto argFloatArg = service::ModifiedArgument<response::FloatType>::require<service::TypeModifier::Nullable>("floatArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -741,7 +741,7 @@ service::FieldResult<std::optional<response::IntType>> Arguments::getIntArgField
 	throw std::runtime_error(R"ex(Arguments::getIntArgField is not implemented)ex");
 }
 
-std::future<response::Value> Arguments::resolveIntArgField(service::ResolverParams&& params)
+std::future<service::ResolverResult> Arguments::resolveIntArgField(service::ResolverParams&& params)
 {
 	auto argIntArg = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("intArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -756,7 +756,7 @@ service::FieldResult<response::BooleanType> Arguments::getNonNullBooleanArgField
 	throw std::runtime_error(R"ex(Arguments::getNonNullBooleanArgField is not implemented)ex");
 }
 
-std::future<response::Value> Arguments::resolveNonNullBooleanArgField(service::ResolverParams&& params)
+std::future<service::ResolverResult> Arguments::resolveNonNullBooleanArgField(service::ResolverParams&& params)
 {
 	auto argNonNullBooleanArg = service::ModifiedArgument<response::BooleanType>::require("nonNullBooleanArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -771,7 +771,7 @@ service::FieldResult<std::optional<std::vector<response::BooleanType>>> Argument
 	throw std::runtime_error(R"ex(Arguments::getNonNullBooleanListField is not implemented)ex");
 }
 
-std::future<response::Value> Arguments::resolveNonNullBooleanListField(service::ResolverParams&& params)
+std::future<service::ResolverResult> Arguments::resolveNonNullBooleanListField(service::ResolverParams&& params)
 {
 	auto argNonNullBooleanListArg = service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable, service::TypeModifier::List>("nonNullBooleanListArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -786,7 +786,7 @@ service::FieldResult<std::optional<std::vector<std::optional<response::BooleanTy
 	throw std::runtime_error(R"ex(Arguments::getBooleanListArgField is not implemented)ex");
 }
 
-std::future<response::Value> Arguments::resolveBooleanListArgField(service::ResolverParams&& params)
+std::future<service::ResolverResult> Arguments::resolveBooleanListArgField(service::ResolverParams&& params)
 {
 	auto argBooleanListArg = service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::List, service::TypeModifier::Nullable>("booleanListArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
@@ -801,7 +801,7 @@ service::FieldResult<response::BooleanType> Arguments::getOptionalNonNullBoolean
 	throw std::runtime_error(R"ex(Arguments::getOptionalNonNullBooleanArgField is not implemented)ex");
 }
 
-std::future<response::Value> Arguments::resolveOptionalNonNullBooleanArgField(service::ResolverParams&& params)
+std::future<service::ResolverResult> Arguments::resolveOptionalNonNullBooleanArgField(service::ResolverParams&& params)
 {
 	const auto defaultArguments = []()
 	{
@@ -825,7 +825,7 @@ std::future<response::Value> Arguments::resolveOptionalNonNullBooleanArgField(se
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
 }
 
-std::future<response::Value> Arguments::resolve_typename(service::ResolverParams&& params)
+std::future<service::ResolverResult> Arguments::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql(Arguments)gql" }, std::move(params));
 }

--- a/samples/validation/ValidationSchema.cpp
+++ b/samples/validation/ValidationSchema.cpp
@@ -1024,7 +1024,7 @@ std::shared_ptr<schema::Schema> GetSchema()
 
 	if (!schema)
 	{
-		schema = std::make_shared<schema::Schema>();
+		schema = std::make_shared<schema::Schema>(false);
 		introspection::AddTypesToSchema(schema);
 		AddTypesToSchema(schema);
 		s_wpSchema = schema;

--- a/samples/validation/ValidationSchema.h
+++ b/samples/validation/ValidationSchema.h
@@ -14,12 +14,6 @@
 #include <vector>
 
 namespace graphql {
-namespace introspection {
-
-class Schema;
-
-} /* namespace introspection */
-
 namespace validation {
 
 enum class DogCommand

--- a/samples/validation/ValidationSchema.h
+++ b/samples/validation/ValidationSchema.h
@@ -80,17 +80,17 @@ public:
 	virtual service::FieldResult<std::optional<response::BooleanType>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<response::BooleanType>>&& booleanListArgArg) const;
 
 private:
-	std::future<response::Value> resolveDog(service::ResolverParams&& params);
-	std::future<response::Value> resolveHuman(service::ResolverParams&& params);
-	std::future<response::Value> resolvePet(service::ResolverParams&& params);
-	std::future<response::Value> resolveCatOrDog(service::ResolverParams&& params);
-	std::future<response::Value> resolveArguments(service::ResolverParams&& params);
-	std::future<response::Value> resolveFindDog(service::ResolverParams&& params);
-	std::future<response::Value> resolveBooleanList(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDog(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveHuman(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePet(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveCatOrDog(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveArguments(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveFindDog(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveBooleanList(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
-	std::future<response::Value> resolve_schema(service::ResolverParams&& params);
-	std::future<response::Value> resolve_type(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_schema(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_type(service::ResolverParams&& params);
 
 	std::shared_ptr<schema::Schema> _schema;
 };
@@ -111,14 +111,14 @@ public:
 	virtual service::FieldResult<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveName(service::ResolverParams&& params);
-	std::future<response::Value> resolveNickname(service::ResolverParams&& params);
-	std::future<response::Value> resolveBarkVolume(service::ResolverParams&& params);
-	std::future<response::Value> resolveDoesKnowCommand(service::ResolverParams&& params);
-	std::future<response::Value> resolveIsHousetrained(service::ResolverParams&& params);
-	std::future<response::Value> resolveOwner(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveName(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNickname(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveBarkVolume(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDoesKnowCommand(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveIsHousetrained(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveOwner(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Alien
@@ -133,10 +133,10 @@ public:
 	virtual service::FieldResult<std::optional<response::StringType>> getHomePlanet(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveName(service::ResolverParams&& params);
-	std::future<response::Value> resolveHomePlanet(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveName(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveHomePlanet(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Human
@@ -151,10 +151,10 @@ public:
 	virtual service::FieldResult<std::vector<std::shared_ptr<service::Object>>> getPets(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveName(service::ResolverParams&& params);
-	std::future<response::Value> resolvePets(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveName(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolvePets(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Cat
@@ -171,12 +171,12 @@ public:
 	virtual service::FieldResult<std::optional<response::IntType>> getMeowVolume(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveName(service::ResolverParams&& params);
-	std::future<response::Value> resolveNickname(service::ResolverParams&& params);
-	std::future<response::Value> resolveDoesKnowCommand(service::ResolverParams&& params);
-	std::future<response::Value> resolveMeowVolume(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveName(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNickname(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDoesKnowCommand(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveMeowVolume(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Mutation
@@ -189,9 +189,9 @@ public:
 	virtual service::FieldResult<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveMutateDog(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveMutateDog(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class MutateDogResult
@@ -204,9 +204,9 @@ public:
 	virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveId(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveId(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Subscription
@@ -220,10 +220,10 @@ public:
 	virtual service::FieldResult<response::BooleanType> getDisallowedSecondRootField(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveNewMessage(service::ResolverParams&& params);
-	std::future<response::Value> resolveDisallowedSecondRootField(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNewMessage(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveDisallowedSecondRootField(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Message
@@ -237,10 +237,10 @@ public:
 	virtual service::FieldResult<response::IdType> getSender(service::FieldParams&& params) const;
 
 private:
-	std::future<response::Value> resolveBody(service::ResolverParams&& params);
-	std::future<response::Value> resolveSender(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveBody(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveSender(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 class Arguments
@@ -260,16 +260,16 @@ public:
 	virtual service::FieldResult<response::BooleanType> getOptionalNonNullBooleanArgField(service::FieldParams&& params, response::BooleanType&& optionalBooleanArgArg) const;
 
 private:
-	std::future<response::Value> resolveMultipleReqs(service::ResolverParams&& params);
-	std::future<response::Value> resolveBooleanArgField(service::ResolverParams&& params);
-	std::future<response::Value> resolveFloatArgField(service::ResolverParams&& params);
-	std::future<response::Value> resolveIntArgField(service::ResolverParams&& params);
-	std::future<response::Value> resolveNonNullBooleanArgField(service::ResolverParams&& params);
-	std::future<response::Value> resolveNonNullBooleanListField(service::ResolverParams&& params);
-	std::future<response::Value> resolveBooleanListArgField(service::ResolverParams&& params);
-	std::future<response::Value> resolveOptionalNonNullBooleanArgField(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveMultipleReqs(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveBooleanArgField(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveFloatArgField(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveIntArgField(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNonNullBooleanArgField(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveNonNullBooleanListField(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveBooleanListArgField(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolveOptionalNonNullBooleanArgField(service::ResolverParams&& params);
 
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 };
 
 } /* namespace object */

--- a/samples/validation/ValidationSchema.h
+++ b/samples/validation/ValidationSchema.h
@@ -6,6 +6,7 @@
 #ifndef VALIDATIONSCHEMA_H
 #define VALIDATIONSCHEMA_H
 
+#include "graphqlservice/GraphQLSchema.h"
 #include "graphqlservice/GraphQLService.h"
 
 #include <memory>
@@ -97,7 +98,7 @@ private:
 	std::future<response::Value> resolve_schema(service::ResolverParams&& params);
 	std::future<response::Value> resolve_type(service::ResolverParams&& params);
 
-	std::shared_ptr<introspection::Schema> _schema;
+	std::shared_ptr<schema::Schema> _schema;
 };
 
 class Dog
@@ -291,7 +292,7 @@ private:
 	std::shared_ptr<object::Subscription> _subscription;
 };
 
-void AddTypesToSchema(const std::shared_ptr<introspection::Schema>& schema);
+void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema);
 
 } /* namespace validation */
 } /* namespace graphql */

--- a/samples/validation/ValidationSchema.h
+++ b/samples/validation/ValidationSchema.h
@@ -286,7 +286,7 @@ private:
 	std::shared_ptr<object::Subscription> _subscription;
 };
 
-void AddTypesToSchema(const std::shared_ptr<schema::Schema>& schema);
+std::shared_ptr<schema::Schema> GetSchema();
 
 } /* namespace validation */
 } /* namespace graphql */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -150,6 +150,7 @@ endif()
 # graphqlservice
 add_library(graphqlservice
   GraphQLService.cpp
+  GraphQLSchema.cpp
   Introspection.cpp
   Validation.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/../IntrospectionSchema.cpp)
@@ -221,6 +222,7 @@ install(TARGETS
 install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/GraphQLParse.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/GraphQLResponse.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/GraphQLSchema.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/GraphQLService.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/GraphQLGrammar.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/GraphQLTree.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,8 +113,8 @@ if(GRAPHQL_UPDATE_SAMPLES)
   add_custom_command(
     OUTPUT
       ${CMAKE_CURRENT_BINARY_DIR}/../IntrospectionSchema.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/IntrospectionSchema.h
-    COMMAND ${CMAKE_COMMAND} -E make_directory include/graphqlservice
+      ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/introspection/IntrospectionSchema.h
+    COMMAND ${CMAKE_COMMAND} -E make_directory include/graphqlservice/introspection
     COMMAND schemagen --introspection
     DEPENDS schemagen
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
@@ -126,11 +126,11 @@ if(GRAPHQL_UPDATE_SAMPLES)
     OUTPUT updated_introspection
     COMMAND ${CMAKE_COMMAND} -E remove -f ${OLD_INTROSPECTION_FILES}
     COMMAND ${CMAKE_COMMAND} -E copy ../IntrospectionSchema.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../samples/introspection/
-    COMMAND ${CMAKE_COMMAND} -E copy ../include/graphqlservice/IntrospectionSchema.h ${CMAKE_CURRENT_SOURCE_DIR}/../samples/introspection/
+    COMMAND ${CMAKE_COMMAND} -E copy ../include/graphqlservice/introspection/IntrospectionSchema.h ${CMAKE_CURRENT_SOURCE_DIR}/../samples/introspection/
     COMMAND ${CMAKE_COMMAND} -E touch updated_introspection
     DEPENDS 
       ${CMAKE_CURRENT_BINARY_DIR}/../IntrospectionSchema.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/IntrospectionSchema.h
+      ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/introspection/IntrospectionSchema.h
     COMMENT "Updating introspection files")
 
   add_custom_target(update_introspection ALL
@@ -139,33 +139,50 @@ else()
   add_custom_command(
     OUTPUT
       ${CMAKE_CURRENT_BINARY_DIR}/../IntrospectionSchema.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/IntrospectionSchema.h
-    COMMAND ${CMAKE_COMMAND} -E make_directory include/graphqlservice
+      ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/introspection/IntrospectionSchema.h
+    COMMAND ${CMAKE_COMMAND} -E make_directory include/graphqlservice/introspection
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/../samples/introspection/IntrospectionSchema.cpp .
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/../samples/introspection/IntrospectionSchema.h include/graphqlservice
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/../samples/introspection/IntrospectionSchema.h include/graphqlservice/introspection
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
     COMMENT "Copying IntrospectionSchema files")
 endif()
 
-# graphqlservice
-add_library(graphqlservice
+add_custom_target(copy_introspection
+  DEPENDS
+    ${CMAKE_CURRENT_BINARY_DIR}/../IntrospectionSchema.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/introspection/IntrospectionSchema.h)
+
+# graphqlservice_nointrospection
+add_library(graphqlservice_nointrospection
   GraphQLService.cpp
   GraphQLSchema.cpp
+  Validation.cpp)
+add_dependencies(graphqlservice_nointrospection copy_introspection)
+add_library(cppgraphqlgen::graphqlservice_nointrospection ALIAS graphqlservice_nointrospection)
+target_link_libraries(graphqlservice_nointrospection PUBLIC
+    graphqlpeg
+    graphqlresponse
+    Threads::Threads)
+target_include_directories(graphqlservice_nointrospection PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+  target_compile_definitions(graphqlservice_nointrospection
+    PUBLIC GRAPHQL_DLLEXPORTS
+    PRIVATE IMPL_GRAPHQLSERVICE_DLL)
+endif()
+
+# graphqlservice
+add_library(graphqlservice
   Introspection.cpp
-  Validation.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/../IntrospectionSchema.cpp)
 add_library(cppgraphqlgen::graphqlservice ALIAS graphqlservice)
-target_link_libraries(graphqlservice PUBLIC
-    graphqlpeg
-    Threads::Threads)
-target_link_libraries(graphqlservice PUBLIC graphqlresponse)
-target_include_directories(graphqlservice PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
+target_link_libraries(graphqlservice PUBLIC graphqlservice_nointrospection)
 
 if(WIN32 AND BUILD_SHARED_LIBS)
   target_compile_definitions(graphqlservice
     PUBLIC GRAPHQL_DLLEXPORTS
-    PRIVATE IMPL_GRAPHQLSERVICE_DLL)
+    PRIVATE IMPL_GRAPHQLINTROSPECTION_DLL)
 endif()
 
 # RapidJSON is the only option for JSON serialization used in this project, but if you want
@@ -213,6 +230,7 @@ endif()
 install(TARGETS
     graphqlpeg
     graphqlresponse
+    graphqlservice_nointrospection
     graphqlservice
   EXPORT cppgraphqlgen-targets
   RUNTIME DESTINATION bin
@@ -226,10 +244,14 @@ install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/GraphQLService.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/GraphQLGrammar.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/GraphQLTree.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/Introspection.h
-    ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/IntrospectionSchema.h
   CONFIGURATIONS ${GRAPHQL_INSTALL_CONFIGURATIONS}
   DESTINATION ${GRAPHQL_INSTALL_INCLUDE_DIR}/graphqlservice)
+
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/introspection/Introspection.h
+    ${CMAKE_CURRENT_BINARY_DIR}/../include/graphqlservice/introspection/IntrospectionSchema.h
+  CONFIGURATIONS ${GRAPHQL_INSTALL_CONFIGURATIONS}
+  DESTINATION ${GRAPHQL_INSTALL_INCLUDE_DIR}/graphqlservice/introspection)
 
 install(EXPORT cppgraphqlgen-targets
   NAMESPACE cppgraphqlgen::

--- a/src/GraphQLResponse.cpp
+++ b/src/GraphQLResponse.cpp
@@ -3,100 +3,78 @@
 
 #include "graphqlservice/GraphQLResponse.h"
 
+#include <algorithm>
+#include <iterator>
+#include <map>
 #include <optional>
 #include <stdexcept>
 #include <variant>
 
 namespace graphql::response {
 
-// Type::Map
-struct MapData
+bool Value::MapData::operator==(const MapData& rhs) const
 {
-	bool operator==(const MapData& rhs) const
+	return map == rhs.map;
+}
+
+bool Value::StringData::operator==(const StringData& rhs) const
+{
+	return from_json == rhs.from_json && string == rhs.string;
+}
+
+bool Value::NullData::operator==(const NullData&) const
+{
+	return true;
+}
+
+bool Value::ScalarData::operator==(const ScalarData& rhs) const
+{
+	if (scalar && rhs.scalar)
 	{
-		return map == rhs.map;
+		return *scalar == *rhs.scalar;
 	}
 
-	MapType map;
-	std::unordered_map<std::string, size_t> members;
-};
-
-// Type::List
-struct ListData
-{
-	bool operator==(const ListData& rhs) const
-	{
-		return list == rhs.list;
-	}
-
-	ListType list;
-};
-
-// Type::String or Type::EnumValue
-struct StringOrEnumData
-{
-	bool operator==(const StringOrEnumData& rhs) const
-	{
-		return string == rhs.string && from_json == rhs.from_json;
-	}
-
-	StringType string;
-	bool from_json = false;
-};
-
-// Type::Scalar
-struct ScalarData
-{
-	bool operator==(const ScalarData& rhs) const
-	{
-		return scalar == rhs.scalar;
-	}
-
-	ScalarType scalar;
-};
-
-struct TypedData
-	: std::variant<std::optional<MapData>, std::optional<ListData>, std::optional<StringOrEnumData>,
-		  std::optional<ScalarData>, BooleanType, IntType, FloatType>
-{
-};
+	return !scalar && !rhs.scalar;
+}
 
 Value::Value(Type type /*= Type::Null*/)
-	: _type(type)
 {
 	switch (type)
 	{
 		case Type::Map:
-			_data = std::make_unique<TypedData>(TypedData { std::make_optional<MapData>() });
+			_data = { MapData {} };
 			break;
 
 		case Type::List:
-			_data = std::make_unique<TypedData>(TypedData { std::make_optional<ListData>() });
+			_data = { ListType {} };
 			break;
 
 		case Type::String:
-		case Type::EnumValue:
-			_data =
-				std::make_unique<TypedData>(TypedData { std::make_optional<StringOrEnumData>() });
+			_data = { StringData {} };
 			break;
 
-		case Type::Scalar:
-			_data = std::make_unique<TypedData>(TypedData { std::make_optional<ScalarData>() });
+		case Type::Null:
+			_data = { NullData {} };
 			break;
 
 		case Type::Boolean:
-			_data = std::make_unique<TypedData>(TypedData { BooleanType { false } });
+			_data = { BooleanType { false } };
 			break;
 
 		case Type::Int:
-			_data = std::make_unique<TypedData>(TypedData { IntType { 0 } });
+			_data = { IntType { 0 } };
 			break;
 
 		case Type::Float:
-			_data = std::make_unique<TypedData>(TypedData { FloatType { 0.0 } });
+			_data = { FloatType { 0.0 } };
 			break;
 
-		default:
+		case Type::EnumValue:
+			_data = { EnumData {} };
+			break;
+
+		case Type::Scalar:
+			_data = { ScalarData {} };
 			break;
 	}
 }
@@ -104,58 +82,121 @@ Value::Value(Type type /*= Type::Null*/)
 Value::~Value()
 {
 	// The default destructor gets inlined and may use a different allocator to free Value's member
-	// variables than the graphqlservice module used to allocate them. So even though this could be
-	// omitted, declare it explicitly and define it in graphqlservice.
+	// variables than the graphqlresponse module used to allocate them. So even though this could be
+	// omitted, declare it explicitly and define it in graphqlresponse.
 }
 
 Value::Value(const char* value)
-	: _type(Type::String)
-	, _data(std::make_unique<TypedData>(
-		  TypedData { StringOrEnumData { StringType { value }, false } }))
+	: _data(TypeData { StringData { StringType { value }, false } })
 {
 }
 
 Value::Value(StringType&& value)
-	: _type(Type::String)
-	, _data(std::make_unique<TypedData>(TypedData { StringOrEnumData { std::move(value), false } }))
+	: _data(TypeData { StringData { std::move(value), false } })
 {
 }
 
 Value::Value(BooleanType value)
-	: _type(Type::Boolean)
-	, _data(std::make_unique<TypedData>(TypedData { value }))
+	: _data(TypeData { value })
 {
 }
 
 Value::Value(IntType value)
-	: _type(Type::Int)
-	, _data(std::make_unique<TypedData>(TypedData { value }))
+	: _data(TypeData { value })
 {
 }
 
 Value::Value(FloatType value)
-	: _type(Type::Float)
-	, _data(std::make_unique<TypedData>(TypedData { value }))
+	: _data(TypeData { value })
 {
 }
 
 Value::Value(Value&& other) noexcept
-	: _type(other.type())
-	, _data(std::move(other._data))
+	: _data(std::move(other._data))
 {
 }
 
 Value::Value(const Value& other)
-	: _type(other.type())
-	, _data(std::make_unique<TypedData>(other._data ? *other._data : TypedData {}))
 {
+	switch (other.type())
+	{
+		case Type::Map:
+		{
+			MapData copy {};
+
+			copy.map.reserve(other.size());
+			for (const auto& entry : other)
+			{
+				copy.map.push_back({ entry.first, Value { entry.second } });
+			}
+
+			std::map<std::string_view, size_t> members;
+
+			for (const auto& entry : copy.map)
+			{
+				members[entry.first] = members.size();
+			}
+
+			copy.members.reserve(members.size());
+			std::transform(members.cbegin(),
+				members.cend(),
+				std::back_inserter(copy.members),
+				[&copy](const auto& entry) noexcept {
+					return entry.second;
+				});
+
+			_data = { std::move(copy) };
+			break;
+		}
+
+		case Type::List:
+		{
+			ListType copy {};
+
+			copy.reserve(other.size());
+			for (size_t i = 0; i < other.size(); ++i)
+			{
+				copy.push_back(Value { other[i] });
+			}
+
+			_data = { std::move(copy) };
+			break;
+		}
+
+		case Type::String:
+			_data = { StringData { other.get<StringType>(), other.maybe_enum() } };
+			break;
+
+		case Type::Null:
+			_data = { NullData {} };
+			break;
+
+		case Type::Boolean:
+			_data = { other.get<BooleanType>() };
+			break;
+
+		case Type::Int:
+			_data = { other.get<IntType>() };
+			break;
+
+		case Type::Float:
+			_data = { other.get<FloatType>() };
+			break;
+
+		case Type::EnumValue:
+			_data = { EnumData { other.get<StringType>() } };
+			break;
+
+		case Type::Scalar:
+			_data = { ScalarData { std::make_unique<ScalarType>(other.get<ScalarType>()) } };
+			break;
+	}
 }
 
 Value& Value::operator=(Value&& rhs) noexcept
 {
 	if (&rhs != this)
 	{
-		const_cast<Type&>(_type) = rhs._type;
 		_data = std::move(rhs._data);
 	}
 
@@ -164,12 +205,7 @@ Value& Value::operator=(Value&& rhs) noexcept
 
 bool Value::operator==(const Value& rhs) const noexcept
 {
-	if (rhs.type() != type())
-	{
-		return false;
-	}
-
-	return !_data || *_data == *rhs._data;
+	return _data == rhs._data;
 }
 
 bool Value::operator!=(const Value& rhs) const noexcept
@@ -179,20 +215,58 @@ bool Value::operator!=(const Value& rhs) const noexcept
 
 Type Value::type() const noexcept
 {
-	return _data ? _type : Type::Null;
+	// As long as the order of the variant alternatives matches the Type enum, we can cast the index
+	// to the Type in one step.
+	static_assert(
+		std::is_same_v<std::variant_alternative_t<static_cast<size_t>(Type::Map), TypeData>,
+			MapData>,
+		"type mistmatch");
+	static_assert(
+		std::is_same_v<std::variant_alternative_t<static_cast<size_t>(Type::List), TypeData>,
+			ListType>,
+		"type mistmatch");
+	static_assert(
+		std::is_same_v<std::variant_alternative_t<static_cast<size_t>(Type::String), TypeData>,
+			StringData>,
+		"type mistmatch");
+	static_assert(
+		std::is_same_v<std::variant_alternative_t<static_cast<size_t>(Type::Boolean), TypeData>,
+			BooleanType>,
+		"type mistmatch");
+	static_assert(
+		std::is_same_v<std::variant_alternative_t<static_cast<size_t>(Type::Int), TypeData>,
+			IntType>,
+		"type mistmatch");
+	static_assert(
+		std::is_same_v<std::variant_alternative_t<static_cast<size_t>(Type::Float), TypeData>,
+			FloatType>,
+		"type mistmatch");
+	static_assert(
+		std::is_same_v<std::variant_alternative_t<static_cast<size_t>(Type::EnumValue), TypeData>,
+			EnumData>,
+		"type mistmatch");
+	static_assert(
+		std::is_same_v<std::variant_alternative_t<static_cast<size_t>(Type::Scalar), TypeData>,
+			ScalarData>,
+		"type mistmatch");
+
+	return static_cast<Type>(_data.index());
 }
 
 Value&& Value::from_json() noexcept
 {
-	std::get<std::optional<StringOrEnumData>>(*_data)->from_json = true;
+	if (std::holds_alternative<StringData>(_data))
+	{
+		std::get<StringData>(_data).from_json = true;
+	}
 
 	return std::move(*this);
 }
 
 bool Value::maybe_enum() const noexcept
 {
-	return type() == Type::EnumValue
-		|| (type() == Type::String && std::get<std::optional<StringOrEnumData>>(*_data)->from_json);
+	return std::holds_alternative<EnumData>(_data)
+		|| (std::holds_alternative<StringData>(_data) && std::get<StringData>(_data).from_json);
 }
 
 void Value::reserve(size_t count)
@@ -201,18 +275,16 @@ void Value::reserve(size_t count)
 	{
 		case Type::Map:
 		{
-			auto& mapData = std::get<std::optional<MapData>>(*_data);
+			auto& mapData = std::get<MapData>(_data);
 
-			mapData->members.reserve(count);
-			mapData->map.reserve(count);
+			mapData.members.reserve(count);
+			mapData.map.reserve(count);
 			break;
 		}
 
 		case Type::List:
 		{
-			auto& listData = std::get<std::optional<ListData>>(*_data);
-
-			listData->list.reserve(count);
+			std::get<ListType>(_data).reserve(count);
 			break;
 		}
 
@@ -227,16 +299,12 @@ size_t Value::size() const
 	{
 		case Type::Map:
 		{
-			const auto& mapData = std::get<std::optional<MapData>>(*_data);
-
-			return mapData->map.size();
+			return std::get<MapData>(_data).map.size();
 		}
 
 		case Type::List:
 		{
-			const auto& listData = std::get<std::optional<ListData>>(*_data);
-
-			return listData->list.size();
+			return std::get<ListType>(_data).size();
 		}
 
 		default:
@@ -246,61 +314,76 @@ size_t Value::size() const
 
 void Value::emplace_back(std::string&& name, Value&& value)
 {
-	if (type() != Type::Map)
+	if (!std::holds_alternative<MapData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::emplace_back for MapType");
 	}
 
-	auto& mapData = std::get<std::optional<MapData>>(*_data);
+	auto& mapData = std::get<MapData>(_data);
+	const auto [itr, itrEnd] = std::equal_range(mapData.members.cbegin(),
+		mapData.members.cend(),
+		std::nullopt,
+		[&mapData, &name](std::optional<size_t> lhs, std::optional<size_t> rhs) noexcept {
+			std::string_view lhsName { lhs == std::nullopt ? name : mapData.map[*lhs].first };
+			std::string_view rhsName { rhs == std::nullopt ? name : mapData.map[*rhs].first };
+			return lhsName < rhsName;
+		});
 
-	if (mapData->members.find(name) != mapData->members.cend())
+	if (itr != itrEnd)
 	{
 		throw std::runtime_error("Duplicate Map member");
 	}
 
-	mapData->members.insert({ name, mapData->map.size() });
-	mapData->map.emplace_back(std::make_pair(std::move(name), std::move(value)));
+	mapData.map.emplace_back(std::make_pair(std::move(name), std::move(value)));
+	mapData.members.insert(itr, mapData.members.size());
 }
 
-MapType::const_iterator Value::find(const std::string& name) const
+MapType::const_iterator Value::find(std::string_view name) const
 {
-	if (type() != Type::Map)
+	if (!std::holds_alternative<MapData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::find for MapType");
 	}
 
-	const auto& mapData = std::get<std::optional<MapData>>(*_data);
-	const auto itr = mapData->members.find(name);
+	const auto& mapData = std::get<MapData>(_data);
+	const auto [itr, itrEnd] = std::equal_range(mapData.members.cbegin(),
+		mapData.members.cend(),
+		std::nullopt,
+		[&mapData, name](std::optional<size_t> lhs, std::optional<size_t> rhs) noexcept {
+			std::string_view lhsName { lhs == std::nullopt ? name : mapData.map[*lhs].first };
+			std::string_view rhsName { rhs == std::nullopt ? name : mapData.map[*rhs].first };
+			return lhsName < rhsName;
+		});
 
-	if (itr == mapData->members.cend())
+	if (itr == itrEnd)
 	{
-		return mapData->map.cend();
+		return mapData.map.cend();
 	}
 
-	return mapData->map.cbegin() + itr->second;
+	return mapData.map.cbegin() + *itr;
 }
 
 MapType::const_iterator Value::begin() const
 {
-	if (type() != Type::Map)
+	if (!std::holds_alternative<MapData>(_data))
 	{
-		throw std::logic_error("Invalid call to Value::end for MapType");
+		throw std::logic_error("Invalid call to Value::begin for MapType");
 	}
 
-	return std::get<std::optional<MapData>>(*_data)->map.cbegin();
+	return std::get<MapData>(_data).map.cbegin();
 }
 
 MapType::const_iterator Value::end() const
 {
-	if (type() != Type::Map)
+	if (!std::holds_alternative<MapData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::end for MapType");
 	}
 
-	return std::get<std::optional<MapData>>(*_data)->map.cend();
+	return std::get<MapData>(_data).map.cend();
 }
 
-const Value& Value::operator[](const std::string& name) const
+const Value& Value::operator[](std::string_view name) const
 {
 	const auto itr = find(name);
 
@@ -314,182 +397,198 @@ const Value& Value::operator[](const std::string& name) const
 
 void Value::emplace_back(Value&& value)
 {
-	if (type() != Type::List)
+	if (!std::holds_alternative<ListType>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::emplace_back for ListType");
 	}
 
-	std::get<std::optional<ListData>>(*_data)->list.emplace_back(std::move(value));
+	std::get<ListType>(_data).emplace_back(std::move(value));
 }
 
 const Value& Value::operator[](size_t index) const
 {
-	if (type() != Type::List)
+	if (!std::holds_alternative<ListType>(_data))
 	{
-		throw std::logic_error("Invalid call to Value::emplace_back for ListType");
+		throw std::logic_error("Invalid call to Value::operator[] for ListType");
 	}
 
-	return std::get<std::optional<ListData>>(*_data)->list.at(index);
+	return std::get<ListType>(_data).at(index);
 }
 
 template <>
 void Value::set<StringType>(StringType&& value)
 {
-	if (type() != Type::String && type() != Type::EnumValue)
+	if (std::holds_alternative<EnumData>(_data))
+	{
+		std::get<EnumData>(_data) = std::move(value);
+	}
+	else if (std::holds_alternative<StringData>(_data))
+	{
+		std::get<StringData>(_data).string = std::move(value);
+	}
+	else
 	{
 		throw std::logic_error("Invalid call to Value::set for StringType");
 	}
-
-	std::get<std::optional<StringOrEnumData>>(*_data)->string = std::move(value);
 }
 
 template <>
 void Value::set<BooleanType>(BooleanType value)
 {
-	if (type() != Type::Boolean)
+	if (!std::holds_alternative<BooleanType>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::set for BooleanType");
 	}
 
-	*_data = { value };
+	_data = { value };
 }
 
 template <>
 void Value::set<IntType>(IntType value)
 {
-	if (type() == Type::Float)
+	if (std::holds_alternative<FloatType>(_data))
 	{
 		// Coerce IntType to FloatType
-		*_data = { static_cast<FloatType>(value) };
+		_data = { static_cast<FloatType>(value) };
+		return;
 	}
-	else
-	{
-		if (type() != Type::Int)
-		{
-			throw std::logic_error("Invalid call to Value::set for IntType");
-		}
 
-		*_data = { value };
+	if (!std::holds_alternative<IntType>(_data))
+	{
+		throw std::logic_error("Invalid call to Value::set for IntType");
 	}
+
+	_data = { value };
 }
 
 template <>
 void Value::set<FloatType>(FloatType value)
 {
-	if (type() != Type::Float)
+	if (!std::holds_alternative<FloatType>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::set for FloatType");
 	}
 
-	*_data = { value };
+	_data = { value };
 }
 
 template <>
 void Value::set<ScalarType>(ScalarType&& value)
 {
-	if (type() != Type::Scalar)
+	if (!std::holds_alternative<ScalarData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::set for ScalarType");
 	}
 
-	*_data = { ScalarData { std::move(value) } };
+	_data = { ScalarData { std::make_unique<ScalarType>(std::move(value)) } };
 }
 
 template <>
 const MapType& Value::get<MapType>() const
 {
-	if (type() != Type::Map)
+	if (!std::holds_alternative<MapData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::get for MapType");
 	}
 
-	return std::get<std::optional<MapData>>(*_data)->map;
+	return std::get<MapData>(_data).map;
 }
 
 template <>
 const ListType& Value::get<ListType>() const
 {
-	if (type() != Type::List)
+	if (!std::holds_alternative<ListType>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::get for ListType");
 	}
 
-	return std::get<std::optional<ListData>>(*_data)->list;
+	return std::get<ListType>(_data);
 }
 
 template <>
 const StringType& Value::get<StringType>() const
 {
-	if (type() != Type::String && type() != Type::EnumValue)
+	if (std::holds_alternative<EnumData>(_data))
 	{
-		throw std::logic_error("Invalid call to Value::get for StringType");
+		return std::get<EnumData>(_data);
+	}
+	else if (std::holds_alternative<StringData>(_data))
+	{
+		return std::get<StringData>(_data).string;
 	}
 
-	return std::get<std::optional<StringOrEnumData>>(*_data)->string;
+	throw std::logic_error("Invalid call to Value::get for StringType");
 }
 
 template <>
 BooleanType Value::get<BooleanType>() const
 {
-	if (type() != Type::Boolean)
+	if (!std::holds_alternative<BooleanType>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::get for BooleanType");
 	}
 
-	return std::get<BooleanType>(*_data);
+	return std::get<BooleanType>(_data);
 }
 
 template <>
 IntType Value::get<IntType>() const
 {
-	if (type() != Type::Int)
+	if (!std::holds_alternative<IntType>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::get for IntType");
 	}
 
-	return std::get<IntType>(*_data);
+	return std::get<IntType>(_data);
 }
 
 template <>
 FloatType Value::get<FloatType>() const
 {
-	if (type() == Type::Int)
+	if (std::holds_alternative<IntType>(_data))
 	{
 		// Coerce IntType to FloatType
-		return static_cast<FloatType>(std::get<IntType>(*_data));
+		return static_cast<FloatType>(std::get<IntType>(_data));
 	}
 
-	if (type() != Type::Float)
+	if (!std::holds_alternative<FloatType>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::get for FloatType");
 	}
 
-	return std::get<FloatType>(*_data);
+	return std::get<FloatType>(_data);
 }
 
 template <>
 const ScalarType& Value::get<ScalarType>() const
 {
-	if (type() != Type::Scalar)
+	if (!std::holds_alternative<ScalarData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::get for ScalarType");
 	}
 
-	return std::get<std::optional<ScalarData>>(*_data)->scalar;
+	const auto& scalar = std::get<ScalarData>(_data).scalar;
+
+	if (!scalar)
+	{
+		throw std::logic_error("Invalid call to Value::get for ScalarType");
+	}
+
+	return *scalar;
 }
 
 template <>
 MapType Value::release<MapType>()
 {
-	if (type() != Type::Map)
+	if (!std::holds_alternative<MapData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::release for MapType");
 	}
 
-	auto& mapData = std::get<std::optional<MapData>>(*_data);
-	MapType result = std::move(mapData->map);
+	auto& mapData = std::get<MapData>(_data);
+	MapType result = std::move(mapData.map);
 
-	mapData->members.clear();
+	mapData.members.clear();
 
 	return result;
 }
@@ -497,12 +596,12 @@ MapType Value::release<MapType>()
 template <>
 ListType Value::release<ListType>()
 {
-	if (type() != Type::List)
+	if (!std::holds_alternative<ListType>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::release for ListType");
 	}
 
-	ListType result = std::move(std::get<std::optional<ListData>>(*_data)->list);
+	ListType result = std::move(std::get<ListType>(_data));
 
 	return result;
 }
@@ -510,15 +609,23 @@ ListType Value::release<ListType>()
 template <>
 StringType Value::release<StringType>()
 {
-	if (type() != Type::String && type() != Type::EnumValue)
+	StringType result;
+
+	if (std::holds_alternative<EnumData>(_data))
+	{
+		result = std::move(std::get<EnumData>(_data));
+	}
+	else if (std::holds_alternative<StringData>(_data))
+	{
+		auto& stringData = std::get<StringData>(_data);
+
+		result = std::move(stringData.string);
+		stringData.from_json = false;
+	}
+	else
 	{
 		throw std::logic_error("Invalid call to Value::release for StringType");
 	}
-
-	auto& stringData = std::get<std::optional<StringOrEnumData>>(*_data);
-	StringType result = std::move(stringData->string);
-
-	stringData->from_json = false;
 
 	return result;
 }
@@ -526,12 +633,19 @@ StringType Value::release<StringType>()
 template <>
 ScalarType Value::release<ScalarType>()
 {
-	if (type() != Type::Scalar)
+	if (!std::holds_alternative<ScalarData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::release for ScalarType");
 	}
 
-	ScalarType result = std::move(std::get<std::optional<ScalarData>>(*_data)->scalar);
+	auto scalar = std::move(std::get<ScalarData>(_data).scalar);
+
+	if (!scalar)
+	{
+		throw std::logic_error("Invalid call to Value::release for ScalarType");
+	}
+
+	ScalarType result = std::move(*scalar);
 
 	return result;
 }

--- a/src/GraphQLSchema.cpp
+++ b/src/GraphQLSchema.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "graphqlservice/GraphQLSchema.h"
-#include "graphqlservice/IntrospectionSchema.h"
+#include "graphqlservice/introspection/IntrospectionSchema.h"
 
 using namespace std::literals;
 

--- a/src/GraphQLSchema.cpp
+++ b/src/GraphQLSchema.cpp
@@ -8,7 +8,8 @@ using namespace std::literals;
 
 namespace graphql::schema {
 
-Schema::Schema()
+Schema::Schema(bool noIntrospection)
+	: _noIntrospection(noIntrospection)
 {
 }
 
@@ -31,6 +32,11 @@ void Schema::AddType(std::string_view name, std::shared_ptr<BaseType> type)
 {
 	_typeMap[name] = _types.size();
 	_types.push_back({ name, std::move(type) });
+}
+
+bool Schema::supportsIntrospection() const noexcept
+{
+	return !_noIntrospection;
 }
 
 const std::shared_ptr<BaseType>& Schema::LookupType(std::string_view name) const

--- a/src/GraphQLSchema.cpp
+++ b/src/GraphQLSchema.cpp
@@ -1,0 +1,436 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "graphqlservice/GraphQLSchema.h"
+#include "graphqlservice/IntrospectionSchema.h"
+
+using namespace std::literals;
+
+namespace graphql::schema {
+
+Schema::Schema()
+{
+}
+
+void Schema::AddQueryType(std::shared_ptr<ObjectType> query)
+{
+	_query = std::move(query);
+}
+
+void Schema::AddMutationType(std::shared_ptr<ObjectType> mutation)
+{
+	_mutation = std::move(mutation);
+}
+
+void Schema::AddSubscriptionType(std::shared_ptr<ObjectType> subscription)
+{
+	_subscription = std::move(subscription);
+}
+
+void Schema::AddType(std::string_view name, std::shared_ptr<BaseType> type)
+{
+	_typeMap[name] = _types.size();
+	_types.push_back({ name, std::move(type) });
+}
+
+const std::shared_ptr<BaseType>& Schema::LookupType(std::string_view name) const
+{
+	auto itr = _typeMap.find(name);
+
+	if (itr == _typeMap.cend())
+	{
+		std::ostringstream message;
+
+		message << "Type not found";
+
+		if (!name.empty())
+		{
+			message << " name: " << name;
+		}
+
+		throw service::schema_exception { { message.str() } };
+	}
+
+	return _types[itr->second].second;
+}
+
+const std::shared_ptr<BaseType>& Schema::WrapType(
+	introspection::TypeKind kind, const std::shared_ptr<BaseType>& ofType)
+{
+	auto& wrappers = (kind == introspection::TypeKind::LIST) ? _listWrappers : _nonNullWrappers;
+	auto itr = wrappers.find(ofType);
+
+	if (itr == wrappers.cend())
+	{
+		std::tie(itr, std::ignore) =
+			wrappers.insert({ ofType, std::make_shared<WrapperType>(kind, ofType) });
+	}
+
+	return itr->second;
+}
+
+void Schema::AddDirective(std::shared_ptr<Directive> directive)
+{
+	_directives.emplace_back(std::move(directive));
+}
+
+const std::vector<std::pair<std::string_view, std::shared_ptr<BaseType>>>& Schema::types()
+	const noexcept
+{
+	return _types;
+}
+
+const std::shared_ptr<ObjectType>& Schema::queryType() const noexcept
+{
+	return _query;
+}
+
+const std::shared_ptr<ObjectType>& Schema::mutationType() const noexcept
+{
+	return _mutation;
+}
+
+const std::shared_ptr<ObjectType>& Schema::subscriptionType() const noexcept
+{
+	return _subscription;
+}
+
+const std::vector<std::shared_ptr<Directive>>& Schema::directives() const noexcept
+{
+	return _directives;
+}
+
+BaseType::BaseType(introspection::TypeKind kind, std::string_view description)
+	: _kind(kind)
+	, _description(description)
+{
+}
+
+introspection::TypeKind BaseType::kind() const noexcept
+{
+	return _kind;
+}
+
+std::string_view BaseType::name() const noexcept
+{
+	return ""sv;
+}
+
+std::string_view BaseType::description() const noexcept
+{
+	return _description;
+}
+
+const std::vector<std::shared_ptr<Field>>& BaseType::fields() const noexcept
+{
+	static const std::vector<std::shared_ptr<Field>> defaultValue {};
+	return defaultValue;
+}
+
+const std::vector<std::shared_ptr<InterfaceType>>& BaseType::interfaces() const noexcept
+{
+	static const std::vector<std::shared_ptr<InterfaceType>> defaultValue {};
+	return defaultValue;
+}
+
+const std::vector<std::weak_ptr<BaseType>>& BaseType::possibleTypes() const noexcept
+{
+	static const std::vector<std::weak_ptr<BaseType>> defaultValue {};
+	return defaultValue;
+}
+
+const std::vector<std::shared_ptr<EnumValue>>& BaseType::enumValues() const noexcept
+{
+	static const std::vector<std::shared_ptr<EnumValue>> defaultValue {};
+	return defaultValue;
+}
+
+const std::vector<std::shared_ptr<InputValue>>& BaseType::inputFields() const noexcept
+{
+	static const std::vector<std::shared_ptr<InputValue>> defaultValue {};
+	return defaultValue;
+}
+
+const std::weak_ptr<BaseType>& BaseType::ofType() const noexcept
+{
+	static const std::weak_ptr<BaseType> defaultValue;
+	return defaultValue;
+}
+
+ScalarType::ScalarType(std::string_view name, std::string_view description)
+	: BaseType(introspection::TypeKind::SCALAR, description)
+	, _name(name)
+{
+}
+
+std::string_view ScalarType::name() const noexcept
+{
+	return _name;
+}
+
+ObjectType::ObjectType(std::string_view name, std::string_view description)
+	: BaseType(introspection::TypeKind::OBJECT, description)
+	, _name(name)
+{
+}
+
+void ObjectType::AddInterfaces(std::vector<std::shared_ptr<InterfaceType>> interfaces)
+{
+	_interfaces = std::move(interfaces);
+
+	for (const auto& interface : _interfaces)
+	{
+		interface->AddPossibleType(std::static_pointer_cast<ObjectType>(shared_from_this()));
+	}
+}
+
+void ObjectType::AddFields(std::vector<std::shared_ptr<Field>> fields)
+{
+	_fields = std::move(fields);
+}
+
+std::string_view ObjectType::name() const noexcept
+{
+	return _name;
+}
+
+const std::vector<std::shared_ptr<Field>>& ObjectType::fields() const noexcept
+{
+	return _fields;
+}
+
+const std::vector<std::shared_ptr<InterfaceType>>& ObjectType::interfaces() const noexcept
+{
+	return _interfaces;
+}
+
+InterfaceType::InterfaceType(std::string_view name, std::string_view description)
+	: BaseType(introspection::TypeKind::INTERFACE, description)
+	, _name(name)
+{
+}
+
+void InterfaceType::AddPossibleType(std::weak_ptr<ObjectType> possibleType)
+{
+	_possibleTypes.push_back(possibleType);
+}
+
+void InterfaceType::AddFields(std::vector<std::shared_ptr<Field>> fields)
+{
+	_fields = std::move(fields);
+}
+
+std::string_view InterfaceType::name() const noexcept
+{
+	return _name;
+}
+
+const std::vector<std::shared_ptr<Field>>& InterfaceType::fields() const noexcept
+{
+	return _fields;
+}
+
+const std::vector<std::weak_ptr<BaseType>>& InterfaceType::possibleTypes() const noexcept
+{
+	return _possibleTypes;
+}
+
+UnionType::UnionType(std::string_view name, std::string_view description)
+	: BaseType(introspection::TypeKind::UNION, description)
+	, _name(name)
+{
+}
+
+void UnionType::AddPossibleTypes(std::vector<std::weak_ptr<BaseType>> possibleTypes)
+{
+	_possibleTypes = std::move(possibleTypes);
+}
+
+std::string_view UnionType::name() const noexcept
+{
+	return _name;
+}
+
+const std::vector<std::weak_ptr<BaseType>>& UnionType::possibleTypes() const noexcept
+{
+	return _possibleTypes;
+}
+
+EnumType::EnumType(std::string_view name, std::string_view description)
+	: BaseType(introspection::TypeKind::ENUM, description)
+	, _name(name)
+{
+}
+
+void EnumType::AddEnumValues(std::vector<EnumValueType> enumValues)
+{
+	_enumValues.reserve(_enumValues.size() + enumValues.size());
+
+	for (auto& value : enumValues)
+	{
+		_enumValues.push_back(
+			std::make_shared<EnumValue>(value.value, value.description, value.deprecationReason));
+	}
+}
+
+std::string_view EnumType::name() const noexcept
+{
+	return _name;
+}
+
+const std::vector<std::shared_ptr<EnumValue>>& EnumType::enumValues() const noexcept
+{
+	return _enumValues;
+}
+
+InputObjectType::InputObjectType(std::string_view name, std::string_view description)
+	: BaseType(introspection::TypeKind::INPUT_OBJECT, description)
+	, _name(name)
+{
+}
+
+void InputObjectType::AddInputValues(std::vector<std::shared_ptr<InputValue>> inputValues)
+{
+	_inputValues = std::move(inputValues);
+}
+
+std::string_view InputObjectType::name() const noexcept
+{
+	return _name;
+}
+
+const std::vector<std::shared_ptr<InputValue>>& InputObjectType::inputFields() const noexcept
+{
+	return _inputValues;
+}
+
+WrapperType::WrapperType(introspection::TypeKind kind, const std::shared_ptr<BaseType>& ofType)
+	: BaseType(kind, std::string_view())
+	, _ofType(ofType)
+{
+}
+
+const std::weak_ptr<BaseType>& WrapperType::ofType() const noexcept
+{
+	return _ofType;
+}
+
+Field::Field(std::string_view name, std::string_view description,
+	std::optional<std::string_view> deprecationReason,
+	std::vector<std::shared_ptr<InputValue>>&& args, const std::shared_ptr<BaseType>& type)
+	: _name(name)
+	, _description(description)
+	, _deprecationReason(deprecationReason)
+	, _args(std::move(args))
+	, _type(type)
+{
+}
+
+std::string_view Field::name() const noexcept
+{
+	return _name;
+}
+
+std::string_view Field::description() const noexcept
+{
+	return _description;
+}
+
+const std::vector<std::shared_ptr<InputValue>>& Field::args() const noexcept
+{
+	return _args;
+}
+
+const std::weak_ptr<BaseType>& Field::type() const noexcept
+{
+	return _type;
+}
+
+const std::optional<std::string_view>& Field::deprecationReason() const noexcept
+{
+	return _deprecationReason;
+}
+
+InputValue::InputValue(std::string_view name, std::string_view description,
+	const std::shared_ptr<BaseType>& type, std::string_view defaultValue)
+	: _name(name)
+	, _description(description)
+	, _type(type)
+	, _defaultValue(defaultValue)
+{
+}
+
+std::string_view InputValue::name() const noexcept
+{
+	return _name;
+}
+
+std::string_view InputValue::description() const noexcept
+{
+	return _description;
+}
+
+const std::weak_ptr<BaseType>& InputValue::type() const noexcept
+{
+	return _type;
+}
+
+std::string_view InputValue::defaultValue() const noexcept
+{
+	return _defaultValue;
+}
+
+EnumValue::EnumValue(std::string_view name, std::string_view description,
+	std::optional<std::string_view> deprecationReason)
+	: _name(name)
+	, _description(description)
+	, _deprecationReason(deprecationReason)
+{
+}
+
+std::string_view EnumValue::name() const noexcept
+{
+	return _name;
+}
+
+std::string_view EnumValue::description() const noexcept
+{
+	return _description;
+}
+
+const std::optional<std::string_view>& EnumValue::deprecationReason() const noexcept
+{
+	return _deprecationReason;
+}
+
+Directive::Directive(std::string_view name, std::string_view description,
+	std::vector<introspection::DirectiveLocation>&& locations,
+	std::vector<std::shared_ptr<InputValue>>&& args)
+	: _name(name)
+	, _description(description)
+	, _locations(std::move(locations))
+	, _args(std::move(args))
+{
+}
+
+std::string_view Directive::name() const noexcept
+{
+	return _name;
+}
+
+std::string_view Directive::description() const noexcept
+{
+	return _description;
+}
+
+const std::vector<introspection::DirectiveLocation>& Directive::locations() const noexcept
+{
+	return _locations;
+}
+
+const std::vector<std::shared_ptr<InputValue>>& Directive::args() const noexcept
+{
+	return _args;
+}
+
+} // namespace graphql::schema

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
-#include <stack>
 
 namespace graphql::service {
 
@@ -41,7 +40,7 @@ void addErrorLocation(const schema_location& location, response::Value& error)
 	error.emplace_back(std::string { strLocations }, std::move(errorLocations));
 }
 
-void addErrorPath(field_path&& path, response::Value& error)
+void addErrorPath(const field_path& path, response::Value& error)
 {
 	if (path.empty())
 	{
@@ -51,21 +50,18 @@ void addErrorPath(field_path&& path, response::Value& error)
 	response::Value errorPath(response::Type::List);
 
 	errorPath.reserve(path.size());
-	while (!path.empty())
+	for (const auto& segment : path)
 	{
-		auto& segment = path.front();
-
-		if (std::holds_alternative<std::string>(segment))
+		if (std::holds_alternative<std::string_view>(segment))
 		{
-			errorPath.emplace_back(response::Value(std::move(std::get<std::string>(segment))));
+			errorPath.emplace_back(
+				response::Value { std::string { std::get<std::string_view>(segment) } });
 		}
 		else if (std::holds_alternative<size_t>(segment))
 		{
 			errorPath.emplace_back(
 				response::Value(static_cast<response::IntType>(std::get<size_t>(segment))));
 		}
-
-		path.pop();
 	}
 
 	error.emplace_back(std::string { strPath }, std::move(errorPath));
@@ -84,7 +80,7 @@ response::Value buildErrorValues(const std::vector<schema_error>& structuredErro
 		entry.reserve(3);
 		addErrorMessage(std::move(error.message), entry);
 		addErrorLocation(error.location, entry);
-		addErrorPath(std::move(error.path), entry);
+		addErrorPath(error.path, entry);
 
 		errors.emplace_back(std::move(entry));
 	}
@@ -94,7 +90,6 @@ response::Value buildErrorValues(const std::vector<schema_error>& structuredErro
 
 schema_exception::schema_exception(std::vector<schema_error>&& structuredErrors)
 	: _structuredErrors(std::move(structuredErrors))
-	, _errors(buildErrorValues(_structuredErrors))
 {
 }
 
@@ -122,22 +117,12 @@ const char* schema_exception::what() const noexcept
 {
 	const char* message = nullptr;
 
-	if (_errors.size() > 0)
+	if (!_structuredErrors.empty())
 	{
-		auto itr = _errors[0].find("message");
-
-		if (itr != _errors[0].end() && itr->second.type() == response::Type::String)
-		{
-			message = itr->second.get<response::StringType>().c_str();
-		}
+		message = _structuredErrors.front().message.c_str();
 	}
 
 	return (message == nullptr) ? "Unknown schema error" : message;
-}
-
-const std::vector<schema_error>& schema_exception::getStructuredErrors() const noexcept
-{
-	return _structuredErrors;
 }
 
 std::vector<schema_error> schema_exception::getStructuredErrors() noexcept
@@ -147,16 +132,9 @@ std::vector<schema_error> schema_exception::getStructuredErrors() noexcept
 	return structuredErrors;
 }
 
-const response::Value& schema_exception::getErrors() const noexcept
+response::Value schema_exception::getErrors() const
 {
-	return _errors;
-}
-
-response::Value schema_exception::getErrors() noexcept
-{
-	auto errors = std::move(_errors);
-
-	return errors;
+	return buildErrorValues(_structuredErrors);
 }
 
 FieldParams::FieldParams(const SelectionSetParams& selectionSetParams, response::Value&& directives)
@@ -739,7 +717,7 @@ void blockSubFields(const ResolverParams& params)
 }
 
 template <>
-std::future<response::Value> ModifiedResult<response::IntType>::convert(
+std::future<ResolverResult> ModifiedResult<response::IntType>::convert(
 	FieldResult<response::IntType>&& result, ResolverParams&& params)
 {
 	blockSubFields(params);
@@ -752,7 +730,7 @@ std::future<response::Value> ModifiedResult<response::IntType>::convert(
 }
 
 template <>
-std::future<response::Value> ModifiedResult<response::FloatType>::convert(
+std::future<ResolverResult> ModifiedResult<response::FloatType>::convert(
 	FieldResult<response::FloatType>&& result, ResolverParams&& params)
 {
 	blockSubFields(params);
@@ -765,7 +743,7 @@ std::future<response::Value> ModifiedResult<response::FloatType>::convert(
 }
 
 template <>
-std::future<response::Value> ModifiedResult<response::StringType>::convert(
+std::future<ResolverResult> ModifiedResult<response::StringType>::convert(
 	FieldResult<response::StringType>&& result, ResolverParams&& params)
 {
 	blockSubFields(params);
@@ -778,7 +756,7 @@ std::future<response::Value> ModifiedResult<response::StringType>::convert(
 }
 
 template <>
-std::future<response::Value> ModifiedResult<response::BooleanType>::convert(
+std::future<ResolverResult> ModifiedResult<response::BooleanType>::convert(
 	FieldResult<response::BooleanType>&& result, ResolverParams&& params)
 {
 	blockSubFields(params);
@@ -791,7 +769,7 @@ std::future<response::Value> ModifiedResult<response::BooleanType>::convert(
 }
 
 template <>
-std::future<response::Value> ModifiedResult<response::Value>::convert(
+std::future<ResolverResult> ModifiedResult<response::Value>::convert(
 	FieldResult<response::Value>&& result, ResolverParams&& params)
 {
 	blockSubFields(params);
@@ -804,7 +782,7 @@ std::future<response::Value> ModifiedResult<response::Value>::convert(
 }
 
 template <>
-std::future<response::Value> ModifiedResult<response::IdType>::convert(
+std::future<ResolverResult> ModifiedResult<response::IdType>::convert(
 	FieldResult<response::IdType>&& result, ResolverParams&& params)
 {
 	blockSubFields(params);
@@ -833,7 +811,7 @@ void requireSubFields(const ResolverParams& params)
 }
 
 template <>
-std::future<response::Value> ModifiedResult<Object>::convert(
+std::future<ResolverResult> ModifiedResult<Object>::convert(
 	FieldResult<std::shared_ptr<Object>>&& result, ResolverParams&& params)
 {
 	requireSubFields(params);
@@ -845,12 +823,7 @@ std::future<response::Value> ModifiedResult<Object>::convert(
 
 			if (!wrappedResult)
 			{
-				response::Value document(response::Type::Map);
-
-				document.emplace_back(std::string { strData },
-					response::Value(response::Type::Null));
-
-				return document;
+				return ResolverResult {};
 			}
 
 			return wrappedResult
@@ -886,7 +859,7 @@ public:
 
 	void visit(const peg::ast_node& selection);
 
-	std::queue<std::pair<std::string, std::future<response::Value>>> getValues();
+	std::vector<std::pair<std::string_view, std::future<ResolverResult>>> getValues();
 
 private:
 	void visitField(const peg::ast_node& field);
@@ -903,9 +876,9 @@ private:
 	const TypeNames& _typeNames;
 	const ResolverMap& _resolvers;
 
-	std::stack<FragmentDirectives> _fragmentDirectives;
+	std::vector<FragmentDirectives> _fragmentDirectives;
 	std::unordered_set<std::string_view> _names;
-	std::queue<std::pair<std::string, std::future<response::Value>>> _values;
+	std::vector<std::pair<std::string_view, std::future<ResolverResult>>> _values;
 };
 
 SelectionVisitor::SelectionVisitor(const SelectionSetParams& selectionSetParams,
@@ -921,12 +894,12 @@ SelectionVisitor::SelectionVisitor(const SelectionSetParams& selectionSetParams,
 	, _typeNames(typeNames)
 	, _resolvers(resolvers)
 {
-	_fragmentDirectives.push({ response::Value(response::Type::Map),
+	_fragmentDirectives.push_back({ response::Value(response::Type::Map),
 		response::Value(response::Type::Map),
 		response::Value(response::Type::Map) });
 }
 
-std::queue<std::pair<std::string, std::future<response::Value>>> SelectionVisitor::getValues()
+std::vector<std::pair<std::string_view, std::future<ResolverResult>>> SelectionVisitor::getValues()
 {
 	auto values = std::move(_values);
 
@@ -951,13 +924,13 @@ void SelectionVisitor::visit(const peg::ast_node& selection)
 
 void SelectionVisitor::visitField(const peg::ast_node& field)
 {
-	std::string name;
+	std::string_view name;
 
 	peg::on_first_child<peg::field_name>(field, [&name](const peg::ast_node& child) {
 		name = child.string_view();
 	});
 
-	std::string alias;
+	std::string_view alias;
 
 	peg::on_first_child<peg::alias_name>(field, [&alias](const peg::ast_node& child) {
 		alias = child.string_view();
@@ -985,7 +958,7 @@ void SelectionVisitor::visitField(const peg::ast_node& field)
 
 	if (itr == itrEnd)
 	{
-		std::promise<response::Value> promise;
+		std::promise<ResolverResult> promise;
 		auto position = field.begin();
 		std::ostringstream error;
 
@@ -994,7 +967,7 @@ void SelectionVisitor::visitField(const peg::ast_node& field)
 		promise.set_exception(std::make_exception_ptr(schema_exception {
 			{ schema_error { error.str(), { position.line, position.column }, { _path } } } }));
 
-		_values.push({ std::move(alias), promise.get_future() });
+		_values.push_back({ alias, promise.get_future() });
 		return;
 	}
 
@@ -1030,15 +1003,15 @@ void SelectionVisitor::visitField(const peg::ast_node& field)
 
 	auto path = _path;
 
-	path.push({ alias });
+	path.push_back({ alias });
 
 	SelectionSetParams selectionSetParams {
 		_resolverContext,
 		_state,
 		_operationDirectives,
-		_fragmentDirectives.top().fragmentDefinitionDirectives,
-		_fragmentDirectives.top().fragmentSpreadDirectives,
-		_fragmentDirectives.top().inlineFragmentDirectives,
+		_fragmentDirectives.back().fragmentDefinitionDirectives,
+		_fragmentDirectives.back().fragmentSpreadDirectives,
+		_fragmentDirectives.back().inlineFragmentDirectives,
 		std::move(path),
 		_launch,
 	};
@@ -1054,11 +1027,11 @@ void SelectionVisitor::visitField(const peg::ast_node& field)
 			_fragments,
 			_variables));
 
-		_values.push({ std::move(alias), std::move(result) });
+		_values.push_back({ alias, std::move(result) });
 	}
 	catch (schema_exception& scx)
 	{
-		std::promise<response::Value> promise;
+		std::promise<ResolverResult> promise;
 		auto position = field.begin();
 		auto messages = scx.getStructuredErrors();
 
@@ -1077,11 +1050,11 @@ void SelectionVisitor::visitField(const peg::ast_node& field)
 
 		promise.set_exception(std::make_exception_ptr(schema_exception { std::move(messages) }));
 
-		_values.push({ std::move(alias), promise.get_future() });
+		_values.push_back({ alias, promise.get_future() });
 	}
 	catch (const std::exception& ex)
 	{
-		std::promise<response::Value> promise;
+		std::promise<ResolverResult> promise;
 		auto position = field.begin();
 		std::ostringstream message;
 
@@ -1092,7 +1065,7 @@ void SelectionVisitor::visitField(const peg::ast_node& field)
 				{ position.line, position.column },
 				std::move(selectionSetParams.errorPath) } } }));
 
-		_values.push({ std::move(alias), promise.get_future() });
+		_values.push_back({ alias, promise.get_future() });
 	}
 }
 
@@ -1134,7 +1107,7 @@ void SelectionVisitor::visitFragmentSpread(const peg::ast_node& fragmentSpread)
 	auto fragmentSpreadDirectives = directiveVisitor.getDirectives();
 
 	// Merge outer fragment spread directives as long as they don't conflict.
-	for (const auto& entry : _fragmentDirectives.top().fragmentSpreadDirectives)
+	for (const auto& entry : _fragmentDirectives.back().fragmentSpreadDirectives)
 	{
 		if (fragmentSpreadDirectives.find(entry.first) == fragmentSpreadDirectives.end())
 		{
@@ -1146,7 +1119,7 @@ void SelectionVisitor::visitFragmentSpread(const peg::ast_node& fragmentSpread)
 	response::Value fragmentDefinitionDirectives(itr->second.getDirectives());
 
 	// Merge outer fragment definition directives as long as they don't conflict.
-	for (const auto& entry : _fragmentDirectives.top().fragmentDefinitionDirectives)
+	for (const auto& entry : _fragmentDirectives.back().fragmentDefinitionDirectives)
 	{
 		if (fragmentDefinitionDirectives.find(entry.first) == fragmentDefinitionDirectives.end())
 		{
@@ -1155,16 +1128,16 @@ void SelectionVisitor::visitFragmentSpread(const peg::ast_node& fragmentSpread)
 		}
 	}
 
-	_fragmentDirectives.push({ std::move(fragmentDefinitionDirectives),
+	_fragmentDirectives.push_back({ std::move(fragmentDefinitionDirectives),
 		std::move(fragmentSpreadDirectives),
-		response::Value(_fragmentDirectives.top().inlineFragmentDirectives) });
+		response::Value(_fragmentDirectives.back().inlineFragmentDirectives) });
 
 	for (const auto& selection : itr->second.getSelection().children)
 	{
 		visit(*selection);
 	}
 
-	_fragmentDirectives.pop();
+	_fragmentDirectives.pop_back();
 }
 
 void SelectionVisitor::visitInlineFragment(const peg::ast_node& inlineFragment)
@@ -1195,7 +1168,7 @@ void SelectionVisitor::visitInlineFragment(const peg::ast_node& inlineFragment)
 				auto inlineFragmentDirectives = directiveVisitor.getDirectives();
 
 				// Merge outer inline fragment directives as long as they don't conflict.
-				for (const auto& entry : _fragmentDirectives.top().inlineFragmentDirectives)
+				for (const auto& entry : _fragmentDirectives.back().inlineFragmentDirectives)
 				{
 					if (inlineFragmentDirectives.find(entry.first)
 						== inlineFragmentDirectives.end())
@@ -1205,9 +1178,9 @@ void SelectionVisitor::visitInlineFragment(const peg::ast_node& inlineFragment)
 					}
 				}
 
-				_fragmentDirectives.push(
-					{ response::Value(_fragmentDirectives.top().fragmentDefinitionDirectives),
-						response::Value(_fragmentDirectives.top().fragmentSpreadDirectives),
+				_fragmentDirectives.push_back(
+					{ response::Value(_fragmentDirectives.back().fragmentDefinitionDirectives),
+						response::Value(_fragmentDirectives.back().fragmentSpreadDirectives),
 						std::move(inlineFragmentDirectives) });
 
 				for (const auto& selection : child.children)
@@ -1215,7 +1188,7 @@ void SelectionVisitor::visitInlineFragment(const peg::ast_node& inlineFragment)
 					visit(*selection);
 				}
 
-				_fragmentDirectives.pop();
+				_fragmentDirectives.pop_back();
 			});
 	}
 }
@@ -1226,14 +1199,15 @@ Object::Object(TypeNames&& typeNames, ResolverMap&& resolvers)
 {
 }
 
-std::future<response::Value> Object::resolve(const SelectionSetParams& selectionSetParams,
+std::future<ResolverResult> Object::resolve(const SelectionSetParams& selectionSetParams,
 	const peg::ast_node& selection, const FragmentMap& fragments,
 	const response::Value& variables) const
 {
-	std::queue<std::pair<std::string, std::future<response::Value>>> selections;
+	std::vector<std::pair<std::string_view, std::future<ResolverResult>>> selections;
 
 	beginSelectionSet(selectionSetParams);
 
+	selections.reserve(selection.children.size());
 	for (const auto& child : selection.children)
 	{
 		SelectionVisitor visitor(selectionSetParams, fragments, variables, _typeNames, _resolvers);
@@ -1242,10 +1216,9 @@ std::future<response::Value> Object::resolve(const SelectionSetParams& selection
 
 		auto values = visitor.getValues();
 
-		while (!values.empty())
+		for (auto& value : values)
 		{
-			selections.push(std::move(values.front()));
-			values.pop();
+			selections.push_back(std::move(value));
 		}
 	}
 
@@ -1253,63 +1226,56 @@ std::future<response::Value> Object::resolve(const SelectionSetParams& selection
 
 	return std::async(
 		selectionSetParams.launch,
-		[](std::queue<std::pair<std::string, std::future<response::Value>>>&& children) {
-			response::Value data(response::Type::Map);
-			response::Value errors(response::Type::List);
+		[](std::vector<std::pair<std::string_view, std::future<ResolverResult>>>&& children) {
+			ResolverResult document { response::Value { response::Type::Map } };
 
-			while (!children.empty())
+			for (auto& child : children)
 			{
-				auto name = std::move(children.front().first);
+				auto name = child.first;
 
 				try
 				{
-					auto value = children.front().second.get();
-					auto members = value.release<response::MapType>();
+					auto value = child.second.get();
+					auto itrData = document.data.find(name);
 
-					for (auto& entry : members)
+					if (itrData == document.data.end())
 					{
-						if (entry.second.type() == response::Type::List && entry.first == strErrors)
+						document.data.emplace_back(std::string { name }, std::move(value.data));
+					}
+					else if (itrData->second != value.data)
+					{
+						std::ostringstream message;
+
+						message << "Ambiguous field error name: " << name;
+
+						document.errors.push_back({ message.str() });
+					}
+
+					if (!value.errors.empty())
+					{
+						document.errors.reserve(document.errors.size() + value.errors.size());
+						for (auto& error : value.errors)
 						{
-							auto errorEntries = entry.second.release<response::ListType>();
-
-							for (auto& errorEntry : errorEntries)
-							{
-								errors.emplace_back(std::move(errorEntry));
-							}
-						}
-						else if (entry.first == strData)
-						{
-							auto itrData = data.find(name);
-
-							if (itrData == data.end())
-							{
-								data.emplace_back(std::move(name), std::move(entry.second));
-							}
-							else if (itrData->second != entry.second)
-							{
-								std::ostringstream message;
-								response::Value error(response::Type::Map);
-
-								message << "Ambiguous field error name: " << name;
-								addErrorMessage(message.str(), error);
-								errors.emplace_back(std::move(error));
-							}
+							document.errors.push_back(std::move(error));
 						}
 					}
 				}
 				catch (schema_exception& scx)
 				{
-					auto messages = scx.getErrors().release<response::ListType>();
+					auto errors = scx.getStructuredErrors();
 
-					errors.reserve(errors.size() + messages.size());
-					for (auto& error : messages)
+					if (!errors.empty())
 					{
-						errors.emplace_back(std::move(error));
+						document.errors.reserve(document.errors.size() + errors.size());
+						for (auto& error : errors)
+						{
+							document.errors.push_back(std::move(error));
+						}
 					}
 
-					if (data.find(name) == data.end())
+					if (document.data.find(name) == document.data.end())
 					{
-						data.emplace_back(std::move(name), {});
+						document.data.emplace_back(std::string { name }, {});
 					}
 				}
 				catch (const std::exception& ex)
@@ -1318,30 +1284,16 @@ std::future<response::Value> Object::resolve(const SelectionSetParams& selection
 
 					message << "Field error name: " << name << " unknown error: " << ex.what();
 
-					response::Value error(response::Type::Map);
+					document.errors.push_back({ message.str() });
 
-					addErrorMessage(message.str(), error);
-					errors.emplace_back(std::move(error));
-
-					if (data.find(name) == data.end())
+					if (document.data.find(name) == document.data.end())
 					{
-						data.emplace_back(std::move(name), {});
+						document.data.emplace_back(std::string { name }, {});
 					}
 				}
-
-				children.pop();
 			}
 
-			response::Value result(response::Type::Map);
-
-			result.emplace_back(std::string { strData }, std::move(data));
-
-			if (errors.size() > 0)
-			{
-				result.emplace_back(std::string { strErrors }, std::move(errors));
-			}
-
-			return result;
+			return document;
 		},
 		std::move(selections));
 }
@@ -1411,7 +1363,7 @@ public:
 		std::shared_ptr<RequestState> state, const TypeMap& operations, response::Value&& variables,
 		FragmentMap&& fragments);
 
-	std::future<response::Value> getValue();
+	std::future<ResolverResult> getValue();
 
 	void visit(std::string_view operationType, const peg::ast_node& operationDefinition);
 
@@ -1420,7 +1372,7 @@ private:
 	const std::launch _launch;
 	std::shared_ptr<OperationData> _params;
 	const TypeMap& _operations;
-	std::future<response::Value> _result;
+	std::future<ResolverResult> _result;
 };
 
 OperationDefinitionVisitor::OperationDefinitionVisitor(ResolverContext resolverContext,
@@ -1434,7 +1386,7 @@ OperationDefinitionVisitor::OperationDefinitionVisitor(ResolverContext resolverC
 {
 }
 
-std::future<response::Value> OperationDefinitionVisitor::getValue()
+std::future<ResolverResult> OperationDefinitionVisitor::getValue()
 {
 	auto result = std::move(_result);
 
@@ -1634,7 +1586,7 @@ void SubscriptionDefinitionVisitor::visit(const peg::ast_node& operationDefiniti
 
 void SubscriptionDefinitionVisitor::visitField(const peg::ast_node& field)
 {
-	std::string name;
+	std::string_view name;
 
 	peg::on_first_child<peg::field_name>(field, [&name](const peg::ast_node& child) {
 		name = child.string_view();
@@ -1898,7 +1850,23 @@ std::future<response::Value> Request::resolve(std::launch launch,
 
 		operationVisitor.visit(operationDefinition.first, *operationDefinition.second);
 
-		return operationVisitor.getValue();
+		return std::async(
+			launch,
+			[](std::future<ResolverResult>&& operationFuture) {
+				auto result = operationFuture.get();
+				response::Value document { response::Type::Map };
+
+				document.emplace_back(std::string { strData }, std::move(result.data));
+
+				if (!result.errors.empty())
+				{
+					document.emplace_back(std::string { strErrors },
+						buildErrorValues(result.errors));
+				}
+
+				return document;
+			},
+			operationVisitor.getValue());
 	}
 	catch (schema_exception& ex)
 	{
@@ -2036,7 +2004,23 @@ std::future<response::Value> Request::resolveUnvalidated(std::launch launch,
 
 		operationVisitor.visit(operationDefinition.first, *operationDefinition.second);
 
-		return operationVisitor.getValue();
+		return std::async(
+			launch,
+			[](std::future<ResolverResult>&& operationFuture) {
+				auto result = operationFuture.get();
+				response::Value document { response::Type::Map };
+
+				document.emplace_back(std::string { strData }, std::move(result.data));
+
+				if (!result.errors.empty())
+				{
+					document.emplace_back(std::string { strErrors },
+						buildErrorValues(result.errors));
+				}
+
+				return document;
+			},
+			operationVisitor.getValue());
 	}
 	catch (schema_exception& ex)
 	{
@@ -2328,8 +2312,9 @@ void Request::deliver(std::launch launch, const SubscriptionName& name,
 		return;
 	}
 
-	std::queue<std::future<void>> callbacks;
+	std::vector<std::future<void>> callbacks;
 
+	callbacks.reserve(itrListeners->second.size());
 	for (const auto& key : itrListeners->second)
 	{
 		auto itrSubscription = _subscriptions.find(key);
@@ -2389,8 +2374,19 @@ void Request::deliver(std::launch launch, const SubscriptionName& name,
 		{
 			result = std::async(
 				launch,
-				[registration](std::future<response::Value> document) {
-					return document.get();
+				[](std::future<ResolverResult>&& operationFuture) {
+					auto result = operationFuture.get();
+					response::Value document { response::Type::Map };
+
+					document.emplace_back(std::string { strData }, std::move(result.data));
+
+					if (!result.errors.empty())
+					{
+						document.emplace_back(std::string { strErrors },
+							buildErrorValues(result.errors));
+					}
+
+					return document;
 				},
 				optionalOrDefaultSubscription->resolve(selectionSetParams,
 					registration->selection,
@@ -2409,7 +2405,7 @@ void Request::deliver(std::launch launch, const SubscriptionName& name,
 			result = promise.get_future();
 		}
 
-		callbacks.push(std::async(
+		callbacks.push_back(std::async(
 			launch,
 			[registration](std::future<response::Value> document) {
 				registration->callback(std::move(document));
@@ -2417,10 +2413,9 @@ void Request::deliver(std::launch launch, const SubscriptionName& name,
 			std::move(result)));
 	}
 
-	while (!callbacks.empty())
+	for (auto& callback : callbacks)
 	{
-		callbacks.front().get();
-		callbacks.pop();
+		callback.get();
 	}
 }
 

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -1835,20 +1835,6 @@ std::future<response::Value> Request::resolve(std::launch launch,
 	const std::shared_ptr<RequestState>& state, peg::ast& query, const std::string& operationName,
 	response::Value&& variables) const
 {
-	auto errors = validate(query);
-
-	if (!errors.empty())
-	{
-		std::promise<response::Value> promise;
-		response::Value document(response::Type::Map);
-
-		document.emplace_back(std::string { strData }, response::Value());
-		document.emplace_back(std::string { strErrors }, buildErrorValues(errors));
-		promise.set_value(std::move(document));
-
-		return promise.get_future();
-	}
-
 	try
 	{
 		FragmentDefinitionVisitor fragmentVisitor(variables);

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -1759,7 +1759,7 @@ void SubscriptionDefinitionVisitor::visitInlineFragment(const peg::ast_node& inl
 
 Request::Request(TypeMap&& operationTypes, const std::shared_ptr<schema::Schema>& schema)
 	: _operations(std::move(operationTypes))
-	, _validation(std::make_unique<ValidateExecutableVisitor>(*this))
+	, _validation(std::make_unique<ValidateExecutableVisitor>(schema))
 {
 }
 

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -1757,7 +1757,7 @@ void SubscriptionDefinitionVisitor::visitInlineFragment(const peg::ast_node& inl
 	}
 }
 
-Request::Request(TypeMap&& operationTypes)
+Request::Request(TypeMap&& operationTypes, const std::shared_ptr<schema::Schema>& schema)
 	: _operations(std::move(operationTypes))
 	, _validation(std::make_unique<ValidateExecutableVisitor>(*this))
 {

--- a/src/GraphQLTree.cpp
+++ b/src/GraphQLTree.cpp
@@ -10,7 +10,6 @@
 #include <functional>
 #include <memory>
 #include <numeric>
-#include <stack>
 #include <tuple>
 
 namespace graphql {

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "graphqlservice/Introspection.h"
+#include "graphqlservice/introspection/Introspection.h"
 
 namespace graphql::introspection {
 

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -5,632 +5,393 @@
 
 namespace graphql::introspection {
 
-Schema::Schema()
+Schema::Schema(const std::shared_ptr<schema::Schema>& schema)
+	: _schema(schema)
 {
-}
-
-void Schema::AddQueryType(std::shared_ptr<ObjectType> query)
-{
-	_query = std::move(query);
-}
-
-void Schema::AddMutationType(std::shared_ptr<ObjectType> mutation)
-{
-	_mutation = std::move(mutation);
-}
-
-void Schema::AddSubscriptionType(std::shared_ptr<ObjectType> subscription)
-{
-	_subscription = std::move(subscription);
-}
-
-void Schema::AddType(response::StringType&& name, std::shared_ptr<object::Type> type)
-{
-	_typeMap[name] = _types.size();
-	_types.push_back({ std::move(name), std::move(type) });
-}
-
-const std::shared_ptr<object::Type>& Schema::LookupType(const response::StringType& name) const
-{
-	auto itr = _typeMap.find(name);
-
-	if (itr == _typeMap.cend())
-	{
-		std::ostringstream message;
-
-		message << "Type not found";
-
-		if (!name.empty())
-		{
-			message << " name: " << name;
-		}
-
-		throw service::schema_exception { { message.str() } };
-	}
-
-	return _types[itr->second].second;
-}
-
-const std::shared_ptr<object::Type>& Schema::WrapType(
-	TypeKind kind, const std::shared_ptr<object::Type>& ofType)
-{
-	auto& wrappers = (kind == TypeKind::LIST) ? _listWrappers : _nonNullWrappers;
-	auto itr = wrappers.find(ofType);
-
-	if (itr == wrappers.cend())
-	{
-		std::tie(itr, std::ignore) =
-			wrappers.insert({ ofType, std::make_shared<WrapperType>(kind, ofType) });
-	}
-
-	return itr->second;
-}
-
-void Schema::AddDirective(std::shared_ptr<object::Directive> directive)
-{
-	_directives.emplace_back(std::move(directive));
 }
 
 service::FieldResult<std::vector<std::shared_ptr<object::Type>>> Schema::getTypes(
 	service::FieldParams&& params) const
 {
-	auto spThis = shared_from_this();
+	const auto& types = _schema->types();
+	std::vector<std::shared_ptr<object::Type>> result(types.size());
 
-	return std::async(params.launch, [this, spThis]() {
-		std::vector<std::shared_ptr<object::Type>> result(_types.size());
-
-		std::transform(_types.cbegin(),
-			_types.cend(),
-			result.begin(),
-			[](const std::pair<response::StringType, std::shared_ptr<object::Type>>& namedType) {
-				return namedType.second;
-			});
-
-		return result;
+	std::transform(types.begin(), types.end(), result.begin(), [](const auto& entry) {
+		return std::make_shared<Type>(entry.second);
 	});
+
+	return result;
 }
 
 service::FieldResult<std::shared_ptr<object::Type>> Schema::getQueryType(
 	service::FieldParams&&) const
 {
-	return _query;
+	const auto& queryType = _schema->queryType();
+
+	return queryType ? std::make_shared<Type>(queryType) : nullptr;
 }
 
 service::FieldResult<std::shared_ptr<object::Type>> Schema::getMutationType(
 	service::FieldParams&&) const
 {
-	return _mutation;
+	const auto& mutationType = _schema->mutationType();
+
+	return mutationType ? std::make_shared<Type>(mutationType) : nullptr;
 }
 
 service::FieldResult<std::shared_ptr<object::Type>> Schema::getSubscriptionType(
 	service::FieldParams&&) const
 {
-	return _subscription;
+	const auto& subscriptionType = _schema->subscriptionType();
+
+	return subscriptionType ? std::make_shared<Type>(subscriptionType) : nullptr;
 }
 
 service::FieldResult<std::vector<std::shared_ptr<object::Directive>>> Schema::getDirectives(
 	service::FieldParams&&) const
 {
-	return _directives;
+	const auto& directives = _schema->directives();
+	std::vector<std::shared_ptr<object::Directive>> result(directives.size());
+
+	std::transform(directives.begin(), directives.end(), result.begin(), [](const auto& entry) {
+		return std::make_shared<Directive>(entry);
+	});
+
+	return result;
 }
 
-BaseType::BaseType(response::StringType&& description)
-	: _description(std::move(description))
+Type::Type(const std::shared_ptr<schema::BaseType>& type)
+	: _type(type)
 {
 }
 
-service::FieldResult<std::optional<response::StringType>> BaseType::getName(
+service::FieldResult<TypeKind> Type::getKind(service::FieldParams&&) const
+{
+	return _type->kind();
+}
+
+service::FieldResult<std::optional<response::StringType>> Type::getName(
 	service::FieldParams&&) const
 {
-	return std::nullopt;
+	const auto name = _type->name();
+
+	return { name.empty() ? std::nullopt : std::make_optional<response::StringType>(name) };
 }
 
-service::FieldResult<std::optional<response::StringType>> BaseType::getDescription(
+service::FieldResult<std::optional<response::StringType>> Type::getDescription(
 	service::FieldParams&&) const
 {
-	return { _description.empty() ? std::nullopt
-								  : std::make_optional<response::StringType>(_description) };
+	const auto description = _type->description();
+
+	return { description.empty() ? std::nullopt
+								 : std::make_optional<response::StringType>(description) };
 }
 
-service::FieldResult<std::optional<std::vector<std::shared_ptr<object::Field>>>>
-BaseType::getFields(
-	service::FieldParams&&, std::optional<response::BooleanType>&& /*includeDeprecatedArg*/) const
+service::FieldResult<std::optional<std::vector<std::shared_ptr<object::Field>>>> Type::getFields(
+	service::FieldParams&&, std::optional<response::BooleanType>&& includeDeprecatedArg) const
 {
-	return std::nullopt;
-}
-
-service::FieldResult<std::optional<std::vector<std::shared_ptr<object::Type>>>> BaseType::
-	getInterfaces(service::FieldParams&&) const
-{
-	return std::nullopt;
-}
-
-service::FieldResult<std::optional<std::vector<std::shared_ptr<object::Type>>>> BaseType::
-	getPossibleTypes(service::FieldParams&&) const
-{
-	return std::nullopt;
-}
-
-service::FieldResult<std::optional<std::vector<std::shared_ptr<object::EnumValue>>>>
-BaseType::getEnumValues(
-	service::FieldParams&&, std::optional<response::BooleanType>&& /*includeDeprecatedArg*/) const
-{
-	return std::nullopt;
-}
-
-service::FieldResult<std::optional<std::vector<std::shared_ptr<object::InputValue>>>> BaseType::
-	getInputFields(service::FieldParams&&) const
-{
-	return std::nullopt;
-}
-
-service::FieldResult<std::shared_ptr<object::Type>> BaseType::getOfType(
-	service::FieldParams&&) const
-{
-	return std::shared_ptr<object::Type> {};
-}
-
-ScalarType::ScalarType(response::StringType&& name, response::StringType&& description)
-	: BaseType(std::move(description))
-	, _name(std::move(name))
-{
-}
-
-service::FieldResult<TypeKind> ScalarType::getKind(service::FieldParams&&) const
-{
-	return TypeKind::SCALAR;
-}
-
-service::FieldResult<std::optional<response::StringType>> ScalarType::getName(
-	service::FieldParams&&) const
-{
-	std::promise<std::optional<response::StringType>> promise;
-
-	promise.set_value(std::make_optional<response::StringType>(_name));
-
-	return promise.get_future();
-}
-
-ObjectType::ObjectType(response::StringType&& name, response::StringType&& description)
-	: BaseType(std::move(description))
-	, _name(std::move(name))
-{
-}
-
-void ObjectType::AddInterfaces(std::vector<std::shared_ptr<InterfaceType>> interfaces)
-{
-	_interfaces = std::move(interfaces);
-
-	for (const auto& interface : _interfaces)
+	switch (_type->kind())
 	{
-		interface->AddPossibleType(std::static_pointer_cast<ObjectType>(shared_from_this()));
+		case introspection::TypeKind::OBJECT:
+		case introspection::TypeKind::INTERFACE:
+			break;
+
+		default:
+			return std::nullopt;
 	}
-}
 
-void ObjectType::AddFields(std::vector<std::shared_ptr<Field>> fields)
-{
-	_fields = std::move(fields);
-}
-
-service::FieldResult<TypeKind> ObjectType::getKind(service::FieldParams&&) const
-{
-	return TypeKind::OBJECT;
-}
-
-service::FieldResult<std::optional<response::StringType>> ObjectType::getName(
-	service::FieldParams&&) const
-{
-	return std::make_optional<response::StringType>(_name);
-}
-
-service::FieldResult<std::optional<std::vector<std::shared_ptr<object::Field>>>> ObjectType::
-	getFields(service::FieldParams&& params,
-		std::optional<response::BooleanType>&& includeDeprecatedArg) const
-{
+	const auto& fields = _type->fields();
 	const bool deprecated = includeDeprecatedArg && *includeDeprecatedArg;
 	auto result = std::make_optional<std::vector<std::shared_ptr<object::Field>>>();
 
-	result->reserve(_fields.size());
-	std::copy_if(_fields.cbegin(),
-		_fields.cend(),
-		std::back_inserter(*result),
-		[&params, deprecated](const std::shared_ptr<Field>& field) {
-			return deprecated
-				|| !field
-						->getIsDeprecated(
-							service::FieldParams(params, response::Value(response::Type::Map)))
-						.get();
-		});
-
-	return { std::move(result) };
-}
-
-service::FieldResult<std::optional<std::vector<std::shared_ptr<object::Type>>>> ObjectType::
-	getInterfaces(service::FieldParams&&) const
-{
-	auto result =
-		std::make_optional<std::vector<std::shared_ptr<object::Type>>>(_interfaces.size());
-
-	std::copy(_interfaces.cbegin(), _interfaces.cend(), result->begin());
-
-	return { std::move(result) };
-}
-
-InterfaceType::InterfaceType(response::StringType&& name, response::StringType&& description)
-	: BaseType(std::move(description))
-	, _name(std::move(name))
-{
-}
-
-void InterfaceType::AddPossibleType(std::weak_ptr<ObjectType> possibleType)
-{
-	_possibleTypes.push_back(possibleType);
-}
-
-void InterfaceType::AddFields(std::vector<std::shared_ptr<Field>> fields)
-{
-	_fields = std::move(fields);
-}
-
-service::FieldResult<TypeKind> InterfaceType::getKind(service::FieldParams&&) const
-{
-	return TypeKind::INTERFACE;
-}
-
-service::FieldResult<std::optional<response::StringType>> InterfaceType::getName(
-	service::FieldParams&&) const
-{
-	return std::make_optional<response::StringType>(_name);
-}
-
-service::FieldResult<std::optional<std::vector<std::shared_ptr<object::Field>>>> InterfaceType::
-	getFields(service::FieldParams&& params,
-		std::optional<response::BooleanType>&& includeDeprecatedArg) const
-{
-	const bool deprecated = includeDeprecatedArg && *includeDeprecatedArg;
-	auto result = std::make_optional<std::vector<std::shared_ptr<object::Field>>>();
-
-	result->reserve(_fields.size());
-	std::copy_if(_fields.cbegin(),
-		_fields.cend(),
-		std::back_inserter(*result),
-		[&params, deprecated](const std::shared_ptr<Field>& field) {
-			return deprecated
-				|| !field
-						->getIsDeprecated(
-							service::FieldParams(params, response::Value(response::Type::Map)))
-						.get();
-		});
-
-	return { std::move(result) };
-}
-
-service::FieldResult<std::optional<std::vector<std::shared_ptr<object::Type>>>> InterfaceType::
-	getPossibleTypes(service::FieldParams&&) const
-{
-	auto result =
-		std::make_optional<std::vector<std::shared_ptr<object::Type>>>(_possibleTypes.size());
-
-	std::transform(_possibleTypes.cbegin(),
-		_possibleTypes.cend(),
-		result->begin(),
-		[](const std::weak_ptr<object::Type>& weak) {
-			return weak.lock();
-		});
-
-	return { std::move(result) };
-}
-
-UnionType::UnionType(response::StringType&& name, response::StringType&& description)
-	: BaseType(std::move(description))
-	, _name(std::move(name))
-{
-}
-
-void UnionType::AddPossibleTypes(std::vector<std::weak_ptr<object::Type>> possibleTypes)
-{
-	_possibleTypes = std::move(possibleTypes);
-}
-
-service::FieldResult<TypeKind> UnionType::getKind(service::FieldParams&&) const
-{
-	return TypeKind::UNION;
-}
-
-service::FieldResult<std::optional<response::StringType>> UnionType::getName(
-	service::FieldParams&&) const
-{
-	return std::make_optional<response::StringType>(_name);
-}
-
-service::FieldResult<std::optional<std::vector<std::shared_ptr<object::Type>>>> UnionType::
-	getPossibleTypes(service::FieldParams&&) const
-{
-	auto result =
-		std::make_optional<std::vector<std::shared_ptr<object::Type>>>(_possibleTypes.size());
-
-	std::transform(_possibleTypes.cbegin(),
-		_possibleTypes.cend(),
-		result->begin(),
-		[](const std::weak_ptr<object::Type>& weak) {
-			return weak.lock();
-		});
-
-	return { std::move(result) };
-}
-
-EnumType::EnumType(response::StringType&& name, response::StringType&& description)
-	: BaseType(std::move(description))
-	, _name(std::move(name))
-{
-}
-
-void EnumType::AddEnumValues(std::vector<EnumValueType> enumValues)
-{
-	_enumValues.reserve(_enumValues.size() + enumValues.size());
-
-	for (auto& value : enumValues)
+	result->reserve(fields.size());
+	for (const auto& field : fields)
 	{
-		_enumValues.push_back(std::make_shared<EnumValue>(std::move(value.value),
-			std::move(value.description),
-			std::move(value.deprecationReason)));
+		if (deprecated || !field->deprecationReason())
+		{
+			result->push_back(std::make_shared<Field>(field));
+		}
 	}
+
+	return result;
 }
 
-service::FieldResult<TypeKind> EnumType::getKind(service::FieldParams&&) const
-{
-	return TypeKind::ENUM;
-}
-
-service::FieldResult<std::optional<response::StringType>> EnumType::getName(
+service::FieldResult<std::optional<std::vector<std::shared_ptr<object::Type>>>> Type::getInterfaces(
 	service::FieldParams&&) const
 {
-	return std::make_optional<response::StringType>(_name);
+	switch (_type->kind())
+	{
+		case introspection::TypeKind::OBJECT:
+			break;
+
+		default:
+			return std::nullopt;
+	}
+
+	const auto& interfaces = _type->interfaces();
+	auto result = std::make_optional<std::vector<std::shared_ptr<object::Type>>>(interfaces.size());
+
+	std::transform(interfaces.begin(), interfaces.end(), result->begin(), [](const auto& entry) {
+		return std::make_shared<Type>(entry);
+	});
+
+	return result;
 }
 
-service::FieldResult<std::optional<std::vector<std::shared_ptr<object::EnumValue>>>> EnumType::
-	getEnumValues(service::FieldParams&& params,
-		std::optional<response::BooleanType>&& includeDeprecatedArg) const
+service::FieldResult<std::optional<std::vector<std::shared_ptr<object::Type>>>> Type::
+	getPossibleTypes(service::FieldParams&&) const
 {
+	switch (_type->kind())
+	{
+		case introspection::TypeKind::INTERFACE:
+		case introspection::TypeKind::UNION:
+			break;
+
+		default:
+			return std::nullopt;
+	}
+
+	const auto& possibleTypes = _type->possibleTypes();
+	auto result =
+		std::make_optional<std::vector<std::shared_ptr<object::Type>>>(possibleTypes.size());
+
+	std::transform(possibleTypes.begin(),
+		possibleTypes.end(),
+		result->begin(),
+		[](const auto& entry) {
+			return std::make_shared<Type>(entry.lock());
+		});
+
+	return result;
+}
+
+service::FieldResult<std::optional<std::vector<std::shared_ptr<object::EnumValue>>>> Type::
+	getEnumValues(
+		service::FieldParams&&, std::optional<response::BooleanType>&& includeDeprecatedArg) const
+{
+	switch (_type->kind())
+	{
+		case introspection::TypeKind::ENUM:
+			break;
+
+		default:
+			return std::nullopt;
+	}
+
+	const auto& enumValues = _type->enumValues();
 	const bool deprecated = includeDeprecatedArg && *includeDeprecatedArg;
 	auto result = std::make_optional<std::vector<std::shared_ptr<object::EnumValue>>>();
 
-	result->reserve(_enumValues.size());
-	std::copy_if(_enumValues.cbegin(),
-		_enumValues.cend(),
-		std::back_inserter(*result),
-		[&params, deprecated](const std::shared_ptr<object::EnumValue>& value) {
-			return deprecated
-				|| !value
-						->getIsDeprecated(
-							service::FieldParams(params, response::Value(response::Type::Map)))
-						.get();
-		});
+	result->reserve(enumValues.size());
+	for (const auto& value : enumValues)
+	{
+		if (deprecated || !value->deprecationReason())
+		{
+			result->push_back(std::make_shared<EnumValue>(value));
+		}
+	}
 
-	return { std::move(result) };
+	return result;
 }
 
-InputObjectType::InputObjectType(response::StringType&& name, response::StringType&& description)
-	: BaseType(std::move(description))
-	, _name(std::move(name))
+service::FieldResult<std::optional<std::vector<std::shared_ptr<object::InputValue>>>> Type::
+	getInputFields(service::FieldParams&&) const
 {
-}
+	switch (_type->kind())
+	{
+		case introspection::TypeKind::INPUT_OBJECT:
+			break;
 
-void InputObjectType::AddInputValues(std::vector<std::shared_ptr<InputValue>> inputValues)
-{
-	_inputValues = std::move(inputValues);
-}
+		default:
+			return std::nullopt;
+	}
 
-service::FieldResult<TypeKind> InputObjectType::getKind(service::FieldParams&&) const
-{
-	return TypeKind::INPUT_OBJECT;
-}
-
-service::FieldResult<std::optional<response::StringType>> InputObjectType::getName(
-	service::FieldParams&&) const
-{
-	return std::make_optional<response::StringType>(_name);
-}
-
-service::FieldResult<std::optional<std::vector<std::shared_ptr<object::InputValue>>>>
-InputObjectType::getInputFields(service::FieldParams&&) const
-{
+	const auto& inputFields = _type->inputFields();
 	auto result =
-		std::make_optional<std::vector<std::shared_ptr<object::InputValue>>>(_inputValues.size());
+		std::make_optional<std::vector<std::shared_ptr<object::InputValue>>>(inputFields.size());
 
-	std::copy(_inputValues.cbegin(), _inputValues.cend(), result->begin());
+	std::transform(inputFields.begin(), inputFields.end(), result->begin(), [](const auto& entry) {
+		return std::make_shared<InputValue>(entry);
+	});
 
-	return { std::move(result) };
+	return result;
 }
 
-WrapperType::WrapperType(TypeKind kind, const std::shared_ptr<object::Type>& ofType)
-	: BaseType(response::StringType())
-	, _kind(kind)
-	, _ofType(ofType)
+service::FieldResult<std::shared_ptr<object::Type>> Type::getOfType(service::FieldParams&&) const
 {
+	switch (_type->kind())
+	{
+		case introspection::TypeKind::LIST:
+		case introspection::TypeKind::NON_NULL:
+			break;
+
+		default:
+			return nullptr;
+	}
+
+	const auto ofType = _type->ofType().lock();
+
+	return ofType ? std::make_shared<Type>(ofType) : nullptr;
 }
 
-service::FieldResult<TypeKind> WrapperType::getKind(service::FieldParams&&) const
-{
-	return _kind;
-}
-
-service::FieldResult<std::shared_ptr<object::Type>> WrapperType::getOfType(
-	service::FieldParams&&) const
-{
-	return _ofType.lock();
-}
-
-Field::Field(response::StringType&& name, response::StringType&& description,
-	std::optional<response::StringType>&& deprecationReason,
-	std::vector<std::shared_ptr<InputValue>>&& args, const std::shared_ptr<object::Type>& type)
-	: _name(std::move(name))
-	, _description(std::move(description))
-	, _deprecationReason(std::move(deprecationReason))
-	, _args(std::move(args))
-	, _type(type)
+Field::Field(const std::shared_ptr<schema::Field>& field)
+	: _field(field)
 {
 }
 
 service::FieldResult<response::StringType> Field::getName(service::FieldParams&&) const
 {
-	return _name;
+	return response::StringType { _field->name() };
 }
 
 service::FieldResult<std::optional<response::StringType>> Field::getDescription(
 	service::FieldParams&&) const
 {
-	return { _description.empty() ? std::nullopt
-								  : std::make_optional<response::StringType>(_description) };
+	const auto description = _field->description();
+
+	return { description.empty() ? std::nullopt
+								 : std::make_optional<response::StringType>(description) };
 }
 
 service::FieldResult<std::vector<std::shared_ptr<object::InputValue>>> Field::getArgs(
 	service::FieldParams&&) const
 {
-	std::vector<std::shared_ptr<object::InputValue>> result(_args.size());
+	const auto& args = _field->args();
+	std::vector<std::shared_ptr<object::InputValue>> result(args.size());
 
-	std::copy(_args.cbegin(), _args.cend(), result.begin());
+	std::transform(args.begin(), args.end(), result.begin(), [](const auto& entry) {
+		return std::make_shared<InputValue>(entry);
+	});
 
-	return { std::move(result) };
+	return result;
 }
 
 service::FieldResult<std::shared_ptr<object::Type>> Field::getType(service::FieldParams&&) const
 {
-	return _type.lock();
+	const auto type = _field->type().lock();
+
+	return type ? std::make_shared<Type>(type) : nullptr;
 }
 
 service::FieldResult<response::BooleanType> Field::getIsDeprecated(service::FieldParams&&) const
 {
-	return _deprecationReason.has_value();
+	return _field->deprecationReason().has_value();
 }
 
 service::FieldResult<std::optional<response::StringType>> Field::getDeprecationReason(
 	service::FieldParams&&) const
 {
-	return { _deprecationReason ? std::make_optional<response::StringType>(*_deprecationReason)
-								: std::nullopt };
+	const auto& deprecationReason = _field->deprecationReason();
+
+	return { deprecationReason ? std::make_optional<response::StringType>(*deprecationReason)
+							   : std::nullopt };
 }
 
-InputValue::InputValue(response::StringType&& name, response::StringType&& description,
-	const std::shared_ptr<object::Type>& type, response::StringType&& defaultValue)
-	: _name(std::move(name))
-	, _description(std::move(description))
-	, _type(type)
-	, _defaultValue(std::move(defaultValue))
+InputValue::InputValue(const std::shared_ptr<schema::InputValue>& inputValue)
+	: _inputValue(inputValue)
 {
 }
 
 service::FieldResult<response::StringType> InputValue::getName(service::FieldParams&&) const
 {
-	return _name;
+	return response::StringType { _inputValue->name() };
 }
 
 service::FieldResult<std::optional<response::StringType>> InputValue::getDescription(
 	service::FieldParams&&) const
 {
-	return { _description.empty() ? std::nullopt
-								  : std::make_optional<response::StringType>(_description) };
+	const auto description = _inputValue->description();
+
+	return { description.empty() ? std::nullopt
+								 : std::make_optional<response::StringType>(description) };
 }
 
 service::FieldResult<std::shared_ptr<object::Type>> InputValue::getType(
 	service::FieldParams&&) const
 {
-	return _type.lock();
+	const auto type = _inputValue->type().lock();
+
+	return type ? std::make_shared<Type>(type) : nullptr;
 }
 
 service::FieldResult<std::optional<response::StringType>> InputValue::getDefaultValue(
 	service::FieldParams&&) const
 {
-	return { _defaultValue.empty() ? std::nullopt
-								   : std::make_optional<response::StringType>(_defaultValue) };
+	const auto defaultValue = _inputValue->defaultValue();
+
+	return { defaultValue.empty() ? std::nullopt
+								   : std::make_optional<response::StringType>(defaultValue) };
 }
 
-EnumValue::EnumValue(response::StringType&& name, response::StringType&& description,
-	std::optional<response::StringType>&& deprecationReason)
-	: _name(std::move(name))
-	, _description(std::move(description))
-	, _deprecationReason(std::move(deprecationReason))
+EnumValue::EnumValue(const std::shared_ptr<schema::EnumValue>& enumValue)
+	: _enumValue(enumValue)
 {
 }
 
 service::FieldResult<response::StringType> EnumValue::getName(service::FieldParams&&) const
 {
-	return _name;
+	return response::StringType { _enumValue->name() };
 }
 
 service::FieldResult<std::optional<response::StringType>> EnumValue::getDescription(
 	service::FieldParams&&) const
 {
-	return { _description.empty() ? std::nullopt
-								  : std::make_optional<response::StringType>(_description) };
+	const auto description = _enumValue->description();
+
+	return { description.empty() ? std::nullopt
+								 : std::make_optional<response::StringType>(description) };
 }
 
 service::FieldResult<response::BooleanType> EnumValue::getIsDeprecated(service::FieldParams&&) const
 {
-	return _deprecationReason.has_value();
+	return _enumValue->deprecationReason().has_value();
 }
 
 service::FieldResult<std::optional<response::StringType>> EnumValue::getDeprecationReason(
 	service::FieldParams&&) const
 {
-	return { _deprecationReason ? std::make_optional<response::StringType>(*_deprecationReason)
-								: std::nullopt };
+	const auto& deprecationReason = _enumValue->deprecationReason();
+
+	return { deprecationReason ? std::make_optional<response::StringType>(*deprecationReason)
+							   : std::nullopt };
 }
 
-Directive::Directive(response::StringType&& name, response::StringType&& description,
-	std::vector<response::StringType>&& locations, std::vector<std::shared_ptr<InputValue>>&& args)
-	: _name(std::move(name))
-	, _description(std::move(description))
-	, _locations(
-		  [](std::vector<response::StringType>&& locationsArg) -> std::vector<DirectiveLocation> {
-			  std::vector<DirectiveLocation> result(locationsArg.size());
-
-			  std::transform(locationsArg.begin(),
-				  locationsArg.end(),
-				  result.begin(),
-				  [](std::string& name) -> DirectiveLocation {
-					  response::Value location(response::Type::EnumValue);
-
-					  location.set<response::StringType>(std::move(name));
-					  return service::ModifiedArgument<DirectiveLocation>::convert(location);
-				  });
-
-			  return result;
-		  }(std::move(locations)))
-	, _args(std::move(args))
+Directive::Directive(const std::shared_ptr<schema::Directive>& directive)
+	: _directive(directive)
 {
 }
 
 service::FieldResult<response::StringType> Directive::getName(service::FieldParams&&) const
 {
-	return _name;
+	return response::StringType { _directive->name() };
 }
 
 service::FieldResult<std::optional<response::StringType>> Directive::getDescription(
 	service::FieldParams&&) const
 {
-	return { _description.empty() ? std::nullopt
-								  : std::make_optional<response::StringType>(_description) };
+	const auto description = _directive->description();
+
+	return { description.empty() ? std::nullopt
+								 : std::make_optional<response::StringType>(description) };
 }
 
 service::FieldResult<std::vector<DirectiveLocation>> Directive::getLocations(
 	service::FieldParams&&) const
 {
-	std::vector<DirectiveLocation> result(_locations.size());
-
-	std::copy(_locations.cbegin(), _locations.cend(), result.begin());
-
-	return { std::move(result) };
+	return { _directive->locations() };
 }
 
 service::FieldResult<std::vector<std::shared_ptr<object::InputValue>>> Directive::getArgs(
 	service::FieldParams&&) const
 {
-	std::vector<std::shared_ptr<object::InputValue>> result(_args.size());
+	const auto& args = _directive->args();
+	std::vector<std::shared_ptr<object::InputValue>> result(args.size());
 
-	std::copy(_args.cbegin(), _args.cend(), result.begin());
+	std::transform(args.begin(), args.end(), result.begin(), [](const auto& entry) {
+		return std::make_shared<InputValue>(entry);
+	});
 
-	return { std::move(result) };
+	return result;
 }
 
 } /* namespace graphql::introspection */

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -60,7 +60,7 @@ service::FieldResult<std::vector<std::shared_ptr<object::Directive>>> Schema::ge
 	return result;
 }
 
-Type::Type(const std::shared_ptr<schema::BaseType>& type)
+Type::Type(const std::shared_ptr<const schema::BaseType>& type)
 	: _type(type)
 {
 }
@@ -234,7 +234,7 @@ service::FieldResult<std::shared_ptr<object::Type>> Type::getOfType(service::Fie
 	return ofType ? std::make_shared<Type>(ofType) : nullptr;
 }
 
-Field::Field(const std::shared_ptr<schema::Field>& field)
+Field::Field(const std::shared_ptr<const schema::Field>& field)
 	: _field(field)
 {
 }
@@ -287,7 +287,7 @@ service::FieldResult<std::optional<response::StringType>> Field::getDeprecationR
 							   : std::nullopt };
 }
 
-InputValue::InputValue(const std::shared_ptr<schema::InputValue>& inputValue)
+InputValue::InputValue(const std::shared_ptr<const schema::InputValue>& inputValue)
 	: _inputValue(inputValue)
 {
 }
@@ -320,10 +320,10 @@ service::FieldResult<std::optional<response::StringType>> InputValue::getDefault
 	const auto defaultValue = _inputValue->defaultValue();
 
 	return { defaultValue.empty() ? std::nullopt
-								   : std::make_optional<response::StringType>(defaultValue) };
+								  : std::make_optional<response::StringType>(defaultValue) };
 }
 
-EnumValue::EnumValue(const std::shared_ptr<schema::EnumValue>& enumValue)
+EnumValue::EnumValue(const std::shared_ptr<const schema::EnumValue>& enumValue)
 	: _enumValue(enumValue)
 {
 }
@@ -356,7 +356,7 @@ service::FieldResult<std::optional<response::StringType>> EnumValue::getDeprecat
 							   : std::nullopt };
 }
 
-Directive::Directive(const std::shared_ptr<schema::Directive>& directive)
+Directive::Directive(const std::shared_ptr<const schema::Directive>& directive)
 	: _directive(directive)
 {
 }

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -2352,7 +2352,14 @@ Operations::Operations()cpp";
 		{
 			sourceFile << R"cpp(	schema->AddType(R"gql()cpp" << builtinType.first
 					   << R"cpp()gql"sv, std::make_shared<schema::ScalarType>(R"gql()cpp"
-					   << builtinType.first << R"cpp()gql"sv, R"md(Built-in type)md"));
+					   << builtinType.first << R"cpp()gql"sv, R"md()cpp";
+
+			if (!_options.noIntrospection)
+			{
+				sourceFile << R"cpp(Built-in type)cpp";
+			}
+
+			sourceFile << R"cpp()md"));
 )cpp";
 		}
 	}
@@ -2363,8 +2370,14 @@ Operations::Operations()cpp";
 		{
 			sourceFile << R"cpp(	schema->AddType(R"gql()cpp" << scalarType.type
 					   << R"cpp()gql"sv, std::make_shared<schema::ScalarType>(R"gql()cpp"
-					   << scalarType.type << R"cpp()gql"sv, R"md()cpp" << scalarType.description
-					   << R"cpp()md"));
+					   << scalarType.type << R"cpp()gql"sv, R"md()cpp";
+
+			if (!_options.noIntrospection)
+			{
+				sourceFile << scalarType.description;
+			}
+
+			sourceFile << R"cpp()md"));
 )cpp";
 		}
 	}
@@ -2375,7 +2388,14 @@ Operations::Operations()cpp";
 		{
 			sourceFile << R"cpp(	auto type)cpp" << enumType.cppType
 					   << R"cpp( = std::make_shared<schema::EnumType>(R"gql()cpp" << enumType.type
-					   << R"cpp()gql"sv, R"md()cpp" << enumType.description << R"cpp()md"sv);
+					   << R"cpp()gql"sv, R"md()cpp";
+
+			if (!_options.noIntrospection)
+			{
+				sourceFile << enumType.description;
+			}
+
+			sourceFile << R"cpp()md"sv);
 	schema->AddType(R"gql()cpp"
 					   << enumType.type << R"cpp()gql"sv, type)cpp" << enumType.cppType << R"cpp();
 )cpp";
@@ -2388,8 +2408,14 @@ Operations::Operations()cpp";
 		{
 			sourceFile << R"cpp(	auto type)cpp" << inputType.cppType
 					   << R"cpp( = std::make_shared<schema::InputObjectType>(R"gql()cpp"
-					   << inputType.type << R"cpp()gql"sv, R"md()cpp" << inputType.description
-					   << R"cpp()md"sv);
+					   << inputType.type << R"cpp()gql"sv, R"md()cpp";
+
+			if (!_options.noIntrospection)
+			{
+				sourceFile << inputType.description;
+			}
+
+			sourceFile << R"cpp()md"sv);
 	schema->AddType(R"gql()cpp"
 					   << inputType.type << R"cpp()gql"sv, type)cpp" << inputType.cppType
 					   << R"cpp();
@@ -2403,7 +2429,14 @@ Operations::Operations()cpp";
 		{
 			sourceFile << R"cpp(	auto type)cpp" << unionType.cppType
 					   << R"cpp( = std::make_shared<schema::UnionType>(R"gql()cpp" << unionType.type
-					   << R"cpp()gql"sv, R"md()cpp" << unionType.description << R"cpp()md"sv);
+					   << R"cpp()gql"sv, R"md()cpp";
+
+			if (!_options.noIntrospection)
+			{
+				sourceFile << unionType.description;
+			}
+
+			sourceFile << R"cpp()md"sv);
 	schema->AddType(R"gql()cpp"
 					   << unionType.type << R"cpp()gql"sv, type)cpp" << unionType.cppType
 					   << R"cpp();
@@ -2417,8 +2450,14 @@ Operations::Operations()cpp";
 		{
 			sourceFile << R"cpp(	auto type)cpp" << interfaceType.cppType
 					   << R"cpp( = std::make_shared<schema::InterfaceType>(R"gql()cpp"
-					   << interfaceType.type << R"cpp()gql"sv, R"md()cpp"
-					   << interfaceType.description << R"cpp()md"sv);
+					   << interfaceType.type << R"cpp()gql"sv, R"md()cpp";
+
+			if (!_options.noIntrospection)
+			{
+				sourceFile << interfaceType.description;
+			}
+
+			sourceFile << R"cpp()md"sv);
 	schema->AddType(R"gql()cpp"
 					   << interfaceType.type << R"cpp()gql"sv, type)cpp" << interfaceType.cppType
 					   << R"cpp();
@@ -2432,8 +2471,14 @@ Operations::Operations()cpp";
 		{
 			sourceFile << R"cpp(	auto type)cpp" << objectType.cppType
 					   << R"cpp( = std::make_shared<schema::ObjectType>(R"gql()cpp"
-					   << objectType.type << R"cpp()gql"sv, R"md()cpp" << objectType.description
-					   << R"cpp()md");
+					   << objectType.type << R"cpp()gql"sv, R"md()cpp";
+
+			if (!_options.noIntrospection)
+			{
+				sourceFile << objectType.description;
+			}
+
+			sourceFile << R"cpp()md");
 	schema->AddType(R"gql()cpp"
 					   << objectType.type << R"cpp()gql"sv, type)cpp" << objectType.cppType
 					   << R"cpp();
@@ -2466,8 +2511,14 @@ Operations::Operations()cpp";
 					sourceFile << R"cpp(		{ service::s_names)cpp" << enumType.cppType
 							   << R"cpp([static_cast<size_t>()cpp" << _schemaNamespace
 							   << R"cpp(::)cpp" << enumType.cppType << R"cpp(::)cpp"
-							   << enumValue.cppValue << R"cpp()], R"md()cpp"
-							   << enumValue.description << R"cpp()md"sv, )cpp";
+							   << enumValue.cppValue << R"cpp()], R"md()cpp";
+
+					if (!_options.noIntrospection)
+					{
+						sourceFile << enumValue.description;
+					}
+
+					sourceFile << R"cpp()md"sv, )cpp";
 
 					if (enumValue.deprecationReason)
 					{
@@ -2512,8 +2563,14 @@ Operations::Operations()cpp";
 
 					firstValue = false;
 					sourceFile << R"cpp(		std::make_shared<schema::InputValue>(R"gql()cpp"
-							   << inputField.name << R"cpp()gql"sv, R"md()cpp"
-							   << inputField.description << R"cpp()md"sv, )cpp"
+							   << inputField.name << R"cpp()gql"sv, R"md()cpp";
+
+					if (!_options.noIntrospection)
+					{
+						sourceFile << inputField.description;
+					}
+
+					sourceFile << R"cpp()md"sv, )cpp"
 							   << getIntrospectionType(inputField.type, inputField.modifiers)
 							   << R"cpp(, R"gql()cpp" << inputField.defaultValueString
 							   << R"cpp()gql"sv))cpp";
@@ -2582,8 +2639,14 @@ Operations::Operations()cpp";
 
 					firstValue = false;
 					sourceFile << R"cpp(		std::make_shared<schema::Field>(R"gql()cpp"
-							   << interfaceField.name << R"cpp()gql"sv, R"md()cpp"
-							   << interfaceField.description << R"cpp()md"sv, )cpp";
+							   << interfaceField.name << R"cpp()gql"sv, R"md()cpp";
+
+					if (!_options.noIntrospection)
+					{
+						sourceFile << interfaceField.description;
+					}
+
+					sourceFile << R"cpp()md"sv, )cpp";
 
 					if (interfaceField.deprecationReason)
 					{
@@ -2615,11 +2678,17 @@ Operations::Operations()cpp";
 							firstArgument = false;
 							sourceFile
 								<< R"cpp(			std::make_shared<schema::InputValue>(R"gql()cpp"
-								<< argument.name << R"cpp()gql"sv, R"md()cpp"
-								<< argument.description << R"cpp()md"sv, )cpp"
-								<< getIntrospectionType(argument.type, argument.modifiers)
-								<< R"cpp(, R"gql()cpp" << argument.defaultValueString
-								<< R"cpp()gql"sv))cpp";
+								<< argument.name << R"cpp()gql"sv, R"md()cpp";
+
+							if (!_options.noIntrospection)
+							{
+								sourceFile << argument.description;
+							}
+
+							sourceFile << R"cpp()md"sv, )cpp"
+									   << getIntrospectionType(argument.type, argument.modifiers)
+									   << R"cpp(, R"gql()cpp" << argument.defaultValueString
+									   << R"cpp()gql"sv))cpp";
 						}
 
 						sourceFile << R"cpp(
@@ -2666,9 +2735,15 @@ Operations::Operations()cpp";
 		{
 			sourceFile
 				<< R"cpp(	schema->AddDirective(std::make_shared<schema::Directive>(R"gql()cpp"
-				<< directive.name << R"cpp()gql"sv, R"md()cpp" << directive.description
-				<< R"cpp()md"sv, std::vector<)cpp" << s_introspectionNamespace
-				<< R"cpp(::DirectiveLocation>()cpp";
+				<< directive.name << R"cpp()gql"sv, R"md()cpp";
+
+			if (!_options.noIntrospection)
+			{
+				sourceFile << directive.description;
+			}
+
+			sourceFile << R"cpp()md"sv, std::vector<)cpp" << s_introspectionNamespace
+					   << R"cpp(::DirectiveLocation>()cpp";
 
 			if (!directive.locations.empty())
 			{
@@ -2713,8 +2788,14 @@ Operations::Operations()cpp";
 
 					firstArgument = false;
 					sourceFile << R"cpp(		std::make_shared<schema::InputValue>(R"gql()cpp"
-							   << argument.name << R"cpp()gql"sv, R"md()cpp" << argument.description
-							   << R"cpp()md"sv, )cpp"
+							   << argument.name << R"cpp()gql"sv, R"md()cpp";
+
+					if (!_options.noIntrospection)
+					{
+						sourceFile << argument.description;
+					}
+
+					sourceFile << R"cpp()md"sv, )cpp"
 							   << getIntrospectionType(argument.type, argument.modifiers)
 							   << R"cpp(, R"gql()cpp" << argument.defaultValueString
 							   << R"cpp()gql"sv))cpp";
@@ -3060,8 +3141,14 @@ void Generator::outputObjectIntrospection(
 
 			firstValue = false;
 			sourceFile << R"cpp(		std::make_shared<schema::Field>(R"gql()cpp"
-					   << objectField.name << R"cpp()gql"sv, R"md()cpp" << objectField.description
-					   << R"cpp()md"sv, )cpp";
+					   << objectField.name << R"cpp()gql"sv, R"md()cpp";
+
+			if (!_options.noIntrospection)
+			{
+				sourceFile << objectField.description;
+			}
+
+			sourceFile << R"cpp()md"sv, )cpp";
 
 			if (objectField.deprecationReason)
 			{
@@ -3092,8 +3179,14 @@ void Generator::outputObjectIntrospection(
 
 					firstArgument = false;
 					sourceFile << R"cpp(			std::make_shared<schema::InputValue>(R"gql()cpp"
-							   << argument.name << R"cpp()gql"sv, R"md()cpp" << argument.description
-							   << R"cpp()md"sv, )cpp"
+							   << argument.name << R"cpp()gql"sv, R"md()cpp";
+
+					if (!_options.noIntrospection)
+					{
+						sourceFile << argument.description;
+					}
+
+					sourceFile << R"cpp()md"sv, )cpp"
 							   << getIntrospectionType(argument.type, argument.modifiers)
 							   << R"cpp(, R"gql()cpp" << argument.defaultValueString
 							   << R"cpp()gql"sv))cpp";

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -2351,8 +2351,8 @@ Operations::Operations()cpp";
 		for (const auto& builtinType : s_builtinTypes)
 		{
 			sourceFile << R"cpp(	schema->AddType(R"gql()cpp" << builtinType.first
-					   << R"cpp()gql"sv, std::make_shared<schema::ScalarType>(R"gql()cpp"
-					   << builtinType.first << R"cpp()gql"sv, R"md()cpp";
+					   << R"cpp()gql"sv, schema::ScalarType::Make(R"gql()cpp" << builtinType.first
+					   << R"cpp()gql"sv, R"md()cpp";
 
 			if (!_options.noIntrospection)
 			{
@@ -2369,8 +2369,8 @@ Operations::Operations()cpp";
 		for (const auto& scalarType : _scalarTypes)
 		{
 			sourceFile << R"cpp(	schema->AddType(R"gql()cpp" << scalarType.type
-					   << R"cpp()gql"sv, std::make_shared<schema::ScalarType>(R"gql()cpp"
-					   << scalarType.type << R"cpp()gql"sv, R"md()cpp";
+					   << R"cpp()gql"sv, schema::ScalarType::Make(R"gql()cpp" << scalarType.type
+					   << R"cpp()gql"sv, R"md()cpp";
 
 			if (!_options.noIntrospection)
 			{
@@ -2387,7 +2387,7 @@ Operations::Operations()cpp";
 		for (const auto& enumType : _enumTypes)
 		{
 			sourceFile << R"cpp(	auto type)cpp" << enumType.cppType
-					   << R"cpp( = std::make_shared<schema::EnumType>(R"gql()cpp" << enumType.type
+					   << R"cpp( = schema::EnumType::Make(R"gql()cpp" << enumType.type
 					   << R"cpp()gql"sv, R"md()cpp";
 
 			if (!_options.noIntrospection)
@@ -2407,8 +2407,8 @@ Operations::Operations()cpp";
 		for (const auto& inputType : _inputTypes)
 		{
 			sourceFile << R"cpp(	auto type)cpp" << inputType.cppType
-					   << R"cpp( = std::make_shared<schema::InputObjectType>(R"gql()cpp"
-					   << inputType.type << R"cpp()gql"sv, R"md()cpp";
+					   << R"cpp( = schema::InputObjectType::Make(R"gql()cpp" << inputType.type
+					   << R"cpp()gql"sv, R"md()cpp";
 
 			if (!_options.noIntrospection)
 			{
@@ -2428,7 +2428,7 @@ Operations::Operations()cpp";
 		for (const auto& unionType : _unionTypes)
 		{
 			sourceFile << R"cpp(	auto type)cpp" << unionType.cppType
-					   << R"cpp( = std::make_shared<schema::UnionType>(R"gql()cpp" << unionType.type
+					   << R"cpp( = schema::UnionType::Make(R"gql()cpp" << unionType.type
 					   << R"cpp()gql"sv, R"md()cpp";
 
 			if (!_options.noIntrospection)
@@ -2449,8 +2449,8 @@ Operations::Operations()cpp";
 		for (const auto& interfaceType : _interfaceTypes)
 		{
 			sourceFile << R"cpp(	auto type)cpp" << interfaceType.cppType
-					   << R"cpp( = std::make_shared<schema::InterfaceType>(R"gql()cpp"
-					   << interfaceType.type << R"cpp()gql"sv, R"md()cpp";
+					   << R"cpp( = schema::InterfaceType::Make(R"gql()cpp" << interfaceType.type
+					   << R"cpp()gql"sv, R"md()cpp";
 
 			if (!_options.noIntrospection)
 			{
@@ -2470,8 +2470,8 @@ Operations::Operations()cpp";
 		for (const auto& objectType : _objectTypes)
 		{
 			sourceFile << R"cpp(	auto type)cpp" << objectType.cppType
-					   << R"cpp( = std::make_shared<schema::ObjectType>(R"gql()cpp"
-					   << objectType.type << R"cpp()gql"sv, R"md()cpp";
+					   << R"cpp( = schema::ObjectType::Make(R"gql()cpp" << objectType.type
+					   << R"cpp()gql"sv, R"md()cpp";
 
 			if (!_options.noIntrospection)
 			{
@@ -2562,7 +2562,7 @@ Operations::Operations()cpp";
 					}
 
 					firstValue = false;
-					sourceFile << R"cpp(		std::make_shared<schema::InputValue>(R"gql()cpp"
+					sourceFile << R"cpp(		schema::InputValue::Make(R"gql()cpp"
 							   << inputField.name << R"cpp()gql"sv, R"md()cpp";
 
 					if (!_options.noIntrospection)
@@ -2638,7 +2638,7 @@ Operations::Operations()cpp";
 					}
 
 					firstValue = false;
-					sourceFile << R"cpp(		std::make_shared<schema::Field>(R"gql()cpp"
+					sourceFile << R"cpp(		schema::Field::Make(R"gql()cpp"
 							   << interfaceField.name << R"cpp()gql"sv, R"md()cpp";
 
 					if (!_options.noIntrospection)
@@ -2658,13 +2658,15 @@ Operations::Operations()cpp";
 						sourceFile << R"cpp(std::nullopt)cpp";
 					}
 
-					sourceFile << R"cpp(, std::vector<std::shared_ptr<schema::InputValue>>()cpp";
+					sourceFile << R"cpp(, )cpp"
+							   << getIntrospectionType(interfaceField.type,
+									  interfaceField.modifiers);
 
 					if (!interfaceField.arguments.empty())
 					{
 						bool firstArgument = true;
 
-						sourceFile << R"cpp({
+						sourceFile << R"cpp(, {
 )cpp";
 
 						for (const auto& argument : interfaceField.arguments)
@@ -2676,9 +2678,8 @@ Operations::Operations()cpp";
 							}
 
 							firstArgument = false;
-							sourceFile
-								<< R"cpp(			std::make_shared<schema::InputValue>(R"gql()cpp"
-								<< argument.name << R"cpp()gql"sv, R"md()cpp";
+							sourceFile << R"cpp(			schema::InputValue::Make(R"gql()cpp"
+									   << argument.name << R"cpp()gql"sv, R"md()cpp";
 
 							if (!_options.noIntrospection)
 							{
@@ -2695,10 +2696,7 @@ Operations::Operations()cpp";
 		})cpp";
 					}
 
-					sourceFile << R"cpp(), )cpp"
-							   << getIntrospectionType(interfaceField.type,
-									  interfaceField.modifiers)
-							   << R"cpp())cpp";
+					sourceFile << R"cpp())cpp";
 				}
 
 				sourceFile << R"cpp(
@@ -2733,23 +2731,21 @@ Operations::Operations()cpp";
 
 		for (const auto& directive : _directives)
 		{
-			sourceFile
-				<< R"cpp(	schema->AddDirective(std::make_shared<schema::Directive>(R"gql()cpp"
-				<< directive.name << R"cpp()gql"sv, R"md()cpp";
+			sourceFile << R"cpp(	schema->AddDirective(schema::Directive::Make(R"gql()cpp"
+					   << directive.name << R"cpp()gql"sv, R"md()cpp";
 
 			if (!_options.noIntrospection)
 			{
 				sourceFile << directive.description;
 			}
 
-			sourceFile << R"cpp()md"sv, std::vector<)cpp" << s_introspectionNamespace
-					   << R"cpp(::DirectiveLocation>()cpp";
+			sourceFile << R"cpp()md"sv, {)cpp";
 
 			if (!directive.locations.empty())
 			{
 				bool firstLocation = true;
 
-				sourceFile << R"cpp({
+				sourceFile << R"cpp(
 )cpp";
 
 				for (const auto& location : directive.locations)
@@ -2766,16 +2762,16 @@ Operations::Operations()cpp";
 				}
 
 				sourceFile << R"cpp(
-	})cpp";
+	)cpp";
 			}
 
-			sourceFile << R"cpp(), std::vector<std::shared_ptr<schema::InputValue>>()cpp";
+			sourceFile << R"cpp(})cpp";
 
 			if (!directive.arguments.empty())
 			{
 				bool firstArgument = true;
 
-				sourceFile << R"cpp({
+				sourceFile << R"cpp(, {
 )cpp";
 
 				for (const auto& argument : directive.arguments)
@@ -2787,7 +2783,7 @@ Operations::Operations()cpp";
 					}
 
 					firstArgument = false;
-					sourceFile << R"cpp(		std::make_shared<schema::InputValue>(R"gql()cpp"
+					sourceFile << R"cpp(		schema::InputValue::Make(R"gql()cpp"
 							   << argument.name << R"cpp()gql"sv, R"md()cpp";
 
 					if (!_options.noIntrospection)
@@ -2804,7 +2800,7 @@ Operations::Operations()cpp";
 				sourceFile << R"cpp(
 	})cpp";
 			}
-			sourceFile << R"cpp()));
+			sourceFile << R"cpp());
 )cpp";
 		}
 	}
@@ -3110,7 +3106,7 @@ void Generator::outputObjectIntrospection(
 			if (_options.separateFiles)
 			{
 				sourceFile
-					<< R"cpp(		std::static_pointer_cast<schema::InterfaceType>(schema->LookupType(R"gql()cpp"
+					<< R"cpp(		std::static_pointer_cast<const schema::InterfaceType>(schema->LookupType(R"gql()cpp"
 					<< interfaceName << R"cpp()gql"sv)))cpp";
 			}
 			else
@@ -3140,8 +3136,8 @@ void Generator::outputObjectIntrospection(
 			}
 
 			firstValue = false;
-			sourceFile << R"cpp(		std::make_shared<schema::Field>(R"gql()cpp"
-					   << objectField.name << R"cpp()gql"sv, R"md()cpp";
+			sourceFile << R"cpp(		schema::Field::Make(R"gql()cpp" << objectField.name
+					   << R"cpp()gql"sv, R"md()cpp";
 
 			if (!_options.noIntrospection)
 			{
@@ -3160,13 +3156,14 @@ void Generator::outputObjectIntrospection(
 				sourceFile << R"cpp(std::nullopt)cpp";
 			}
 
-			sourceFile << R"cpp(, std::vector<std::shared_ptr<schema::InputValue>>()cpp";
+			sourceFile << R"cpp(, )cpp"
+					   << getIntrospectionType(objectField.type, objectField.modifiers);
 
 			if (!objectField.arguments.empty())
 			{
 				bool firstArgument = true;
 
-				sourceFile << R"cpp({
+				sourceFile << R"cpp(, {
 )cpp";
 
 				for (const auto& argument : objectField.arguments)
@@ -3178,7 +3175,7 @@ void Generator::outputObjectIntrospection(
 					}
 
 					firstArgument = false;
-					sourceFile << R"cpp(			std::make_shared<schema::InputValue>(R"gql()cpp"
+					sourceFile << R"cpp(			schema::InputValue::Make(R"gql()cpp"
 							   << argument.name << R"cpp()gql"sv, R"md()cpp";
 
 					if (!_options.noIntrospection)
@@ -3196,9 +3193,7 @@ void Generator::outputObjectIntrospection(
 		})cpp";
 			}
 
-			sourceFile << R"cpp(), )cpp"
-					   << getIntrospectionType(objectField.type, objectField.modifiers)
-					   << R"cpp())cpp";
+			sourceFile << R"cpp())cpp";
 		}
 
 		sourceFile << R"cpp(

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -2516,7 +2516,8 @@ Operations::Operations()cpp";
 			{
 				bool firstValue = true;
 
-				sourceFile << R"cpp(	type)cpp" << unionType.cppType << R"cpp(->AddPossibleTypes({
+				sourceFile << R"cpp(	type)cpp" << unionType.cppType
+						   << R"cpp(->AddPossibleTypes({
 )cpp";
 
 				for (const auto& unionOption : unionType.options)
@@ -2737,7 +2738,8 @@ Operations::Operations()cpp";
 
 	if (!schema)
 	{
-		schema = std::make_shared<schema::Schema>();
+		schema = std::make_shared<schema::Schema>()cpp"
+				   << (_options.noIntrospection ? "true" : "false") << R"cpp();
 		)cpp" << s_introspectionNamespace
 				   << R"cpp(::AddTypesToSchema(schema);
 		AddTypesToSchema(schema);

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -1983,14 +1983,14 @@ private:
 		}
 
 		headerFile << R"cpp(
-	std::future<response::Value> resolve_typename(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_typename(service::ResolverParams&& params);
 )cpp";
 
 		if (!_options.noIntrospection && isQueryType)
 		{
 			headerFile
-				<< R"cpp(	std::future<response::Value> resolve_schema(service::ResolverParams&& params);
-	std::future<response::Value> resolve_type(service::ResolverParams&& params);
+				<< R"cpp(	std::future<service::ResolverResult> resolve_schema(service::ResolverParams&& params);
+	std::future<service::ResolverResult> resolve_type(service::ResolverParams&& params);
 
 	std::shared_ptr<schema::Schema> _schema;
 )cpp";
@@ -2047,7 +2047,7 @@ std::string Generator::getResolverDeclaration(const OutputField& outputField) co
 	std::string fieldName(outputField.cppName);
 
 	fieldName[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(fieldName[0])));
-	output << R"cpp(	std::future<response::Value> resolve)cpp" << fieldName
+	output << R"cpp(	std::future<service::ResolverResult> resolve)cpp" << fieldName
 		   << R"cpp((service::ResolverParams&& params);
 )cpp";
 
@@ -2146,7 +2146,7 @@ template <>
 }
 
 template <>
-std::future<response::Value> ModifiedResult<)cpp"
+std::future<service::ResolverResult> ModifiedResult<)cpp"
 					   << _schemaNamespace << R"cpp(::)cpp" << enumType.cppType
 					   << R"cpp(>::convert(service::FieldResult<)cpp" << _schemaNamespace
 					   << R"cpp(::)cpp" << enumType.cppType
@@ -2890,7 +2890,7 @@ service::FieldResult<)cpp"
 		}
 
 		sourceFile << R"cpp(
-std::future<response::Value> )cpp"
+std::future<service::ResolverResult> )cpp"
 				   << objectType.cppType << R"cpp(::resolve)cpp" << fieldName
 				   << R"cpp((service::ResolverParams&& params)
 {
@@ -2969,7 +2969,7 @@ std::future<response::Value> )cpp"
 	}
 
 	sourceFile << R"cpp(
-std::future<response::Value> )cpp"
+std::future<service::ResolverResult> )cpp"
 			   << objectType.cppType << R"cpp(::resolve_typename(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<response::StringType>::convert(response::StringType{ R"gql()cpp"
@@ -2981,14 +2981,14 @@ std::future<response::Value> )cpp"
 	{
 		sourceFile
 			<< R"cpp(
-std::future<response::Value> )cpp"
+std::future<service::ResolverResult> )cpp"
 			<< objectType.cppType << R"cpp(::resolve_schema(service::ResolverParams&& params)
 {
 	return service::ModifiedResult<service::Object>::convert(std::static_pointer_cast<service::Object>(std::make_shared<)cpp"
 			<< s_introspectionNamespace << R"cpp(::Schema>(_schema)), std::move(params));
 }
 
-std::future<response::Value> )cpp"
+std::future<service::ResolverResult> )cpp"
 			<< objectType.cppType << R"cpp(::resolve_type(service::ResolverParams&& params)
 {
 	auto argName = service::ModifiedArgument<response::StringType>::require("name", params.arguments);

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -1689,22 +1689,9 @@ bool Generator::outputHeader() const noexcept
 )cpp";
 
 	NamespaceScope graphqlNamespace { headerFile, "graphql" };
-	NamespaceScope introspectionNamespace { headerFile, s_introspectionNamespace };
-	NamespaceScope schemaNamespace { headerFile, _schemaNamespace, true };
+	NamespaceScope schemaNamespace { headerFile, _schemaNamespace };
 	NamespaceScope objectNamespace { headerFile, "object", true };
 	PendingBlankLine pendingSeparator { headerFile };
-
-	headerFile << R"cpp(
-class Schema;
-)cpp";
-
-	if (_options.separateFiles)
-	{
-		headerFile << R"cpp(class ObjectType;
-)cpp";
-	}
-
-	headerFile << std::endl;
 
 	std::string queryType;
 
@@ -1718,11 +1705,6 @@ class Schema;
 				break;
 			}
 		}
-
-		introspectionNamespace.exit();
-		headerFile << std::endl;
-		schemaNamespace.enter();
-		pendingSeparator.add();
 	}
 
 	if (!_enumTypes.empty())

--- a/src/Validation.cpp
+++ b/src/Validation.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "graphqlservice/GraphQLGrammar.h"
-#include "graphqlservice/IntrospectionSchema.h"
+#include "graphqlservice/introspection/IntrospectionSchema.h"
 
 #include "Validation.h"
 

--- a/src/Validation.cpp
+++ b/src/Validation.cpp
@@ -1662,7 +1662,7 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 
 	ValidateFieldArguments validateArguments;
 	std::map<std::string_view, schema_location> argumentLocations;
-	std::queue<std::string_view> argumentNames;
+	std::vector<std::string_view> argumentNames;
 
 	peg::on_first_child<peg::arguments>(field,
 		[this, &name, &validateArguments, &argumentLocations, &argumentNames](
@@ -1689,7 +1689,7 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 				visitor.visit(*argument->children.back());
 				validateArguments[argumentName] = visitor.getArgumentValue();
 				argumentLocations[argumentName] = { position.line, position.column };
-				argumentNames.push(std::move(argumentName));
+				argumentNames.push_back(argumentName);
 			}
 		});
 
@@ -1724,12 +1724,8 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 
 	if (itrField != itrType->second.end())
 	{
-		while (!argumentNames.empty())
+		for (auto argumentName : argumentNames)
 		{
-			auto argumentName = std::move(argumentNames.front());
-
-			argumentNames.pop();
-
 			auto itrArgument = itrField->second.arguments.find(argumentName);
 
 			if (itrArgument == itrField->second.arguments.end())
@@ -2059,7 +2055,7 @@ void ValidateExecutableVisitor::visitDirectives(
 			[this, &directive, &directiveName, itrDirective](const peg::ast_node& child) {
 				ValidateFieldArguments validateArguments;
 				std::map<std::string_view, schema_location> argumentLocations;
-				std::queue<std::string_view> argumentNames;
+				std::vector<std::string_view> argumentNames;
 
 				for (auto& argument : child.children)
 				{
@@ -2083,15 +2079,11 @@ void ValidateExecutableVisitor::visitDirectives(
 					visitor.visit(*argument->children.back());
 					validateArguments[argumentName] = visitor.getArgumentValue();
 					argumentLocations[argumentName] = { position.line, position.column };
-					argumentNames.push(std::move(argumentName));
+					argumentNames.push_back(argumentName);
 				}
 
-				while (!argumentNames.empty())
+				for (auto argumentName : argumentNames)
 				{
-					auto argumentName = std::move(argumentNames.front());
-
-					argumentNames.pop();
-
 					auto itrArgument = itrDirective->second.arguments.find(argumentName);
 
 					if (itrArgument == itrDirective->second.arguments.end())

--- a/src/Validation.cpp
+++ b/src/Validation.cpp
@@ -14,6 +14,23 @@ using namespace std::literals;
 
 namespace graphql::service {
 
+SharedType getSharedType(const ValidateType& type) noexcept
+{
+	return type ? type->get().shared_from_this() : SharedType {};
+}
+
+ValidateType getValidateType(const SharedType& type) noexcept
+{
+	return type ? std::make_optional(std::cref(*type)) : std::nullopt;
+}
+
+bool operator==(const ValidateType& lhs, const ValidateType& rhs) noexcept
+{
+	// Equal if they're either both std::nullopt or they are both not empty and the addresses of the
+	// references match.
+	return (lhs ? (rhs && &lhs->get() == &rhs->get()) : !rhs);
+}
+
 bool ValidateArgumentVariable::operator==(const ValidateArgumentVariable& other) const
 {
 	return name == other.name;
@@ -243,10 +260,10 @@ void ValidateArgumentValueVisitor::visitObjectValue(const peg::ast_node& objectV
 	_argumentValue.position = { position.line, position.column };
 }
 
-ValidateField::ValidateField(std::string&& returnType, std::optional<std::string_view> objectType,
+ValidateField::ValidateField(ValidateType&& returnType, ValidateType&& objectType,
 	std::string_view fieldName, ValidateFieldArguments&& arguments)
 	: returnType(std::move(returnType))
-	, objectType(objectType)
+	, objectType(std::move(objectType))
 	, fieldName(fieldName)
 	, arguments(std::move(arguments))
 {
@@ -254,15 +271,15 @@ ValidateField::ValidateField(std::string&& returnType, std::optional<std::string
 
 bool ValidateField::operator==(const ValidateField& other) const
 {
-	return returnType == other.returnType
-		&& ((objectType && other.objectType && *objectType != *other.objectType)
+	return (returnType == other.returnType)
+		&& ((objectType && other.objectType && &objectType->get() != &other.objectType->get())
 			|| (fieldName == other.fieldName && arguments == other.arguments));
 }
 
 ValidateVariableTypeVisitor::ValidateVariableTypeVisitor(
-	const std::shared_ptr<schema::Schema>& schema, const ValidateTypeKinds& typeKinds)
+	const std::shared_ptr<schema::Schema>& schema, const ValidateTypes& types)
 	: _schema(schema)
-	, _typeKinds(typeKinds)
+	, _types(types)
 {
 }
 
@@ -285,20 +302,20 @@ void ValidateVariableTypeVisitor::visit(const peg::ast_node& typeName)
 void ValidateVariableTypeVisitor::visitNamedType(const peg::ast_node& namedType)
 {
 	auto name = namedType.string_view();
-	auto itrKind = _typeKinds.find(name);
+	auto itrType = _types.find(name);
 
-	if (itrKind == _typeKinds.end())
+	if (itrType == _types.end())
 	{
 		return;
 	}
 
-	switch (itrKind->second)
+	switch (itrType->second->get().kind())
 	{
 		case introspection::TypeKind::SCALAR:
 		case introspection::TypeKind::ENUM:
 		case introspection::TypeKind::INPUT_OBJECT:
 			_isInputType = true;
-			_variableType = _schema->LookupType(name);
+			_variableType = getValidateType(_schema->LookupType(name));
 			break;
 
 		default:
@@ -308,20 +325,22 @@ void ValidateVariableTypeVisitor::visitNamedType(const peg::ast_node& namedType)
 
 void ValidateVariableTypeVisitor::visitListType(const peg::ast_node& listType)
 {
-	ValidateVariableTypeVisitor visitor(_schema, _typeKinds);
+	ValidateVariableTypeVisitor visitor(_schema, _types);
 
 	visitor.visit(*listType.children.front());
 	_isInputType = visitor.isInputType();
-	_variableType = _schema->WrapType(introspection::TypeKind::LIST, visitor.getType());
+	_variableType = getValidateType(
+		_schema->WrapType(introspection::TypeKind::LIST, getSharedType(visitor.getType())));
 }
 
 void ValidateVariableTypeVisitor::visitNonNullType(const peg::ast_node& nonNullType)
 {
-	ValidateVariableTypeVisitor visitor(_schema, _typeKinds);
+	ValidateVariableTypeVisitor visitor(_schema, _types);
 
 	visitor.visit(*nonNullType.children.front());
 	_isInputType = visitor.isInputType();
-	_variableType = _schema->WrapType(introspection::TypeKind::NON_NULL, visitor.getType());
+	_variableType = getValidateType(
+		_schema->WrapType(introspection::TypeKind::NON_NULL, getSharedType(visitor.getType())));
 }
 
 bool ValidateVariableTypeVisitor::isInputType() const
@@ -345,17 +364,17 @@ ValidateExecutableVisitor::ValidateExecutableVisitor(const std::shared_ptr<schem
 
 	if (queryType)
 	{
-		_operationTypes[strQuery] = queryType->name();
+		_operationTypes[strQuery] = getValidateType(queryType);
 	}
 
 	if (mutationType)
 	{
-		_operationTypes[strMutation] = mutationType->name();
+		_operationTypes[strMutation] = getValidateType(mutationType);
 	}
 
 	if (subscriptionType)
 	{
-		_operationTypes[strSubscription] = subscriptionType->name();
+		_operationTypes[strSubscription] = getValidateType(subscriptionType);
 	}
 
 	const auto& types = _schema->types();
@@ -415,7 +434,7 @@ ValidateExecutableVisitor::ValidateExecutableVisitor(const std::shared_ptr<schem
 			_scalarTypes.insert(name);
 		}
 
-		_typeKinds[std::move(name)] = kind;
+		_types[name] = getValidateType(entry.second);
 	}
 
 	const auto& directives = _schema->directives();
@@ -571,17 +590,17 @@ void ValidateExecutableVisitor::visitFragmentDefinition(const peg::ast_node& fra
 	const auto& typeCondition = fragmentDefinition.children[1];
 	auto innerType = typeCondition->children.front()->string_view();
 
-	auto itrKind = _typeKinds.find(innerType);
+	auto itrType = _types.find(innerType);
 
-	if (itrKind == _typeKinds.end() || isScalarType(itrKind->second))
+	if (itrType == _types.end() || isScalarType(itrType->second->get().kind()))
 	{
 		// http://spec.graphql.org/June2018/#sec-Fragment-Spread-Type-Existence
 		// http://spec.graphql.org/June2018/#sec-Fragments-On-Composite-Types
 		auto position = typeCondition->begin();
 		std::ostringstream message;
 
-		message << (itrKind == _typeKinds.end() ? "Undefined target type on fragment definition: "
-												: "Scalar target type on fragment definition: ")
+		message << (itrType == _types.end() ? "Undefined target type on fragment definition: "
+											: "Scalar target type on fragment definition: ")
 				<< name << " name: " << innerType;
 
 		_errors.push_back({ message.str(), { position.line, position.column } });
@@ -589,11 +608,11 @@ void ValidateExecutableVisitor::visitFragmentDefinition(const peg::ast_node& fra
 	}
 
 	_fragmentStack.insert(name);
-	_scopedType = std::move(innerType);
+	_scopedType = itrType->second;
 
 	visitSelection(selection);
 
-	_scopedType = {};
+	_scopedType.reset();
 	_fragmentStack.clear();
 	_selectionFields.clear();
 }
@@ -650,7 +669,7 @@ void ValidateExecutableVisitor::visitOperationDefinition(const peg::ast_node& op
 				else if (child->is_type<peg::named_type>() || child->is_type<peg::list_type>()
 					|| child->is_type<peg::nonnull_type>())
 				{
-					ValidateVariableTypeVisitor visitor(_schema, _typeKinds);
+					ValidateVariableTypeVisitor visitor(_schema, _types);
 
 					visitor.visit(*child);
 
@@ -763,7 +782,7 @@ void ValidateExecutableVisitor::visitOperationDefinition(const peg::ast_node& op
 		_errors.push_back({ error.str(), { position.line, position.column } });
 	}
 
-	_scopedType = {};
+	_scopedType.reset();
 	_fragmentStack.clear();
 	_selectionFields.clear();
 
@@ -806,7 +825,7 @@ void ValidateExecutableVisitor::visitSelection(const peg::ast_node& selection)
 }
 
 ValidateTypeFieldArguments ValidateExecutableVisitor::getArguments(
-	const std::vector<std::shared_ptr<schema::InputValue>>& args)
+	const std::vector<std::shared_ptr<const schema::InputValue>>& args)
 {
 	ValidateTypeFieldArguments result;
 
@@ -822,25 +841,12 @@ ValidateTypeFieldArguments ValidateExecutableVisitor::getArguments(
 		argument.defaultValue = !arg->defaultValue().empty();
 		argument.nonNullDefaultValue =
 			argument.defaultValue && arg->defaultValue() != R"gql(null)gql"sv;
-		argument.type = arg->type().lock();
+		argument.type = getValidateType(arg->type().lock());
 
 		result[arg->name()] = std::move(argument);
 	}
 
 	return result;
-}
-
-std::optional<introspection::TypeKind> ValidateExecutableVisitor::getTypeKind(
-	std::string_view name) const
-{
-	auto itrKind = _typeKinds.find(name);
-
-	return (itrKind == _typeKinds.cend() ? std::nullopt : std::make_optional(itrKind->second));
-}
-
-std::optional<introspection::TypeKind> ValidateExecutableVisitor::getScopedTypeKind() const
-{
-	return getTypeKind(_scopedType);
 }
 
 constexpr bool ValidateExecutableVisitor::isScalarType(introspection::TypeKind kind)
@@ -859,17 +865,17 @@ constexpr bool ValidateExecutableVisitor::isScalarType(introspection::TypeKind k
 
 bool ValidateExecutableVisitor::matchesScopedType(std::string_view name) const
 {
-	if (name == _scopedType)
+	if (name == _scopedType->get().name())
 	{
 		return true;
 	}
 
-	auto itrScoped = _matchingTypes.find(_scopedType);
-	auto itrNamed = _matchingTypes.find(name);
+	const auto itrScoped = _matchingTypes.find(_scopedType->get().name());
+	const auto itrNamed = _matchingTypes.find(name);
 
 	if (itrScoped != _matchingTypes.end() && itrNamed != _matchingTypes.end())
 	{
-		auto itrMatch = std::find_if(itrScoped->second.begin(),
+		const auto itrMatch = std::find_if(itrScoped->second.begin(),
 			itrScoped->second.end(),
 			[this, itrNamed](std::string_view matchingType) noexcept {
 				return itrNamed->second.find(matchingType) != itrNamed->second.end();
@@ -926,7 +932,7 @@ bool ValidateExecutableVisitor::validateInputValue(
 		}
 	}
 
-	const auto kind = type->kind();
+	const auto kind = type->get().kind();
 
 	if (!argument.value)
 	{
@@ -945,7 +951,7 @@ bool ValidateExecutableVisitor::validateInputValue(
 		case introspection::TypeKind::NON_NULL:
 		{
 			// Unwrap and check the next one.
-			const auto ofType = type->ofType().lock();
+			const auto ofType = getValidateType(type->get().ofType().lock());
 
 			if (!ofType)
 			{
@@ -964,7 +970,7 @@ bool ValidateExecutableVisitor::validateInputValue(
 				return false;
 			}
 
-			const auto ofType = type->ofType().lock();
+			const auto ofType = getValidateType(type->get().ofType().lock());
 
 			if (!ofType)
 			{
@@ -987,7 +993,7 @@ bool ValidateExecutableVisitor::validateInputValue(
 
 		case introspection::TypeKind::INPUT_OBJECT:
 		{
-			const auto name = type->name();
+			const auto name = type->get().name();
 
 			if (name.empty())
 			{
@@ -1071,7 +1077,7 @@ bool ValidateExecutableVisitor::validateInputValue(
 					return false;
 				}
 
-				const auto fieldKind = entry.second.type->kind();
+				const auto fieldKind = entry.second.type->get().kind();
 
 				if (fieldKind == introspection::TypeKind::NON_NULL)
 				{
@@ -1091,7 +1097,7 @@ bool ValidateExecutableVisitor::validateInputValue(
 
 		case introspection::TypeKind::ENUM:
 		{
-			const auto name = type->name();
+			const auto name = type->get().name();
 
 			if (name.empty())
 			{
@@ -1128,7 +1134,7 @@ bool ValidateExecutableVisitor::validateInputValue(
 
 		case introspection::TypeKind::SCALAR:
 		{
-			const auto name = type->name();
+			const auto name = type->get().name();
 
 			if (name.empty())
 			{
@@ -1221,11 +1227,11 @@ bool ValidateExecutableVisitor::validateVariableType(bool isNonNull,
 		return false;
 	}
 
-	const auto variableKind = variableType->kind();
+	const auto variableKind = variableType->get().kind();
 
 	if (variableKind == introspection::TypeKind::NON_NULL)
 	{
-		const auto ofType = variableType->ofType().lock();
+		const auto ofType = getValidateType(variableType->get().ofType().lock());
 
 		if (!ofType)
 		{
@@ -1242,7 +1248,7 @@ bool ValidateExecutableVisitor::validateVariableType(bool isNonNull,
 		return false;
 	}
 
-	const auto inputKind = inputType->kind();
+	const auto inputKind = inputType->get().kind();
 
 	switch (inputKind)
 	{
@@ -1256,7 +1262,7 @@ bool ValidateExecutableVisitor::validateVariableType(bool isNonNull,
 			}
 
 			// Unwrap and check the next one.
-			const auto ofType = inputType->ofType().lock();
+			const auto ofType = getValidateType(inputType->get().ofType().lock());
 
 			if (!ofType)
 			{
@@ -1277,7 +1283,7 @@ bool ValidateExecutableVisitor::validateVariableType(bool isNonNull,
 			}
 
 			// Unwrap and check the next one.
-			const auto variableOfType = variableType->ofType().lock();
+			const auto variableOfType = getValidateType(variableType->get().ofType().lock());
 
 			if (!variableOfType)
 			{
@@ -1285,7 +1291,7 @@ bool ValidateExecutableVisitor::validateVariableType(bool isNonNull,
 				return false;
 			}
 
-			const auto inputOfType = inputType->ofType().lock();
+			const auto inputOfType = getValidateType(inputType->get().ofType().lock());
 
 			if (!inputOfType)
 			{
@@ -1340,7 +1346,7 @@ bool ValidateExecutableVisitor::validateVariableType(bool isNonNull,
 		}
 	}
 
-	const auto variableName = variableType->name();
+	const auto variableName = variableType->get().name();
 
 	if (variableName.empty())
 	{
@@ -1348,7 +1354,7 @@ bool ValidateExecutableVisitor::validateVariableType(bool isNonNull,
 		return false;
 	}
 
-	const auto inputName = inputType->name();
+	const auto inputName = inputType->get().name();
 
 	if (inputName.empty())
 	{
@@ -1373,68 +1379,66 @@ bool ValidateExecutableVisitor::validateVariableType(bool isNonNull,
 ValidateExecutableVisitor::TypeFields::const_iterator ValidateExecutableVisitor::
 	getScopedTypeFields()
 {
-	auto typeKind = getScopedTypeKind();
-	auto itrType = _typeFields.find(_scopedType);
+	auto typeKind = _scopedType->get().kind();
+	auto itrType = _typeFields.find(_scopedType->get().name());
 
-	if (itrType == _typeFields.cend() && typeKind && !isScalarType(*typeKind))
+	if (itrType == _typeFields.cend() && !isScalarType(typeKind))
 	{
-		const auto& type = _schema->LookupType(_scopedType);
+		const auto& fields = _scopedType->get().fields();
+		std::map<std::string_view, ValidateTypeField> validateFields;
 
-		if (type)
+		for (auto& entry : fields)
 		{
-			const auto& fields = type->fields();
-			std::map<std::string_view, ValidateTypeField> validateFields;
-
-			for (auto& entry : fields)
+			if (!entry)
 			{
-				if (!entry)
-				{
-					continue;
-				}
-
-				const auto fieldName = entry->name();
-				ValidateTypeField subField;
-
-				subField.returnType = entry->type().lock();
-
-				if (fieldName.empty() || !subField.returnType)
-				{
-					continue;
-				}
-
-				subField.arguments = getArguments(entry->args());
-
-				validateFields[fieldName] = std::move(subField);
+				continue;
 			}
 
-			if (_schema->supportsIntrospection() && _scopedType == _operationTypes[strQuery])
+			const auto fieldName = entry->name();
+			ValidateTypeField subField;
+
+			subField.returnType = getValidateType(entry->type().lock());
+
+			if (fieldName.empty() || !subField.returnType)
 			{
-				ValidateTypeField schemaField;
-
-				schemaField.returnType = _schema->WrapType(introspection::TypeKind::NON_NULL,
-					_schema->LookupType(R"gql(__Schema)gql"sv));
-				validateFields[R"gql(__schema)gql"sv] = std::move(schemaField);
-
-				ValidateTypeField typeField;
-				ValidateArgument nameArgument;
-
-				typeField.returnType = _schema->LookupType(R"gql(__Type)gql"sv);
-
-				nameArgument.type = _schema->WrapType(introspection::TypeKind::NON_NULL,
-					_schema->LookupType(R"gql(String)gql"sv));
-				typeField.arguments[R"gql(name)gql"sv] = std::move(nameArgument);
-
-				validateFields[R"gql(__type)gql"sv] = std::move(typeField);
+				continue;
 			}
 
-			ValidateTypeField typenameField;
+			subField.arguments = getArguments(entry->args());
 
-			typenameField.returnType = _schema->WrapType(introspection::TypeKind::NON_NULL,
-				_schema->LookupType(R"gql(String)gql"sv));
-			validateFields[R"gql(__typename)gql"sv] = std::move(typenameField);
-
-			itrType = _typeFields.insert({ _scopedType, std::move(validateFields) }).first;
+			validateFields[fieldName] = std::move(subField);
 		}
+
+		if (_schema->supportsIntrospection() && _scopedType == _operationTypes[strQuery])
+		{
+			ValidateTypeField schemaField;
+
+			schemaField.returnType =
+				getValidateType(_schema->WrapType(introspection::TypeKind::NON_NULL,
+					_schema->LookupType(R"gql(__Schema)gql"sv)));
+			validateFields[R"gql(__schema)gql"sv] = std::move(schemaField);
+
+			ValidateTypeField typeField;
+			ValidateArgument nameArgument;
+
+			typeField.returnType = getValidateType(_schema->LookupType(R"gql(__Type)gql"sv));
+
+			nameArgument.type = getValidateType(_schema->WrapType(introspection::TypeKind::NON_NULL,
+				_schema->LookupType(R"gql(String)gql"sv)));
+			typeField.arguments[R"gql(name)gql"sv] = std::move(nameArgument);
+
+			validateFields[R"gql(__type)gql"sv] = std::move(typeField);
+		}
+
+		ValidateTypeField typenameField;
+
+		typenameField.returnType =
+			getValidateType(_schema->WrapType(introspection::TypeKind::NON_NULL,
+				_schema->LookupType(R"gql(String)gql"sv)));
+		validateFields[R"gql(__typename)gql"sv] = std::move(typenameField);
+
+		itrType =
+			_typeFields.insert({ _scopedType->get().name(), std::move(validateFields) }).first;
 	}
 
 	return itrType;
@@ -1443,58 +1447,44 @@ ValidateExecutableVisitor::TypeFields::const_iterator ValidateExecutableVisitor:
 ValidateExecutableVisitor::InputTypeFields::const_iterator ValidateExecutableVisitor::
 	getInputTypeFields(std::string_view name)
 {
-	auto typeKind = getTypeKind(name);
-	auto itrType = _inputTypeFields.find(name);
+	auto itrFields = _inputTypeFields.find(name);
 
-	if (itrType == _inputTypeFields.cend() && typeKind
-		&& *typeKind == introspection::TypeKind::INPUT_OBJECT)
+	if (itrFields == _inputTypeFields.cend())
 	{
-		const auto& type = _schema->LookupType(name);
+		auto itrType = _types.find(name);
 
-		if (type)
+		if (itrType != _types.cend()
+			&& itrType->second->get().kind() == introspection::TypeKind::INPUT_OBJECT)
 		{
-			itrType = _inputTypeFields.insert({ name, getArguments(type->inputFields()) }).first;
+			itrFields = _inputTypeFields
+							.insert({ name, getArguments(itrType->second->get().inputFields()) })
+							.first;
 		}
 	}
 
-	return itrType;
+	return itrFields;
 }
 
 template <class _FieldTypes>
-std::string_view ValidateExecutableVisitor::getFieldType(
+ValidateType ValidateExecutableVisitor::getFieldType(
 	const _FieldTypes& fields, std::string_view name)
 {
-	std::string_view result;
 	auto itrType = fields.find(name);
 
 	if (itrType == fields.end())
 	{
-		return result;
+		return ValidateType {};
 	}
 
 	// Iteratively expand nested types till we get the underlying field type.
 	auto fieldType = getValidateFieldType(itrType->second);
 
-	do
+	while (fieldType && fieldType->get().name().empty())
 	{
-		const auto name = fieldType->name();
-		const auto ofType = fieldType->ofType().lock();
+		fieldType = getValidateType(fieldType->get().ofType().lock());
+	}
 
-		if (!name.empty())
-		{
-			result = name;
-		}
-		else if (ofType)
-		{
-			fieldType = ofType;
-		}
-		else
-		{
-			break;
-		}
-	} while (result.empty());
-
-	return result;
+	return fieldType;
 }
 
 const ValidateType& ValidateExecutableVisitor::getValidateFieldType(
@@ -1510,54 +1500,17 @@ const ValidateType& ValidateExecutableVisitor::getValidateFieldType(
 }
 
 template <class _FieldTypes>
-std::string ValidateExecutableVisitor::getWrappedFieldType(
+ValidateType ValidateExecutableVisitor::getWrappedFieldType(
 	const _FieldTypes& fields, std::string_view name)
 {
-	std::string result;
 	auto itrType = fields.find(name);
 
 	if (itrType == fields.end())
 	{
-		return result;
+		return std::nullopt;
 	}
 
-	result = getWrappedFieldType(getValidateFieldType(itrType->second));
-
-	return result;
-}
-
-std::string ValidateExecutableVisitor::getWrappedFieldType(const ValidateType& returnType)
-{
-	// Recursively expand nested types till we get the underlying field type.
-	const auto name = returnType->name();
-
-	if (!name.empty())
-	{
-		return std::string { name };
-	}
-
-	std::ostringstream oss;
-	const auto kind = returnType->kind();
-	const auto ofType = returnType->ofType().lock();
-
-	if (ofType)
-	{
-		switch (kind)
-		{
-			case introspection::TypeKind::LIST:
-				oss << '[' << getWrappedFieldType(ofType) << ']';
-				break;
-
-			case introspection::TypeKind::NON_NULL:
-				oss << getWrappedFieldType(ofType) << '!';
-				break;
-
-			default:
-				break;
-		}
-	}
-
-	return oss.str();
+	return getValidateFieldType(itrType->second);
 }
 
 void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
@@ -1572,22 +1525,6 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 		name = child.string_view();
 	});
 
-	auto kind = getScopedTypeKind();
-
-	if (!kind)
-	{
-		// http://spec.graphql.org/June2018/#sec-Leaf-Field-Selections
-		auto position = field.begin();
-		std::ostringstream message;
-
-		message << "Field on unknown type: " << _scopedType << " name: " << name;
-
-		_errors.push_back({ message.str(), { position.line, position.column } });
-		return;
-	}
-
-	std::string_view innerType;
-	std::string wrappedType;
 	auto itrType = getScopedTypeFields();
 
 	if (itrType == _typeFields.cend())
@@ -1596,13 +1533,16 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 		auto position = field.begin();
 		std::ostringstream message;
 
-		message << "Field on scalar type: " << _scopedType << " name: " << name;
+		message << "Field on scalar type: " << _scopedType->get().name() << " name: " << name;
 
 		_errors.push_back({ message.str(), { position.line, position.column } });
 		return;
 	}
 
-	switch (*kind)
+	ValidateType innerType;
+	ValidateType wrappedType;
+
+	switch (_scopedType->get().kind())
 	{
 		case introspection::TypeKind::OBJECT:
 		case introspection::TypeKind::INTERFACE:
@@ -1621,15 +1561,17 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 				auto position = field.begin();
 				std::ostringstream message;
 
-				message << "Field on union type: " << _scopedType << " name: " << name;
+				message << "Field on union type: " << _scopedType->get().name()
+						<< " name: " << name;
 
 				_errors.push_back({ message.str(), { position.line, position.column } });
 				return;
 			}
 
 			// http://spec.graphql.org/June2018/#sec-Field-Selections-on-Objects-Interfaces-and-Unions-Types
-			innerType = "String";
-			wrappedType = "String!";
+			innerType = getValidateType(_schema->LookupType("String"sv));
+			wrappedType = getValidateType(
+				_schema->WrapType(introspection::TypeKind::NON_NULL, getSharedType(innerType)));
 			break;
 		}
 
@@ -1637,13 +1579,13 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 			break;
 	}
 
-	if (innerType.empty())
+	if (!innerType)
 	{
 		// http://spec.graphql.org/June2018/#sec-Field-Selections-on-Objects-Interfaces-and-Unions-Types
 		auto position = field.begin();
 		std::ostringstream message;
 
-		message << "Undefined field type: " << _scopedType << " name: " << name;
+		message << "Undefined field type: " << _scopedType->get().name() << " name: " << name;
 
 		_errors.push_back({ message.str(), { position.line, position.column } });
 		return;
@@ -1677,8 +1619,8 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 					// http://spec.graphql.org/June2018/#sec-Argument-Uniqueness
 					std::ostringstream message;
 
-					message << "Conflicting argument type: " << _scopedType << " field: " << name
-							<< " name: " << argumentName;
+					message << "Conflicting argument type: " << _scopedType->get().name()
+							<< " field: " << name << " name: " << argumentName;
 
 					_errors.push_back({ message.str(), { position.line, position.column } });
 					continue;
@@ -1693,10 +1635,11 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 			}
 		});
 
-	std::optional<std::string_view> objectType =
-		(*kind == introspection::TypeKind::OBJECT ? std::make_optional(_scopedType) : std::nullopt);
+	ValidateType objectType =
+		(_scopedType->get().kind() == introspection::TypeKind::OBJECT ? _scopedType
+																	  : ValidateType {});
 	ValidateField validateField(std::move(wrappedType),
-		objectType,
+		std::move(objectType),
 		name,
 		std::move(validateArguments));
 	auto itrValidateField = _selectionFields.find(alias);
@@ -1714,7 +1657,7 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 			auto position = field.begin();
 			std::ostringstream message;
 
-			message << "Conflicting field type: " << _scopedType << " name: " << name;
+			message << "Conflicting field type: " << _scopedType->get().name() << " name: " << name;
 
 			_errors.push_back({ message.str(), { position.line, position.column } });
 		}
@@ -1733,8 +1676,8 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 				// http://spec.graphql.org/June2018/#sec-Argument-Names
 				std::ostringstream message;
 
-				message << "Undefined argument type: " << _scopedType << " field: " << name
-						<< " name: " << argumentName;
+				message << "Undefined argument type: " << _scopedType->get().name()
+						<< " field: " << name << " name: " << argumentName;
 
 				_errors.push_back({ message.str(), argumentLocations[argumentName] });
 			}
@@ -1755,8 +1698,8 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 					// http://spec.graphql.org/June2018/#sec-Values-of-Correct-Type
 					std::ostringstream message;
 
-					message << "Incompatible argument type: " << _scopedType << " field: " << name
-							<< " name: " << argument.first;
+					message << "Incompatible argument type: " << _scopedType->get().name()
+							<< " field: " << name << " name: " << argument.first;
 
 					_errors.push_back({ message.str(), argumentLocations[argument.first] });
 				}
@@ -1771,7 +1714,7 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 
 			// See if the argument is wrapped in NON_NULL
 			if (argument.second.type
-				&& introspection::TypeKind::NON_NULL == argument.second.type->kind())
+				&& introspection::TypeKind::NON_NULL == argument.second.type->get().kind())
 			{
 				// http://spec.graphql.org/June2018/#sec-Required-Arguments
 				auto position = field.begin();
@@ -1779,7 +1722,8 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 
 				message << (missing ? "Missing argument type: "
 									: "Required non-null argument type: ")
-						<< _scopedType << " field: " << name << " name: " << argument.first;
+						<< _scopedType->get().name() << " field: " << name
+						<< " name: " << argument.first;
 
 				_errors.push_back({ message.str(), { position.line, position.column } });
 			}
@@ -1815,21 +1759,16 @@ void ValidateExecutableVisitor::visitField(const peg::ast_node& field)
 		_fieldCount = outerFieldCount;
 	}
 
-	if (subFieldCount == 0)
+	if (subFieldCount == 0 && !isScalarType(innerType->get().kind()))
 	{
-		auto itrInnerKind = _typeKinds.find(innerType);
+		// http://spec.graphql.org/June2018/#sec-Leaf-Field-Selections
+		auto position = field.begin();
+		std::ostringstream message;
 
-		if (itrInnerKind != _typeKinds.end() && !isScalarType(itrInnerKind->second))
-		{
-			// http://spec.graphql.org/June2018/#sec-Leaf-Field-Selections
-			auto position = field.begin();
-			std::ostringstream message;
+		message << "Missing fields on non-scalar type: " << innerType->get().name();
 
-			message << "Missing fields on non-scalar type: " << innerType;
-
-			_errors.push_back({ message.str(), { position.line, position.column } });
-			return;
-		}
+		_errors.push_back({ message.str(), { position.line, position.column } });
+		return;
 	}
 
 	++_fieldCount;
@@ -1875,8 +1814,9 @@ void ValidateExecutableVisitor::visitFragmentSpread(const peg::ast_node& fragmen
 	const auto& selection = *itr->second.children.back();
 	const auto& typeCondition = itr->second.children[1];
 	const auto innerType = typeCondition->children.front()->string_view();
+	const auto itrInner = _types.find(innerType);
 
-	if (!matchesScopedType(innerType))
+	if (itrInner == _types.cend() || !matchesScopedType(innerType))
 	{
 		// http://spec.graphql.org/June2018/#sec-Fragment-spread-is-possible
 		auto position = fragmentSpread.begin();
@@ -1891,7 +1831,7 @@ void ValidateExecutableVisitor::visitFragmentSpread(const peg::ast_node& fragmen
 	auto outerType = std::move(_scopedType);
 
 	_fragmentStack.insert(name);
-	_scopedType = std::move(innerType);
+	_scopedType = itrInner->second;
 
 	visitSelection(selection);
 
@@ -1918,35 +1858,39 @@ void ValidateExecutableVisitor::visitInlineFragment(const peg::ast_node& inlineF
 			typeConditionLocation = { position.line, position.column };
 		});
 
+	ValidateType fragmentType;
+
 	if (innerType.empty())
 	{
-		innerType = _scopedType;
+		fragmentType = _scopedType;
 	}
 	else
 	{
-		auto itrKind = _typeKinds.find(innerType);
+		auto itrInner = _types.find(innerType);
 
-		if (itrKind == _typeKinds.end() || isScalarType(itrKind->second))
+		if (itrInner == _types.end())
 		{
 			// http://spec.graphql.org/June2018/#sec-Fragment-Spread-Type-Existence
-			// http://spec.graphql.org/June2018/#sec-Fragments-On-Composite-Types
 			std::ostringstream message;
 
-			message << (itrKind == _typeKinds.end()
-					? "Undefined target type on inline fragment name: "
-					: "Scalar target type on inline fragment name: ")
-					<< innerType;
+			message << "Undefined target type on inline fragment name: " << innerType;
 
 			_errors.push_back({ message.str(), std::move(typeConditionLocation) });
 			return;
 		}
 
-		if (!matchesScopedType(innerType))
+		fragmentType = itrInner->second;
+
+		if (isScalarType(fragmentType->get().kind()) || !matchesScopedType(innerType))
 		{
+			// http://spec.graphql.org/June2018/#sec-Fragments-On-Composite-Types
 			// http://spec.graphql.org/June2018/#sec-Fragment-spread-is-possible
 			std::ostringstream message;
 
-			message << "Incompatible target type on inline fragment name: " << innerType;
+			message << (isScalarType(fragmentType->get().kind())
+					? "Scalar target type on inline fragment name: "
+					: "Incompatible target type on inline fragment name: ")
+					<< innerType;
 
 			_errors.push_back({ message.str(), std::move(typeConditionLocation) });
 			return;
@@ -1954,10 +1898,10 @@ void ValidateExecutableVisitor::visitInlineFragment(const peg::ast_node& inlineF
 	}
 
 	peg::on_first_child<peg::selection_set>(inlineFragment,
-		[this, &innerType](const peg::ast_node& selection) {
+		[this, &fragmentType](const peg::ast_node& selection) {
 			auto outerType = std::move(_scopedType);
 
-			_scopedType = std::move(innerType);
+			_scopedType = std::move(fragmentType);
 
 			visitSelection(selection);
 
@@ -2129,7 +2073,7 @@ void ValidateExecutableVisitor::visitDirectives(
 
 					// See if the argument is wrapped in NON_NULL
 					if (argument.second.type
-						&& introspection::TypeKind::NON_NULL == argument.second.type->kind())
+						&& introspection::TypeKind::NON_NULL == argument.second.type->get().kind())
 					{
 						// http://spec.graphql.org/June2018/#sec-Required-Arguments
 						auto position = directive->begin();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,15 @@ target_link_libraries(today_tests PRIVATE
 add_bigobj_flag(today_tests)
 gtest_add_tests(TARGET today_tests)
 
+add_executable(nointrospection_tests NoIntrospectionTests.cpp)
+target_link_libraries(nointrospection_tests PRIVATE
+  unifiedgraphql_nointrospection
+  graphqljson
+  GTest::GTest
+  GTest::Main)
+add_bigobj_flag(nointrospection_tests)
+gtest_add_tests(TARGET nointrospection_tests)
+
 add_executable(argument_tests ArgumentTests.cpp)
 target_link_libraries(argument_tests PRIVATE
   unifiedgraphql
@@ -62,6 +71,7 @@ if(WIN32 AND BUILD_SHARED_LIBS)
 
   add_dependencies(validation_tests copy_test_dlls)
   add_dependencies(today_tests copy_test_dlls)
+  add_dependencies(nointrospection_tests copy_test_dlls)
   add_dependencies(argument_tests copy_test_dlls)
   add_dependencies(pegtl_tests copy_test_dlls)
   add_dependencies(response_tests copy_test_dlls)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,7 +62,8 @@ target_include_directories(response_tests PUBLIC
 gtest_add_tests(TARGET response_tests)
 
 if(WIN32 AND BUILD_SHARED_LIBS)
-  add_custom_target(copy_test_dlls ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlservice> ${CMAKE_CURRENT_BINARY_DIR}
+  add_custom_target(copy_test_dlls ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlservice_nointrospection> ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlservice> ${CMAKE_CURRENT_BINARY_DIR}
       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqljson> ${CMAKE_CURRENT_BINARY_DIR}
       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlpeg> ${CMAKE_CURRENT_BINARY_DIR}
       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphqlresponse> ${CMAKE_CURRENT_BINARY_DIR}

--- a/test/NoIntrospectionTests.cpp
+++ b/test/NoIntrospectionTests.cpp
@@ -1,0 +1,251 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include "TodayMock.h"
+
+#include "graphqlservice/JSONResponse.h"
+
+#include <chrono>
+
+using namespace graphql;
+
+using namespace std::literals;
+
+
+// this is similar to TodayTests, will trust QueryEverything works
+// and then check if introspection is disabled
+
+class NoIntrospectionServiceCase : public ::testing::Test
+{
+public:
+	static void SetUpTestCase()
+	{
+		std::string fakeAppointmentId("fakeAppointmentId");
+		_fakeAppointmentId.resize(fakeAppointmentId.size());
+		std::copy(fakeAppointmentId.cbegin(), fakeAppointmentId.cend(), _fakeAppointmentId.begin());
+
+		std::string fakeTaskId("fakeTaskId");
+		_fakeTaskId.resize(fakeTaskId.size());
+		std::copy(fakeTaskId.cbegin(), fakeTaskId.cend(), _fakeTaskId.begin());
+
+		std::string fakeFolderId("fakeFolderId");
+		_fakeFolderId.resize(fakeFolderId.size());
+		std::copy(fakeFolderId.cbegin(), fakeFolderId.cend(), _fakeFolderId.begin());
+
+		auto query = std::make_shared<today::Query>(
+			[]() -> std::vector<std::shared_ptr<today::Appointment>>
+		{
+			++_getAppointmentsCount;
+			return { std::make_shared<today::Appointment>(response::IdType(_fakeAppointmentId), "tomorrow", "Lunch?", false) };
+		}, []() -> std::vector<std::shared_ptr<today::Task>>
+		{
+			++_getTasksCount;
+			return { std::make_shared<today::Task>(response::IdType(_fakeTaskId), "Don't forget", true) };
+		}, []() -> std::vector<std::shared_ptr<today::Folder>>
+		{
+			++_getUnreadCountsCount;
+			return { std::make_shared<today::Folder>(response::IdType(_fakeFolderId), "\"Fake\" Inbox", 3) };
+		});
+		auto mutation = std::make_shared<today::Mutation>(
+			[](today::CompleteTaskInput&& input) -> std::shared_ptr<today::CompleteTaskPayload>
+		{
+			return std::make_shared<today::CompleteTaskPayload>(
+				std::make_shared<today::Task>(std::move(input.id), "Mutated Task!", *(input.isComplete)),
+				std::move(input.clientMutationId)
+				);
+		});
+		auto subscription = std::make_shared<today::NextAppointmentChange>(
+			[](const std::shared_ptr<service::RequestState>&) -> std::shared_ptr<today::Appointment>
+		{
+			return { std::make_shared<today::Appointment>(response::IdType(_fakeAppointmentId), "tomorrow", "Lunch?", true) };
+		});
+
+		_service = std::make_shared<today::Operations>(query, mutation, subscription);
+	}
+
+	static void TearDownTestCase()
+	{
+		_fakeAppointmentId.clear();
+		_fakeTaskId.clear();
+		_fakeFolderId.clear();
+		_service.reset();
+	}
+
+protected:
+	static response::IdType _fakeAppointmentId;
+	static response::IdType _fakeTaskId;
+	static response::IdType _fakeFolderId;
+
+	static std::shared_ptr<today::Operations> _service;
+	static size_t _getAppointmentsCount;
+	static size_t _getTasksCount;
+	static size_t _getUnreadCountsCount;
+};
+
+response::IdType NoIntrospectionServiceCase::_fakeAppointmentId;
+response::IdType NoIntrospectionServiceCase::_fakeTaskId;
+response::IdType NoIntrospectionServiceCase::_fakeFolderId;
+
+std::shared_ptr<today::Operations> NoIntrospectionServiceCase::_service;
+size_t NoIntrospectionServiceCase::_getAppointmentsCount = 0;
+size_t NoIntrospectionServiceCase::_getTasksCount = 0;
+size_t NoIntrospectionServiceCase::_getUnreadCountsCount = 0;
+size_t today::NextAppointmentChange::_notifySubscribeCount = 0;
+size_t today::NextAppointmentChange::_subscriptionCount = 0;
+size_t today::NextAppointmentChange::_notifyUnsubscribeCount = 0;
+
+TEST_F(NoIntrospectionServiceCase, QueryEverything)
+{
+	auto query = R"(
+		query Everything {
+			appointments {
+				edges {
+					node {
+						id
+						subject
+						when
+						isNow
+						__typename
+					}
+				}
+			}
+			tasks {
+				edges {
+					node {
+						id
+						title
+						isComplete
+						__typename
+					}
+				}
+			}
+			unreadCounts {
+				edges {
+					node {
+						id
+						name
+						unreadCount
+						__typename
+					}
+				}
+			}
+		})"_graphql;
+	// TODO: cherry-pick validation support without Introspection
+	query.validated = true;
+	response::Value variables(response::Type::Map);
+	auto state = std::make_shared<today::RequestState>(1);
+	auto result = _service->resolve(std::launch::async, state, query, "Everything", std::move(variables)).get();
+	EXPECT_EQ(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
+	EXPECT_EQ(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
+	EXPECT_EQ(size_t(1), _getUnreadCountsCount) << "today service lazy loads the unreadCounts and caches the result";
+	EXPECT_EQ(size_t(1), state->appointmentsRequestId) << "today service passed the same RequestState";
+	EXPECT_EQ(size_t(1), state->tasksRequestId) << "today service passed the same RequestState";
+	EXPECT_EQ(size_t(1), state->unreadCountsRequestId) << "today service passed the same RequestState";
+	EXPECT_EQ(size_t(1), state->loadAppointmentsCount) << "today service called the loader once";
+	EXPECT_EQ(size_t(1), state->loadTasksCount) << "today service called the loader once";
+	EXPECT_EQ(size_t(1), state->loadUnreadCountsCount) << "today service called the loader once";
+
+	try
+	{
+		ASSERT_TRUE(result.type() == response::Type::Map);
+		auto errorsItr = result.find("errors");
+		if (errorsItr != result.get<response::MapType>().cend())
+		{
+			FAIL() << response::toJSON(response::Value(errorsItr->second));
+		}
+		const auto data = service::ScalarArgument::require("data", result);
+
+		const auto appointments = service::ScalarArgument::require("appointments", data);
+		const auto appointmentEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", appointments);
+		ASSERT_EQ(1, appointmentEdges.size()) << "appointments should have 1 entry";
+		ASSERT_TRUE(appointmentEdges[0].type() == response::Type::Map) << "appointment should be an object";
+		const auto appointmentNode = service::ScalarArgument::require("node", appointmentEdges[0]);
+		EXPECT_EQ(_fakeAppointmentId, service::IdArgument::require("id", appointmentNode)) << "id should match in base64 encoding";
+		EXPECT_EQ("Lunch?", service::StringArgument::require("subject", appointmentNode)) << "subject should match";
+		EXPECT_EQ("tomorrow", service::StringArgument::require("when", appointmentNode)) << "when should match";
+		EXPECT_FALSE(service::BooleanArgument::require("isNow", appointmentNode)) << "isNow should match";
+		EXPECT_EQ("Appointment", service::StringArgument::require("__typename", appointmentNode)) << "__typename should match";
+
+		const auto tasks = service::ScalarArgument::require("tasks", data);
+		const auto taskEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", tasks);
+		ASSERT_EQ(1, taskEdges.size()) << "tasks should have 1 entry";
+		ASSERT_TRUE(taskEdges[0].type() == response::Type::Map) << "task should be an object";
+		const auto taskNode = service::ScalarArgument::require("node", taskEdges[0]);
+		EXPECT_EQ(_fakeTaskId, service::IdArgument::require("id", taskNode)) << "id should match in base64 encoding";
+		EXPECT_EQ("Don't forget", service::StringArgument::require("title", taskNode)) << "title should match";
+		EXPECT_TRUE(service::BooleanArgument::require("isComplete", taskNode)) << "isComplete should match";
+		EXPECT_EQ("Task", service::StringArgument::require("__typename", taskNode)) << "__typename should match";
+
+		const auto unreadCounts = service::ScalarArgument::require("unreadCounts", data);
+		const auto unreadCountEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", unreadCounts);
+		ASSERT_EQ(1, unreadCountEdges.size()) << "unreadCounts should have 1 entry";
+		ASSERT_TRUE(unreadCountEdges[0].type() == response::Type::Map) << "unreadCount should be an object";
+		const auto unreadCountNode = service::ScalarArgument::require("node", unreadCountEdges[0]);
+		EXPECT_EQ(_fakeFolderId, service::IdArgument::require("id", unreadCountNode)) << "id should match in base64 encoding";
+		EXPECT_EQ("\"Fake\" Inbox", service::StringArgument::require("name", unreadCountNode)) << "name should match";
+		EXPECT_EQ(3, service::IntArgument::require("unreadCount", unreadCountNode)) << "unreadCount should match";
+		EXPECT_EQ("Folder", service::StringArgument::require("__typename", unreadCountNode)) << "__typename should match";
+	}
+	catch (service::schema_exception & ex)
+	{
+		FAIL() << response::toJSON(ex.getErrors());
+	}
+}
+
+TEST_F(NoIntrospectionServiceCase, NoSchema)
+{
+	auto query = R"(query {
+			__schema {
+				queryType { name }
+			}
+		})"_graphql;
+	// TODO: cherry-pick validation support without Introspection
+	query.validated = true;
+	response::Value variables(response::Type::Map);
+	auto future = _service->resolve(std::launch::deferred, nullptr, query, "", std::move(variables));
+	auto result = future.get();
+
+	try
+	{
+		ASSERT_TRUE(result.type() == response::Type::Map);
+		auto errorsItr = result.find("errors");
+		ASSERT_FALSE(errorsItr == result.get<response::MapType>().cend());
+		auto errorsString = response::toJSON(response::Value(errorsItr->second));
+		// TODO: cherry-pick validation support without Introspection
+		EXPECT_EQ(R"js([{"message":"Unknown field name: __schema","locations":[{"line":2,"column":4}]}])js", errorsString) << "error should match";
+	}
+	catch (service::schema_exception & ex)
+	{
+		FAIL() << response::toJSON(ex.getErrors());
+	}
+}
+
+TEST_F(NoIntrospectionServiceCase, NoType)
+{
+	auto query = R"(query {
+			__type(name: "Query") {
+				description
+			}
+		})"_graphql;
+	// TODO: cherry-pick validation support without Introspection
+	query.validated = true;
+	response::Value variables(response::Type::Map);
+	auto future = _service->resolve(std::launch::deferred, nullptr, query, "", std::move(variables));
+	auto result = future.get();
+
+	try
+	{
+		ASSERT_TRUE(result.type() == response::Type::Map);
+		auto errorsItr = result.find("errors");
+		ASSERT_FALSE(errorsItr == result.get<response::MapType>().cend());
+		auto errorsString = response::toJSON(response::Value(errorsItr->second));
+		// TODO: cherry-pick validation support without Introspection
+		EXPECT_EQ(R"js([{"message":"Unknown field name: __type","locations":[{"line":2,"column":4}]}])js", errorsString) << "error should match";
+	}
+	catch (service::schema_exception & ex)
+	{
+		FAIL() << response::toJSON(ex.getErrors());
+	}
+}

--- a/test/NoIntrospectionTests.cpp
+++ b/test/NoIntrospectionTests.cpp
@@ -132,8 +132,6 @@ TEST_F(NoIntrospectionServiceCase, QueryEverything)
 				}
 			}
 		})"_graphql;
-	// TODO: cherry-pick validation support without Introspection
-	query.validated = true;
 	response::Value variables(response::Type::Map);
 	auto state = std::make_shared<today::RequestState>(1);
 	auto result = _service->resolve(std::launch::async, state, query, "Everything", std::move(variables)).get();
@@ -201,8 +199,6 @@ TEST_F(NoIntrospectionServiceCase, NoSchema)
 				queryType { name }
 			}
 		})"_graphql;
-	// TODO: cherry-pick validation support without Introspection
-	query.validated = true;
 	response::Value variables(response::Type::Map);
 	auto future = _service->resolve(std::launch::deferred, nullptr, query, "", std::move(variables));
 	auto result = future.get();
@@ -213,8 +209,7 @@ TEST_F(NoIntrospectionServiceCase, NoSchema)
 		auto errorsItr = result.find("errors");
 		ASSERT_FALSE(errorsItr == result.get<response::MapType>().cend());
 		auto errorsString = response::toJSON(response::Value(errorsItr->second));
-		// TODO: cherry-pick validation support without Introspection
-		EXPECT_EQ(R"js([{"message":"Unknown field name: __schema","locations":[{"line":2,"column":4}]}])js", errorsString) << "error should match";
+		EXPECT_EQ(R"js([{"message":"Undefined field type: Query name: __schema","locations":[{"line":2,"column":4}]}])js", errorsString) << "error should match";
 	}
 	catch (service::schema_exception & ex)
 	{
@@ -229,8 +224,6 @@ TEST_F(NoIntrospectionServiceCase, NoType)
 				description
 			}
 		})"_graphql;
-	// TODO: cherry-pick validation support without Introspection
-	query.validated = true;
 	response::Value variables(response::Type::Map);
 	auto future = _service->resolve(std::launch::deferred, nullptr, query, "", std::move(variables));
 	auto result = future.get();
@@ -241,8 +234,7 @@ TEST_F(NoIntrospectionServiceCase, NoType)
 		auto errorsItr = result.find("errors");
 		ASSERT_FALSE(errorsItr == result.get<response::MapType>().cend());
 		auto errorsString = response::toJSON(response::Value(errorsItr->second));
-		// TODO: cherry-pick validation support without Introspection
-		EXPECT_EQ(R"js([{"message":"Unknown field name: __type","locations":[{"line":2,"column":4}]}])js", errorsString) << "error should match";
+		EXPECT_EQ(R"js([{"message":"Undefined field type: Query name: __type","locations":[{"line":2,"column":4}]}])js", errorsString) << "error should match";
 	}
 	catch (service::schema_exception & ex)
 	{

--- a/test/TodayTests.cpp
+++ b/test/TodayTests.cpp
@@ -238,6 +238,64 @@ TEST_F(TodayServiceCase, QueryAppointments)
 	}
 }
 
+TEST_F(TodayServiceCase, QueryAppointmentsWithForceError)
+{
+	auto query = R"({
+			appointments {
+				edges {
+					node {
+						appointmentId: id
+						subject
+						when
+						isNow
+						forceError
+					}
+				}
+			}
+		})"_graphql;
+	response::Value variables(response::Type::Map);
+	auto state = std::make_shared<today::RequestState>(2);
+	auto result = _service->resolve(state, query, "", std::move(variables)).get();
+	EXPECT_EQ(size_t(1), _getAppointmentsCount) << "today service lazy loads the appointments and caches the result";
+	EXPECT_GE(size_t(1), _getTasksCount) << "today service lazy loads the tasks and caches the result";
+	EXPECT_GE(size_t(1), _getUnreadCountsCount) << "today service lazy loads the unreadCounts and caches the result";
+	EXPECT_EQ(size_t(2), state->appointmentsRequestId) << "today service passed the same RequestState";
+	EXPECT_EQ(size_t(0), state->tasksRequestId) << "today service did not call the loader";
+	EXPECT_EQ(size_t(0), state->unreadCountsRequestId) << "today service did not call the loader";
+	EXPECT_EQ(size_t(1), state->loadAppointmentsCount) << "today service called the loader once";
+	EXPECT_EQ(size_t(0), state->loadTasksCount) << "today service did not call the loader";
+	EXPECT_EQ(size_t(0), state->loadUnreadCountsCount) << "today service did not call the loader";
+
+	try
+	{
+		ASSERT_TRUE(result.type() == response::Type::Map);
+		auto errorsItr = result.find("errors");
+		if (errorsItr == result.get<response::MapType>().cend())
+		{
+			FAIL() << response::toJSON(response::Value(result)) << "no errors returned";
+		}
+
+		auto errorsString = response::toJSON(response::Value(errorsItr->second));
+		EXPECT_EQ(R"js([{"message":"Field error name: forceError unknown error: this error was forced","locations":[{"line":9,"column":7}],"path":["appointments","edges",0,"node","forceError"]}])js", errorsString) << "error should match";
+
+		const auto data = service::ScalarArgument::require("data", result);
+
+		const auto appointments = service::ScalarArgument::require("appointments", data);
+		const auto appointmentEdges = service::ScalarArgument::require<service::TypeModifier::List>("edges", appointments);
+		ASSERT_EQ(1, appointmentEdges.size()) << "appointments should have 1 entry";
+		ASSERT_TRUE(appointmentEdges[0].type() == response::Type::Map) << "appointment should be an object";
+		const auto appointmentNode = service::ScalarArgument::require("node", appointmentEdges[0]);
+		EXPECT_EQ(_fakeAppointmentId, service::IdArgument::require("appointmentId", appointmentNode)) << "id should match in base64 encoding";
+		EXPECT_EQ("Lunch?", service::StringArgument::require("subject", appointmentNode)) << "subject should match";
+		EXPECT_EQ("tomorrow", service::StringArgument::require("when", appointmentNode)) << "when should match";
+		EXPECT_FALSE(service::BooleanArgument::require("isNow", appointmentNode)) << "isNow should match";
+	}
+	catch (service::schema_exception & ex)
+	{
+		FAIL() << response::toJSON(ex.getErrors());
+	}
+}
+
 TEST_F(TodayServiceCase, QueryTasks)
 {
 	auto query = R"gql({


### PR DESCRIPTION
Fixes #126 

This branch incorporates most of the changes from PR #126. Rather than building a separate schema structure specifically for validation, it generates an optimized representation of the schema which is shared between Validation and Introspection. There's still an option to disable Introspection in the `schemagen` tool with `--no-introspection`, but that's mostly for cases where you want to disable Introspection and not just to get the performance benefit. The overhead of re-enabling Introspection on top of the shared schema is minimal.

There's more to do to optimize allocations in the `peg::graphql` grammar and parsing, but I think we'll target a separate PR for that.