### PR TITLE
Improve memory consumption

### DIFF
--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -230,6 +230,9 @@ struct FieldParams : SelectionSetParams
 	GRAPHQLSERVICE_EXPORT explicit FieldParams(
 		const SelectionSetParams& selectionSetParams, response::Value&& directives);
 
+	GRAPHQLSERVICE_EXPORT explicit FieldParams(
+		SelectionSetParams&& selectionSetParams, response::Value&& directives);
+
 	// Each field owns its own field-specific directives. Once the accessor returns it will be
 	// destroyed, but you can move it into another instance of response::Value to keep it alive
 	// longer.

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -633,7 +633,7 @@ struct ModifiedResult
 		static_assert(std::is_same_v<std::shared_ptr<Type>, typename ResultTraits<Type>::type>,
 			"this is the derived object type");
 		auto resultFuture = std::async(
-			params.launch,
+			std::launch::deferred,
 			[](auto&& objectType) {
 				return std::static_pointer_cast<Object>(objectType.get());
 			},
@@ -662,7 +662,7 @@ struct ModifiedResult
 		ResolverParams&& params)
 	{
 		return std::async(
-			params.launch,
+			std::launch::deferred,
 			[](auto&& wrappedFuture, ResolverParams&& wrappedParams) {
 				auto wrappedResult = wrappedFuture.get();
 
@@ -696,7 +696,7 @@ struct ModifiedResult
 			"this is the optional version");
 
 		return std::async(
-			params.launch,
+			std::launch::deferred,
 			[](auto&& wrappedFuture, ResolverParams&& wrappedParams) {
 				auto wrappedResult = wrappedFuture.get();
 
@@ -724,7 +724,7 @@ struct ModifiedResult
 		ResolverParams&& params)
 	{
 		return std::async(
-			params.launch,
+			std::launch::deferred,
 			[](auto&& wrappedFuture, const ResolverParams&& wrappedParams) {
 				auto wrappedResult = wrappedFuture.get();
 				std::vector<std::future<ResolverResult>> children;

--- a/include/graphqlservice/GraphQLTree.h
+++ b/include/graphqlservice/GraphQLTree.h
@@ -22,11 +22,126 @@ namespace graphql::peg {
 
 using namespace tao::graphqlpeg;
 
-struct ast_node : parse_tree::basic_node<ast_node>
+struct ast_node
 {
-	GRAPHQLPEG_EXPORT std::string_view unescaped_view() const;
+	// Requirements as per
+	// https://github.com/taocpp/PEGTL/blob/master/doc/Parse-Tree.md#custom-node-class
+	ast_node() = default;
+	ast_node(const ast_node&) = delete;
+	ast_node(ast_node&&) = delete;
+	~ast_node() = default;
+	ast_node& operator=(const ast_node&) = delete;
+	ast_node& operator=(ast_node&&) = delete;
 
-	std::variant<std::string_view, std::string> unescaped;
+	using children_t = std::vector<std::unique_ptr<ast_node>>;
+	children_t children;
+	std::string_view type;
+	std::string_view m_string_view;
+	std::string_view unescaped;
+	internal::iterator m_begin;
+	std::string_view source;
+
+	[[nodiscard]] bool is_root() const noexcept
+	{
+		return type.empty();
+	}
+
+	template <typename U>
+	[[nodiscard]] bool is_type() const noexcept
+	{
+		const auto u = tao::demangle<U>();
+		return ((type.data() == u.data()) && (type.size() == u.size())) || (type == u);
+	}
+
+	template <typename U>
+	void set_type() noexcept
+	{
+		type = tao::demangle<U>();
+	}
+
+	[[nodiscard]] position begin() const
+	{
+		return position(m_begin, source);
+	}
+
+	[[nodiscard]] bool has_content() const noexcept
+	{
+		return m_string_view.size() > 0;
+	}
+
+	[[nodiscard]] std::string_view string_view() const noexcept
+	{
+		return m_string_view;
+	}
+
+	[[nodiscard]] std::string_view unescaped_view() const noexcept
+	{
+		return unescaped;
+	}
+
+	[[nodiscard]] std::string string() const
+	{
+		return std::string(m_string_view);
+	}
+
+	template <typename... States>
+	void remove_content(States&&... /*unused*/) noexcept
+	{
+		m_string_view = {};
+		unescaped = {};
+	}
+
+	// all non-root nodes are initialized by calling this method
+	template <typename Rule, typename ParseInput, typename... States>
+	void start(const ParseInput& in, States&&... /*unused*/)
+	{
+		set_type<Rule>();
+		source = in.source();
+		m_begin = internal::iterator(in.iterator());
+		m_string_view = {};
+		unescaped = {};
+	}
+
+	// if parsing of the rule succeeded, this method is called
+	template <typename Rule, typename ParseInput, typename... States>
+	void success(const ParseInput& in, States&&... /*unused*/) noexcept
+	{
+		const auto& end = in.iterator();
+		m_string_view = std::string_view(m_begin.data, end.data - m_begin.data);
+		unescaped = m_string_view;
+	}
+
+	// if parsing of the rule failed, this method is called
+	template <typename Rule, typename ParseInput, typename... States>
+	void failure(const ParseInput& /*unused*/, States&&... /*unused*/) noexcept
+	{
+	}
+
+	// if parsing of the rule failed with an exception, this method is called
+	template <typename Rule, typename ParseInput, typename... States>
+	void unwind(const ParseInput& /*unused*/, States&&... /*unused*/) noexcept
+	{
+	}
+
+	// if parsing succeeded and the (optional) transform call
+	// did not discard the node, it is appended to its parent.
+	// note that "child" is the node whose Rule just succeeded
+	// and "*this" is the parent where the node should be appended.
+	template <typename... States>
+	void emplace_back(std::unique_ptr<ast_node>&& child, States&&... /*unused*/)
+	{
+		assert(child);
+		children.emplace_back(std::move(child));
+	}
+};
+
+struct ast_unescaped_string : ast_node
+{
+	ast_unescaped_string() = default;
+	ast_unescaped_string(std::unique_ptr<ast_node>&& reference, std::string&& unescaped);
+
+protected:
+	std::string _unescaped; // storage to keep string_view alive
 };
 
 struct ast_input

--- a/samples/introspection/IntrospectionSchema.cpp
+++ b/samples/introspection/IntrospectionSchema.cpp
@@ -135,7 +135,8 @@ Schema::Schema()
 std::future<service::ResolverResult> Schema::resolveTypes(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTypes(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTypes(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Type>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
@@ -144,7 +145,8 @@ std::future<service::ResolverResult> Schema::resolveTypes(service::ResolverParam
 std::future<service::ResolverResult> Schema::resolveQueryType(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getQueryType(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getQueryType(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Type>::convert(std::move(result), std::move(params));
@@ -153,7 +155,8 @@ std::future<service::ResolverResult> Schema::resolveQueryType(service::ResolverP
 std::future<service::ResolverResult> Schema::resolveMutationType(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getMutationType(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getMutationType(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Type>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -162,7 +165,8 @@ std::future<service::ResolverResult> Schema::resolveMutationType(service::Resolv
 std::future<service::ResolverResult> Schema::resolveSubscriptionType(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getSubscriptionType(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getSubscriptionType(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Type>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -171,7 +175,8 @@ std::future<service::ResolverResult> Schema::resolveSubscriptionType(service::Re
 std::future<service::ResolverResult> Schema::resolveDirectives(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDirectives(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDirectives(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Directive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
@@ -203,7 +208,8 @@ Type::Type()
 std::future<service::ResolverResult> Type::resolveKind(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getKind(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getKind(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<TypeKind>::convert(std::move(result), std::move(params));
@@ -212,7 +218,8 @@ std::future<service::ResolverResult> Type::resolveKind(service::ResolverParams&&
 std::future<service::ResolverResult> Type::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getName(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -221,7 +228,8 @@ std::future<service::ResolverResult> Type::resolveName(service::ResolverParams&&
 std::future<service::ResolverResult> Type::resolveDescription(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDescription(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDescription(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -245,7 +253,8 @@ std::future<service::ResolverResult> Type::resolveFields(service::ResolverParams
 		? std::move(pairIncludeDeprecated.first)
 		: service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable>("includeDeprecated", defaultArguments));
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getFields(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIncludeDeprecated));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getFields(service::FieldParams(std::move(params), std::move(directives)), std::move(argIncludeDeprecated));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Field>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
@@ -254,7 +263,8 @@ std::future<service::ResolverResult> Type::resolveFields(service::ResolverParams
 std::future<service::ResolverResult> Type::resolveInterfaces(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getInterfaces(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getInterfaces(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Type>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
@@ -263,7 +273,8 @@ std::future<service::ResolverResult> Type::resolveInterfaces(service::ResolverPa
 std::future<service::ResolverResult> Type::resolvePossibleTypes(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPossibleTypes(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPossibleTypes(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Type>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
@@ -287,7 +298,8 @@ std::future<service::ResolverResult> Type::resolveEnumValues(service::ResolverPa
 		? std::move(pairIncludeDeprecated.first)
 		: service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable>("includeDeprecated", defaultArguments));
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getEnumValues(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIncludeDeprecated));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getEnumValues(service::FieldParams(std::move(params), std::move(directives)), std::move(argIncludeDeprecated));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<EnumValue>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
@@ -296,7 +308,8 @@ std::future<service::ResolverResult> Type::resolveEnumValues(service::ResolverPa
 std::future<service::ResolverResult> Type::resolveInputFields(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getInputFields(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getInputFields(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<InputValue>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
@@ -305,7 +318,8 @@ std::future<service::ResolverResult> Type::resolveInputFields(service::ResolverP
 std::future<service::ResolverResult> Type::resolveOfType(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getOfType(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getOfType(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Type>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -334,7 +348,8 @@ Field::Field()
 std::future<service::ResolverResult> Field::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getName(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
@@ -343,7 +358,8 @@ std::future<service::ResolverResult> Field::resolveName(service::ResolverParams&
 std::future<service::ResolverResult> Field::resolveDescription(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDescription(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDescription(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -352,7 +368,8 @@ std::future<service::ResolverResult> Field::resolveDescription(service::Resolver
 std::future<service::ResolverResult> Field::resolveArgs(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getArgs(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getArgs(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<InputValue>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
@@ -361,7 +378,8 @@ std::future<service::ResolverResult> Field::resolveArgs(service::ResolverParams&
 std::future<service::ResolverResult> Field::resolveType(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getType(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getType(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Type>::convert(std::move(result), std::move(params));
@@ -370,7 +388,8 @@ std::future<service::ResolverResult> Field::resolveType(service::ResolverParams&
 std::future<service::ResolverResult> Field::resolveIsDeprecated(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getIsDeprecated(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getIsDeprecated(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -379,7 +398,8 @@ std::future<service::ResolverResult> Field::resolveIsDeprecated(service::Resolve
 std::future<service::ResolverResult> Field::resolveDeprecationReason(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDeprecationReason(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDeprecationReason(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -406,7 +426,8 @@ InputValue::InputValue()
 std::future<service::ResolverResult> InputValue::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getName(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
@@ -415,7 +436,8 @@ std::future<service::ResolverResult> InputValue::resolveName(service::ResolverPa
 std::future<service::ResolverResult> InputValue::resolveDescription(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDescription(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDescription(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -424,7 +446,8 @@ std::future<service::ResolverResult> InputValue::resolveDescription(service::Res
 std::future<service::ResolverResult> InputValue::resolveType(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getType(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getType(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Type>::convert(std::move(result), std::move(params));
@@ -433,7 +456,8 @@ std::future<service::ResolverResult> InputValue::resolveType(service::ResolverPa
 std::future<service::ResolverResult> InputValue::resolveDefaultValue(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDefaultValue(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDefaultValue(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -460,7 +484,8 @@ EnumValue::EnumValue()
 std::future<service::ResolverResult> EnumValue::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getName(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
@@ -469,7 +494,8 @@ std::future<service::ResolverResult> EnumValue::resolveName(service::ResolverPar
 std::future<service::ResolverResult> EnumValue::resolveDescription(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDescription(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDescription(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -478,7 +504,8 @@ std::future<service::ResolverResult> EnumValue::resolveDescription(service::Reso
 std::future<service::ResolverResult> EnumValue::resolveIsDeprecated(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getIsDeprecated(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getIsDeprecated(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -487,7 +514,8 @@ std::future<service::ResolverResult> EnumValue::resolveIsDeprecated(service::Res
 std::future<service::ResolverResult> EnumValue::resolveDeprecationReason(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDeprecationReason(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDeprecationReason(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -514,7 +542,8 @@ Directive::Directive()
 std::future<service::ResolverResult> Directive::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getName(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
@@ -523,7 +552,8 @@ std::future<service::ResolverResult> Directive::resolveName(service::ResolverPar
 std::future<service::ResolverResult> Directive::resolveDescription(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDescription(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDescription(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -532,7 +562,8 @@ std::future<service::ResolverResult> Directive::resolveDescription(service::Reso
 std::future<service::ResolverResult> Directive::resolveLocations(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getLocations(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getLocations(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<DirectiveLocation>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
@@ -541,7 +572,8 @@ std::future<service::ResolverResult> Directive::resolveLocations(service::Resolv
 std::future<service::ResolverResult> Directive::resolveArgs(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getArgs(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getArgs(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<InputValue>::convert<service::TypeModifier::List>(std::move(result), std::move(params));

--- a/samples/separate/AppointmentConnectionObject.cpp
+++ b/samples/separate/AppointmentConnectionObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<PageInfo>> AppointmentConnection::getPageIn
 std::future<service::ResolverResult> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPageInfo(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>
 std::future<service::ResolverResult> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getEdges(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<AppointmentEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));

--- a/samples/separate/AppointmentEdgeObject.cpp
+++ b/samples/separate/AppointmentEdgeObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<Appointment>> AppointmentEdge::getNode(serv
 std::future<service::ResolverResult> AppointmentEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<response::Value> AppointmentEdge::getCursor(service::FieldP
 std::future<service::ResolverResult> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getCursor(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));

--- a/samples/separate/AppointmentObject.cpp
+++ b/samples/separate/AppointmentObject.cpp
@@ -40,7 +40,8 @@ service::FieldResult<response::IdType> Appointment::getId(service::FieldParams&&
 std::future<service::ResolverResult> Appointment::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -54,7 +55,8 @@ service::FieldResult<std::optional<response::Value>> Appointment::getWhen(servic
 std::future<service::ResolverResult> Appointment::resolveWhen(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getWhen(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getWhen(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -68,7 +70,8 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getSubjec
 std::future<service::ResolverResult> Appointment::resolveSubject(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getSubject(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getSubject(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -82,7 +85,8 @@ service::FieldResult<response::BooleanType> Appointment::getIsNow(service::Field
 std::future<service::ResolverResult> Appointment::resolveIsNow(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getIsNow(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getIsNow(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -96,7 +100,8 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getForceE
 std::future<service::ResolverResult> Appointment::resolveForceError(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getForceError(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getForceError(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));

--- a/samples/separate/CompleteTaskPayloadObject.cpp
+++ b/samples/separate/CompleteTaskPayloadObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<Task>> CompleteTaskPayload::getTask(service
 std::future<service::ResolverResult> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTask(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTask(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<std::optional<response::StringType>> CompleteTaskPayload::g
 std::future<service::ResolverResult> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getClientMutationId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getClientMutationId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));

--- a/samples/separate/ExpensiveObject.cpp
+++ b/samples/separate/ExpensiveObject.cpp
@@ -34,7 +34,8 @@ service::FieldResult<response::IntType> Expensive::getOrder(service::FieldParams
 std::future<service::ResolverResult> Expensive::resolveOrder(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getOrder(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getOrder(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));

--- a/samples/separate/FolderConnectionObject.cpp
+++ b/samples/separate/FolderConnectionObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<PageInfo>> FolderConnection::getPageInfo(se
 std::future<service::ResolverResult> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPageInfo(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> Fo
 std::future<service::ResolverResult> FolderConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getEdges(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<FolderEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));

--- a/samples/separate/FolderEdgeObject.cpp
+++ b/samples/separate/FolderEdgeObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<Folder>> FolderEdge::getNode(service::Field
 std::future<service::ResolverResult> FolderEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Folder>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<response::Value> FolderEdge::getCursor(service::FieldParams
 std::future<service::ResolverResult> FolderEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getCursor(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));

--- a/samples/separate/FolderObject.cpp
+++ b/samples/separate/FolderObject.cpp
@@ -38,7 +38,8 @@ service::FieldResult<response::IdType> Folder::getId(service::FieldParams&&) con
 std::future<service::ResolverResult> Folder::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -52,7 +53,8 @@ service::FieldResult<std::optional<response::StringType>> Folder::getName(servic
 std::future<service::ResolverResult> Folder::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getName(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -66,7 +68,8 @@ service::FieldResult<response::IntType> Folder::getUnreadCount(service::FieldPar
 std::future<service::ResolverResult> Folder::resolveUnreadCount(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnreadCount(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnreadCount(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));

--- a/samples/separate/MutationObject.cpp
+++ b/samples/separate/MutationObject.cpp
@@ -36,7 +36,8 @@ std::future<service::ResolverResult> Mutation::resolveCompleteTask(service::Reso
 {
 	auto argInput = service::ModifiedArgument<today::CompleteTaskInput>::require("input", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = applyCompleteTask(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argInput));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = applyCompleteTask(service::FieldParams(std::move(params), std::move(directives)), std::move(argInput));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<CompleteTaskPayload>::convert(std::move(result), std::move(params));
@@ -51,7 +52,8 @@ std::future<service::ResolverResult> Mutation::resolveSetFloat(service::Resolver
 {
 	auto argValue = service::ModifiedArgument<response::FloatType>::require("value", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = applySetFloat(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argValue));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = applySetFloat(service::FieldParams(std::move(params), std::move(directives)), std::move(argValue));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::FloatType>::convert(std::move(result), std::move(params));

--- a/samples/separate/NestedTypeObject.cpp
+++ b/samples/separate/NestedTypeObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<response::IntType> NestedType::getDepth(service::FieldParam
 std::future<service::ResolverResult> NestedType::resolveDepth(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDepth(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDepth(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<std::shared_ptr<NestedType>> NestedType::getNested(service:
 std::future<service::ResolverResult> NestedType::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNested(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));

--- a/samples/separate/PageInfoObject.cpp
+++ b/samples/separate/PageInfoObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<response::BooleanType> PageInfo::getHasNextPage(service::Fi
 std::future<service::ResolverResult> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getHasNextPage(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getHasNextPage(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<response::BooleanType> PageInfo::getHasPreviousPage(service
 std::future<service::ResolverResult> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getHasPreviousPage(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getHasPreviousPage(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));

--- a/samples/separate/QueryObject.cpp
+++ b/samples/separate/QueryObject.cpp
@@ -47,7 +47,8 @@ std::future<service::ResolverResult> Query::resolveNode(service::ResolverParams&
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argId));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)), std::move(argId));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<service::Object>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -65,7 +66,8 @@ std::future<service::ResolverResult> Query::resolveAppointments(service::Resolve
 	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getAppointments(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getAppointments(service::FieldParams(std::move(params), std::move(directives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<AppointmentConnection>::convert(std::move(result), std::move(params));
@@ -83,7 +85,8 @@ std::future<service::ResolverResult> Query::resolveTasks(service::ResolverParams
 	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTasks(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTasks(service::FieldParams(std::move(params), std::move(directives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<TaskConnection>::convert(std::move(result), std::move(params));
@@ -101,7 +104,8 @@ std::future<service::ResolverResult> Query::resolveUnreadCounts(service::Resolve
 	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnreadCounts(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnreadCounts(service::FieldParams(std::move(params), std::move(directives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<FolderConnection>::convert(std::move(result), std::move(params));
@@ -138,7 +142,8 @@ std::future<service::ResolverResult> Query::resolveAppointmentsById(service::Res
 		? std::move(pairIds.first)
 		: service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", defaultArguments));
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getAppointmentsById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getAppointmentsById(service::FieldParams(std::move(params), std::move(directives)), std::move(argIds));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -153,7 +158,8 @@ std::future<service::ResolverResult> Query::resolveTasksById(service::ResolverPa
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTasksById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTasksById(service::FieldParams(std::move(params), std::move(directives)), std::move(argIds));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -168,7 +174,8 @@ std::future<service::ResolverResult> Query::resolveUnreadCountsById(service::Res
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnreadCountsById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnreadCountsById(service::FieldParams(std::move(params), std::move(directives)), std::move(argIds));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Folder>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -182,7 +189,8 @@ service::FieldResult<std::shared_ptr<NestedType>> Query::getNested(service::Fiel
 std::future<service::ResolverResult> Query::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNested(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
@@ -196,7 +204,8 @@ service::FieldResult<response::StringType> Query::getUnimplemented(service::Fiel
 std::future<service::ResolverResult> Query::resolveUnimplemented(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnimplemented(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnimplemented(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
@@ -210,7 +219,8 @@ service::FieldResult<std::vector<std::shared_ptr<Expensive>>> Query::getExpensiv
 std::future<service::ResolverResult> Query::resolveExpensive(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getExpensive(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getExpensive(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Expensive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));

--- a/samples/separate/SubscriptionObject.cpp
+++ b/samples/separate/SubscriptionObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<Appointment>> Subscription::getNextAppointm
 std::future<service::ResolverResult> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNextAppointmentChange(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNextAppointmentChange(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -50,7 +51,8 @@ std::future<service::ResolverResult> Subscription::resolveNodeChange(service::Re
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNodeChange(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argId));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNodeChange(service::FieldParams(std::move(params), std::move(directives)), std::move(argId));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<service::Object>::convert(std::move(result), std::move(params));

--- a/samples/separate/TaskConnectionObject.cpp
+++ b/samples/separate/TaskConnectionObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<PageInfo>> TaskConnection::getPageInfo(serv
 std::future<service::ResolverResult> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPageInfo(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> Task
 std::future<service::ResolverResult> TaskConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getEdges(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<TaskEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));

--- a/samples/separate/TaskEdgeObject.cpp
+++ b/samples/separate/TaskEdgeObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<Task>> TaskEdge::getNode(service::FieldPara
 std::future<service::ResolverResult> TaskEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<response::Value> TaskEdge::getCursor(service::FieldParams&&
 std::future<service::ResolverResult> TaskEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getCursor(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));

--- a/samples/separate/TaskObject.cpp
+++ b/samples/separate/TaskObject.cpp
@@ -38,7 +38,8 @@ service::FieldResult<response::IdType> Task::getId(service::FieldParams&&) const
 std::future<service::ResolverResult> Task::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -52,7 +53,8 @@ service::FieldResult<std::optional<response::StringType>> Task::getTitle(service
 std::future<service::ResolverResult> Task::resolveTitle(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTitle(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTitle(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -66,7 +68,8 @@ service::FieldResult<response::BooleanType> Task::getIsComplete(service::FieldPa
 std::future<service::ResolverResult> Task::resolveIsComplete(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getIsComplete(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getIsComplete(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/AppointmentConnectionObject.cpp
+++ b/samples/separate_nointrospection/AppointmentConnectionObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<PageInfo>> AppointmentConnection::getPageIn
 std::future<service::ResolverResult> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPageInfo(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>
 std::future<service::ResolverResult> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getEdges(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<AppointmentEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/AppointmentEdgeObject.cpp
+++ b/samples/separate_nointrospection/AppointmentEdgeObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<Appointment>> AppointmentEdge::getNode(serv
 std::future<service::ResolverResult> AppointmentEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<response::Value> AppointmentEdge::getCursor(service::FieldP
 std::future<service::ResolverResult> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getCursor(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/AppointmentObject.cpp
+++ b/samples/separate_nointrospection/AppointmentObject.cpp
@@ -40,7 +40,8 @@ service::FieldResult<response::IdType> Appointment::getId(service::FieldParams&&
 std::future<service::ResolverResult> Appointment::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -54,7 +55,8 @@ service::FieldResult<std::optional<response::Value>> Appointment::getWhen(servic
 std::future<service::ResolverResult> Appointment::resolveWhen(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getWhen(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getWhen(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -68,7 +70,8 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getSubjec
 std::future<service::ResolverResult> Appointment::resolveSubject(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getSubject(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getSubject(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -82,7 +85,8 @@ service::FieldResult<response::BooleanType> Appointment::getIsNow(service::Field
 std::future<service::ResolverResult> Appointment::resolveIsNow(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getIsNow(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getIsNow(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -96,7 +100,8 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getForceE
 std::future<service::ResolverResult> Appointment::resolveForceError(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getForceError(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getForceError(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/CompleteTaskPayloadObject.cpp
+++ b/samples/separate_nointrospection/CompleteTaskPayloadObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<Task>> CompleteTaskPayload::getTask(service
 std::future<service::ResolverResult> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTask(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTask(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<std::optional<response::StringType>> CompleteTaskPayload::g
 std::future<service::ResolverResult> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getClientMutationId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getClientMutationId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/ExpensiveObject.cpp
+++ b/samples/separate_nointrospection/ExpensiveObject.cpp
@@ -34,7 +34,8 @@ service::FieldResult<response::IntType> Expensive::getOrder(service::FieldParams
 std::future<service::ResolverResult> Expensive::resolveOrder(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getOrder(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getOrder(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/FolderConnectionObject.cpp
+++ b/samples/separate_nointrospection/FolderConnectionObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<PageInfo>> FolderConnection::getPageInfo(se
 std::future<service::ResolverResult> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPageInfo(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> Fo
 std::future<service::ResolverResult> FolderConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getEdges(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<FolderEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/FolderEdgeObject.cpp
+++ b/samples/separate_nointrospection/FolderEdgeObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<Folder>> FolderEdge::getNode(service::Field
 std::future<service::ResolverResult> FolderEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Folder>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<response::Value> FolderEdge::getCursor(service::FieldParams
 std::future<service::ResolverResult> FolderEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getCursor(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/FolderObject.cpp
+++ b/samples/separate_nointrospection/FolderObject.cpp
@@ -38,7 +38,8 @@ service::FieldResult<response::IdType> Folder::getId(service::FieldParams&&) con
 std::future<service::ResolverResult> Folder::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -52,7 +53,8 @@ service::FieldResult<std::optional<response::StringType>> Folder::getName(servic
 std::future<service::ResolverResult> Folder::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getName(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -66,7 +68,8 @@ service::FieldResult<response::IntType> Folder::getUnreadCount(service::FieldPar
 std::future<service::ResolverResult> Folder::resolveUnreadCount(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnreadCount(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnreadCount(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/MutationObject.cpp
+++ b/samples/separate_nointrospection/MutationObject.cpp
@@ -36,7 +36,8 @@ std::future<service::ResolverResult> Mutation::resolveCompleteTask(service::Reso
 {
 	auto argInput = service::ModifiedArgument<today::CompleteTaskInput>::require("input", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = applyCompleteTask(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argInput));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = applyCompleteTask(service::FieldParams(std::move(params), std::move(directives)), std::move(argInput));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<CompleteTaskPayload>::convert(std::move(result), std::move(params));
@@ -51,7 +52,8 @@ std::future<service::ResolverResult> Mutation::resolveSetFloat(service::Resolver
 {
 	auto argValue = service::ModifiedArgument<response::FloatType>::require("value", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = applySetFloat(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argValue));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = applySetFloat(service::FieldParams(std::move(params), std::move(directives)), std::move(argValue));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::FloatType>::convert(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/NestedTypeObject.cpp
+++ b/samples/separate_nointrospection/NestedTypeObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<response::IntType> NestedType::getDepth(service::FieldParam
 std::future<service::ResolverResult> NestedType::resolveDepth(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDepth(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDepth(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<std::shared_ptr<NestedType>> NestedType::getNested(service:
 std::future<service::ResolverResult> NestedType::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNested(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/PageInfoObject.cpp
+++ b/samples/separate_nointrospection/PageInfoObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<response::BooleanType> PageInfo::getHasNextPage(service::Fi
 std::future<service::ResolverResult> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getHasNextPage(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getHasNextPage(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<response::BooleanType> PageInfo::getHasPreviousPage(service
 std::future<service::ResolverResult> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getHasPreviousPage(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getHasPreviousPage(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/QueryObject.cpp
+++ b/samples/separate_nointrospection/QueryObject.cpp
@@ -44,7 +44,8 @@ std::future<service::ResolverResult> Query::resolveNode(service::ResolverParams&
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argId));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)), std::move(argId));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<service::Object>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -62,7 +63,8 @@ std::future<service::ResolverResult> Query::resolveAppointments(service::Resolve
 	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getAppointments(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getAppointments(service::FieldParams(std::move(params), std::move(directives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<AppointmentConnection>::convert(std::move(result), std::move(params));
@@ -80,7 +82,8 @@ std::future<service::ResolverResult> Query::resolveTasks(service::ResolverParams
 	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTasks(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTasks(service::FieldParams(std::move(params), std::move(directives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<TaskConnection>::convert(std::move(result), std::move(params));
@@ -98,7 +101,8 @@ std::future<service::ResolverResult> Query::resolveUnreadCounts(service::Resolve
 	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnreadCounts(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnreadCounts(service::FieldParams(std::move(params), std::move(directives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<FolderConnection>::convert(std::move(result), std::move(params));
@@ -135,7 +139,8 @@ std::future<service::ResolverResult> Query::resolveAppointmentsById(service::Res
 		? std::move(pairIds.first)
 		: service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", defaultArguments));
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getAppointmentsById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getAppointmentsById(service::FieldParams(std::move(params), std::move(directives)), std::move(argIds));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -150,7 +155,8 @@ std::future<service::ResolverResult> Query::resolveTasksById(service::ResolverPa
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTasksById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTasksById(service::FieldParams(std::move(params), std::move(directives)), std::move(argIds));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -165,7 +171,8 @@ std::future<service::ResolverResult> Query::resolveUnreadCountsById(service::Res
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnreadCountsById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnreadCountsById(service::FieldParams(std::move(params), std::move(directives)), std::move(argIds));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Folder>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -179,7 +186,8 @@ service::FieldResult<std::shared_ptr<NestedType>> Query::getNested(service::Fiel
 std::future<service::ResolverResult> Query::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNested(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
@@ -193,7 +201,8 @@ service::FieldResult<response::StringType> Query::getUnimplemented(service::Fiel
 std::future<service::ResolverResult> Query::resolveUnimplemented(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnimplemented(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnimplemented(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
@@ -207,7 +216,8 @@ service::FieldResult<std::vector<std::shared_ptr<Expensive>>> Query::getExpensiv
 std::future<service::ResolverResult> Query::resolveExpensive(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getExpensive(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getExpensive(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Expensive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/SubscriptionObject.cpp
+++ b/samples/separate_nointrospection/SubscriptionObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<Appointment>> Subscription::getNextAppointm
 std::future<service::ResolverResult> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNextAppointmentChange(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNextAppointmentChange(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -50,7 +51,8 @@ std::future<service::ResolverResult> Subscription::resolveNodeChange(service::Re
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNodeChange(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argId));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNodeChange(service::FieldParams(std::move(params), std::move(directives)), std::move(argId));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<service::Object>::convert(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/TaskConnectionObject.cpp
+++ b/samples/separate_nointrospection/TaskConnectionObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<PageInfo>> TaskConnection::getPageInfo(serv
 std::future<service::ResolverResult> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPageInfo(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> Task
 std::future<service::ResolverResult> TaskConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getEdges(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<TaskEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/TaskEdgeObject.cpp
+++ b/samples/separate_nointrospection/TaskEdgeObject.cpp
@@ -35,7 +35,8 @@ service::FieldResult<std::shared_ptr<Task>> TaskEdge::getNode(service::FieldPara
 std::future<service::ResolverResult> TaskEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -49,7 +50,8 @@ service::FieldResult<response::Value> TaskEdge::getCursor(service::FieldParams&&
 std::future<service::ResolverResult> TaskEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getCursor(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));

--- a/samples/separate_nointrospection/TaskObject.cpp
+++ b/samples/separate_nointrospection/TaskObject.cpp
@@ -38,7 +38,8 @@ service::FieldResult<response::IdType> Task::getId(service::FieldParams&&) const
 std::future<service::ResolverResult> Task::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -52,7 +53,8 @@ service::FieldResult<std::optional<response::StringType>> Task::getTitle(service
 std::future<service::ResolverResult> Task::resolveTitle(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTitle(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTitle(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -66,7 +68,8 @@ service::FieldResult<response::BooleanType> Task::getIsComplete(service::FieldPa
 std::future<service::ResolverResult> Task::resolveIsComplete(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getIsComplete(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getIsComplete(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));

--- a/samples/today/TodayMock.cpp
+++ b/samples/today/TodayMock.cpp
@@ -186,10 +186,8 @@ struct EdgeConstraints
 	using vec_type = std::vector<std::shared_ptr<_Object>>;
 	using itr_type = typename vec_type::const_iterator;
 
-	EdgeConstraints(const std::shared_ptr<service::RequestState>& state, service::field_path&& path,
-		const vec_type& objects)
+	EdgeConstraints(const std::shared_ptr<service::RequestState>& state, const vec_type& objects)
 		: _state(state)
-		, _path(std::move(path))
 		, _objects(objects)
 	{
 	}
@@ -240,7 +238,7 @@ struct EdgeConstraints
 
 				error << "Invalid argument: first value: " << *first;
 				throw service::schema_exception {
-					{ service::schema_error { error.str(), {}, _path } }
+					{ service::schema_error { error.str(), {}, {} } }
 				};
 			}
 
@@ -258,7 +256,7 @@ struct EdgeConstraints
 
 				error << "Invalid argument: last value: " << *last;
 				throw service::schema_exception {
-					{ service::schema_error { error.str(), {}, _path } }
+					{ service::schema_error { error.str(), {}, {} } }
 				};
 			}
 
@@ -278,7 +276,6 @@ struct EdgeConstraints
 
 private:
 	const std::shared_ptr<service::RequestState>& _state;
-	const service::field_path _path;
 	const vec_type& _objects;
 };
 
@@ -294,13 +291,10 @@ service::FieldResult<std::shared_ptr<object::AppointmentConnection>> Query::getA
 		[this, spThis, state](std::optional<int>&& firstWrapped,
 			std::optional<response::Value>&& afterWrapped,
 			std::optional<int>&& lastWrapped,
-			std::optional<response::Value>&& beforeWrapped,
-			service::field_path&& path) {
+			std::optional<response::Value>&& beforeWrapped) {
 			loadAppointments(state);
 
-			EdgeConstraints<Appointment, AppointmentConnection> constraints(state,
-				std::move(path),
-				_appointments);
+			EdgeConstraints<Appointment, AppointmentConnection> constraints(state, _appointments);
 			auto connection = constraints(firstWrapped, afterWrapped, lastWrapped, beforeWrapped);
 
 			return std::static_pointer_cast<object::AppointmentConnection>(connection);
@@ -308,8 +302,7 @@ service::FieldResult<std::shared_ptr<object::AppointmentConnection>> Query::getA
 		std::move(first),
 		std::move(after),
 		std::move(last),
-		std::move(before),
-		std::move(params.errorPath));
+		std::move(before));
 }
 
 service::FieldResult<std::shared_ptr<object::TaskConnection>> Query::getTasks(
@@ -324,11 +317,10 @@ service::FieldResult<std::shared_ptr<object::TaskConnection>> Query::getTasks(
 		[this, spThis, state](std::optional<int>&& firstWrapped,
 			std::optional<response::Value>&& afterWrapped,
 			std::optional<int>&& lastWrapped,
-			std::optional<response::Value>&& beforeWrapped,
-			service::field_path&& path) {
+			std::optional<response::Value>&& beforeWrapped) {
 			loadTasks(state);
 
-			EdgeConstraints<Task, TaskConnection> constraints(state, std::move(path), _tasks);
+			EdgeConstraints<Task, TaskConnection> constraints(state, _tasks);
 			auto connection = constraints(firstWrapped, afterWrapped, lastWrapped, beforeWrapped);
 
 			return std::static_pointer_cast<object::TaskConnection>(connection);
@@ -336,8 +328,7 @@ service::FieldResult<std::shared_ptr<object::TaskConnection>> Query::getTasks(
 		std::move(first),
 		std::move(after),
 		std::move(last),
-		std::move(before),
-		std::move(params.errorPath));
+		std::move(before));
 }
 
 service::FieldResult<std::shared_ptr<object::FolderConnection>> Query::getUnreadCounts(
@@ -352,13 +343,10 @@ service::FieldResult<std::shared_ptr<object::FolderConnection>> Query::getUnread
 		[this, spThis, state](std::optional<int>&& firstWrapped,
 			std::optional<response::Value>&& afterWrapped,
 			std::optional<int>&& lastWrapped,
-			std::optional<response::Value>&& beforeWrapped,
-			service::field_path&& path) {
+			std::optional<response::Value>&& beforeWrapped) {
 			loadUnreadCounts(state);
 
-			EdgeConstraints<Folder, FolderConnection> constraints(state,
-				std::move(path),
-				_unreadCounts);
+			EdgeConstraints<Folder, FolderConnection> constraints(state, _unreadCounts);
 			auto connection = constraints(firstWrapped, afterWrapped, lastWrapped, beforeWrapped);
 
 			return std::static_pointer_cast<object::FolderConnection>(connection);
@@ -366,8 +354,7 @@ service::FieldResult<std::shared_ptr<object::FolderConnection>> Query::getUnread
 		std::move(first),
 		std::move(after),
 		std::move(last),
-		std::move(before),
-		std::move(params.errorPath));
+		std::move(before));
 }
 
 service::FieldResult<std::vector<std::shared_ptr<object::Appointment>>> Query::getAppointmentsById(

--- a/samples/unified/TodaySchema.cpp
+++ b/samples/unified/TodaySchema.cpp
@@ -122,7 +122,8 @@ std::future<service::ResolverResult> Query::resolveNode(service::ResolverParams&
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argId));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)), std::move(argId));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<service::Object>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -140,7 +141,8 @@ std::future<service::ResolverResult> Query::resolveAppointments(service::Resolve
 	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getAppointments(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getAppointments(service::FieldParams(std::move(params), std::move(directives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<AppointmentConnection>::convert(std::move(result), std::move(params));
@@ -158,7 +160,8 @@ std::future<service::ResolverResult> Query::resolveTasks(service::ResolverParams
 	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTasks(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTasks(service::FieldParams(std::move(params), std::move(directives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<TaskConnection>::convert(std::move(result), std::move(params));
@@ -176,7 +179,8 @@ std::future<service::ResolverResult> Query::resolveUnreadCounts(service::Resolve
 	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnreadCounts(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnreadCounts(service::FieldParams(std::move(params), std::move(directives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<FolderConnection>::convert(std::move(result), std::move(params));
@@ -213,7 +217,8 @@ std::future<service::ResolverResult> Query::resolveAppointmentsById(service::Res
 		? std::move(pairIds.first)
 		: service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", defaultArguments));
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getAppointmentsById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getAppointmentsById(service::FieldParams(std::move(params), std::move(directives)), std::move(argIds));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -228,7 +233,8 @@ std::future<service::ResolverResult> Query::resolveTasksById(service::ResolverPa
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTasksById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTasksById(service::FieldParams(std::move(params), std::move(directives)), std::move(argIds));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -243,7 +249,8 @@ std::future<service::ResolverResult> Query::resolveUnreadCountsById(service::Res
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnreadCountsById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnreadCountsById(service::FieldParams(std::move(params), std::move(directives)), std::move(argIds));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Folder>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -257,7 +264,8 @@ service::FieldResult<std::shared_ptr<NestedType>> Query::getNested(service::Fiel
 std::future<service::ResolverResult> Query::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNested(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
@@ -271,7 +279,8 @@ service::FieldResult<response::StringType> Query::getUnimplemented(service::Fiel
 std::future<service::ResolverResult> Query::resolveUnimplemented(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnimplemented(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnimplemented(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
@@ -285,7 +294,8 @@ service::FieldResult<std::vector<std::shared_ptr<Expensive>>> Query::getExpensiv
 std::future<service::ResolverResult> Query::resolveExpensive(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getExpensive(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getExpensive(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Expensive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
@@ -329,7 +339,8 @@ service::FieldResult<response::BooleanType> PageInfo::getHasNextPage(service::Fi
 std::future<service::ResolverResult> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getHasNextPage(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getHasNextPage(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -343,7 +354,8 @@ service::FieldResult<response::BooleanType> PageInfo::getHasPreviousPage(service
 std::future<service::ResolverResult> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getHasPreviousPage(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getHasPreviousPage(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -373,7 +385,8 @@ service::FieldResult<std::shared_ptr<Appointment>> AppointmentEdge::getNode(serv
 std::future<service::ResolverResult> AppointmentEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -387,7 +400,8 @@ service::FieldResult<response::Value> AppointmentEdge::getCursor(service::FieldP
 std::future<service::ResolverResult> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getCursor(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
@@ -417,7 +431,8 @@ service::FieldResult<std::shared_ptr<PageInfo>> AppointmentConnection::getPageIn
 std::future<service::ResolverResult> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPageInfo(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
@@ -431,7 +446,8 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>
 std::future<service::ResolverResult> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getEdges(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<AppointmentEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -461,7 +477,8 @@ service::FieldResult<std::shared_ptr<Task>> TaskEdge::getNode(service::FieldPara
 std::future<service::ResolverResult> TaskEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -475,7 +492,8 @@ service::FieldResult<response::Value> TaskEdge::getCursor(service::FieldParams&&
 std::future<service::ResolverResult> TaskEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getCursor(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
@@ -505,7 +523,8 @@ service::FieldResult<std::shared_ptr<PageInfo>> TaskConnection::getPageInfo(serv
 std::future<service::ResolverResult> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPageInfo(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
@@ -519,7 +538,8 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> Task
 std::future<service::ResolverResult> TaskConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getEdges(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<TaskEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -549,7 +569,8 @@ service::FieldResult<std::shared_ptr<Folder>> FolderEdge::getNode(service::Field
 std::future<service::ResolverResult> FolderEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Folder>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -563,7 +584,8 @@ service::FieldResult<response::Value> FolderEdge::getCursor(service::FieldParams
 std::future<service::ResolverResult> FolderEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getCursor(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
@@ -593,7 +615,8 @@ service::FieldResult<std::shared_ptr<PageInfo>> FolderConnection::getPageInfo(se
 std::future<service::ResolverResult> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPageInfo(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
@@ -607,7 +630,8 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> Fo
 std::future<service::ResolverResult> FolderConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getEdges(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<FolderEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -637,7 +661,8 @@ service::FieldResult<std::shared_ptr<Task>> CompleteTaskPayload::getTask(service
 std::future<service::ResolverResult> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTask(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTask(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -651,7 +676,8 @@ service::FieldResult<std::optional<response::StringType>> CompleteTaskPayload::g
 std::future<service::ResolverResult> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getClientMutationId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getClientMutationId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -682,7 +708,8 @@ std::future<service::ResolverResult> Mutation::resolveCompleteTask(service::Reso
 {
 	auto argInput = service::ModifiedArgument<today::CompleteTaskInput>::require("input", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = applyCompleteTask(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argInput));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = applyCompleteTask(service::FieldParams(std::move(params), std::move(directives)), std::move(argInput));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<CompleteTaskPayload>::convert(std::move(result), std::move(params));
@@ -697,7 +724,8 @@ std::future<service::ResolverResult> Mutation::resolveSetFloat(service::Resolver
 {
 	auto argValue = service::ModifiedArgument<response::FloatType>::require("value", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = applySetFloat(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argValue));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = applySetFloat(service::FieldParams(std::move(params), std::move(directives)), std::move(argValue));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::FloatType>::convert(std::move(result), std::move(params));
@@ -727,7 +755,8 @@ service::FieldResult<std::shared_ptr<Appointment>> Subscription::getNextAppointm
 std::future<service::ResolverResult> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNextAppointmentChange(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNextAppointmentChange(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -742,7 +771,8 @@ std::future<service::ResolverResult> Subscription::resolveNodeChange(service::Re
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNodeChange(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argId));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNodeChange(service::FieldParams(std::move(params), std::move(directives)), std::move(argId));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<service::Object>::convert(std::move(result), std::move(params));
@@ -777,7 +807,8 @@ service::FieldResult<response::IdType> Appointment::getId(service::FieldParams&&
 std::future<service::ResolverResult> Appointment::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -791,7 +822,8 @@ service::FieldResult<std::optional<response::Value>> Appointment::getWhen(servic
 std::future<service::ResolverResult> Appointment::resolveWhen(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getWhen(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getWhen(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -805,7 +837,8 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getSubjec
 std::future<service::ResolverResult> Appointment::resolveSubject(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getSubject(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getSubject(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -819,7 +852,8 @@ service::FieldResult<response::BooleanType> Appointment::getIsNow(service::Field
 std::future<service::ResolverResult> Appointment::resolveIsNow(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getIsNow(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getIsNow(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -833,7 +867,8 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getForceE
 std::future<service::ResolverResult> Appointment::resolveForceError(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getForceError(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getForceError(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -866,7 +901,8 @@ service::FieldResult<response::IdType> Task::getId(service::FieldParams&&) const
 std::future<service::ResolverResult> Task::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -880,7 +916,8 @@ service::FieldResult<std::optional<response::StringType>> Task::getTitle(service
 std::future<service::ResolverResult> Task::resolveTitle(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTitle(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTitle(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -894,7 +931,8 @@ service::FieldResult<response::BooleanType> Task::getIsComplete(service::FieldPa
 std::future<service::ResolverResult> Task::resolveIsComplete(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getIsComplete(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getIsComplete(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -927,7 +965,8 @@ service::FieldResult<response::IdType> Folder::getId(service::FieldParams&&) con
 std::future<service::ResolverResult> Folder::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -941,7 +980,8 @@ service::FieldResult<std::optional<response::StringType>> Folder::getName(servic
 std::future<service::ResolverResult> Folder::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getName(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -955,7 +995,8 @@ service::FieldResult<response::IntType> Folder::getUnreadCount(service::FieldPar
 std::future<service::ResolverResult> Folder::resolveUnreadCount(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnreadCount(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnreadCount(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
@@ -985,7 +1026,8 @@ service::FieldResult<response::IntType> NestedType::getDepth(service::FieldParam
 std::future<service::ResolverResult> NestedType::resolveDepth(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDepth(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDepth(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
@@ -999,7 +1041,8 @@ service::FieldResult<std::shared_ptr<NestedType>> NestedType::getNested(service:
 std::future<service::ResolverResult> NestedType::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNested(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
@@ -1028,7 +1071,8 @@ service::FieldResult<response::IntType> Expensive::getOrder(service::FieldParams
 std::future<service::ResolverResult> Expensive::resolveOrder(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getOrder(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getOrder(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));

--- a/samples/unified_nointrospection/TodaySchema.cpp
+++ b/samples/unified_nointrospection/TodaySchema.cpp
@@ -119,7 +119,8 @@ std::future<service::ResolverResult> Query::resolveNode(service::ResolverParams&
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argId));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)), std::move(argId));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<service::Object>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -137,7 +138,8 @@ std::future<service::ResolverResult> Query::resolveAppointments(service::Resolve
 	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getAppointments(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getAppointments(service::FieldParams(std::move(params), std::move(directives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<AppointmentConnection>::convert(std::move(result), std::move(params));
@@ -155,7 +157,8 @@ std::future<service::ResolverResult> Query::resolveTasks(service::ResolverParams
 	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTasks(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTasks(service::FieldParams(std::move(params), std::move(directives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<TaskConnection>::convert(std::move(result), std::move(params));
@@ -173,7 +176,8 @@ std::future<service::ResolverResult> Query::resolveUnreadCounts(service::Resolve
 	auto argLast = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("last", params.arguments);
 	auto argBefore = service::ModifiedArgument<response::Value>::require<service::TypeModifier::Nullable>("before", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnreadCounts(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnreadCounts(service::FieldParams(std::move(params), std::move(directives)), std::move(argFirst), std::move(argAfter), std::move(argLast), std::move(argBefore));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<FolderConnection>::convert(std::move(result), std::move(params));
@@ -210,7 +214,8 @@ std::future<service::ResolverResult> Query::resolveAppointmentsById(service::Res
 		? std::move(pairIds.first)
 		: service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", defaultArguments));
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getAppointmentsById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getAppointmentsById(service::FieldParams(std::move(params), std::move(directives)), std::move(argIds));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -225,7 +230,8 @@ std::future<service::ResolverResult> Query::resolveTasksById(service::ResolverPa
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTasksById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTasksById(service::FieldParams(std::move(params), std::move(directives)), std::move(argIds));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -240,7 +246,8 @@ std::future<service::ResolverResult> Query::resolveUnreadCountsById(service::Res
 {
 	auto argIds = service::ModifiedArgument<response::IdType>::require<service::TypeModifier::List>("ids", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnreadCountsById(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIds));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnreadCountsById(service::FieldParams(std::move(params), std::move(directives)), std::move(argIds));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Folder>::convert<service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -254,7 +261,8 @@ service::FieldResult<std::shared_ptr<NestedType>> Query::getNested(service::Fiel
 std::future<service::ResolverResult> Query::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNested(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
@@ -268,7 +276,8 @@ service::FieldResult<response::StringType> Query::getUnimplemented(service::Fiel
 std::future<service::ResolverResult> Query::resolveUnimplemented(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnimplemented(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnimplemented(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
@@ -282,7 +291,8 @@ service::FieldResult<std::vector<std::shared_ptr<Expensive>>> Query::getExpensiv
 std::future<service::ResolverResult> Query::resolveExpensive(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getExpensive(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getExpensive(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Expensive>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
@@ -312,7 +322,8 @@ service::FieldResult<response::BooleanType> PageInfo::getHasNextPage(service::Fi
 std::future<service::ResolverResult> PageInfo::resolveHasNextPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getHasNextPage(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getHasNextPage(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -326,7 +337,8 @@ service::FieldResult<response::BooleanType> PageInfo::getHasPreviousPage(service
 std::future<service::ResolverResult> PageInfo::resolveHasPreviousPage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getHasPreviousPage(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getHasPreviousPage(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -356,7 +368,8 @@ service::FieldResult<std::shared_ptr<Appointment>> AppointmentEdge::getNode(serv
 std::future<service::ResolverResult> AppointmentEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -370,7 +383,8 @@ service::FieldResult<response::Value> AppointmentEdge::getCursor(service::FieldP
 std::future<service::ResolverResult> AppointmentEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getCursor(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
@@ -400,7 +414,8 @@ service::FieldResult<std::shared_ptr<PageInfo>> AppointmentConnection::getPageIn
 std::future<service::ResolverResult> AppointmentConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPageInfo(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
@@ -414,7 +429,8 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>
 std::future<service::ResolverResult> AppointmentConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getEdges(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<AppointmentEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -444,7 +460,8 @@ service::FieldResult<std::shared_ptr<Task>> TaskEdge::getNode(service::FieldPara
 std::future<service::ResolverResult> TaskEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -458,7 +475,8 @@ service::FieldResult<response::Value> TaskEdge::getCursor(service::FieldParams&&
 std::future<service::ResolverResult> TaskEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getCursor(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
@@ -488,7 +506,8 @@ service::FieldResult<std::shared_ptr<PageInfo>> TaskConnection::getPageInfo(serv
 std::future<service::ResolverResult> TaskConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPageInfo(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
@@ -502,7 +521,8 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> Task
 std::future<service::ResolverResult> TaskConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getEdges(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<TaskEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -532,7 +552,8 @@ service::FieldResult<std::shared_ptr<Folder>> FolderEdge::getNode(service::Field
 std::future<service::ResolverResult> FolderEdge::resolveNode(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNode(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNode(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Folder>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -546,7 +567,8 @@ service::FieldResult<response::Value> FolderEdge::getCursor(service::FieldParams
 std::future<service::ResolverResult> FolderEdge::resolveCursor(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getCursor(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getCursor(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert(std::move(result), std::move(params));
@@ -576,7 +598,8 @@ service::FieldResult<std::shared_ptr<PageInfo>> FolderConnection::getPageInfo(se
 std::future<service::ResolverResult> FolderConnection::resolvePageInfo(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPageInfo(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPageInfo(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<PageInfo>::convert(std::move(result), std::move(params));
@@ -590,7 +613,8 @@ service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> Fo
 std::future<service::ResolverResult> FolderConnection::resolveEdges(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getEdges(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getEdges(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<FolderEdge>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -620,7 +644,8 @@ service::FieldResult<std::shared_ptr<Task>> CompleteTaskPayload::getTask(service
 std::future<service::ResolverResult> CompleteTaskPayload::resolveTask(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTask(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTask(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Task>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -634,7 +659,8 @@ service::FieldResult<std::optional<response::StringType>> CompleteTaskPayload::g
 std::future<service::ResolverResult> CompleteTaskPayload::resolveClientMutationId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getClientMutationId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getClientMutationId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -665,7 +691,8 @@ std::future<service::ResolverResult> Mutation::resolveCompleteTask(service::Reso
 {
 	auto argInput = service::ModifiedArgument<today::CompleteTaskInput>::require("input", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = applyCompleteTask(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argInput));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = applyCompleteTask(service::FieldParams(std::move(params), std::move(directives)), std::move(argInput));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<CompleteTaskPayload>::convert(std::move(result), std::move(params));
@@ -680,7 +707,8 @@ std::future<service::ResolverResult> Mutation::resolveSetFloat(service::Resolver
 {
 	auto argValue = service::ModifiedArgument<response::FloatType>::require("value", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = applySetFloat(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argValue));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = applySetFloat(service::FieldParams(std::move(params), std::move(directives)), std::move(argValue));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::FloatType>::convert(std::move(result), std::move(params));
@@ -710,7 +738,8 @@ service::FieldResult<std::shared_ptr<Appointment>> Subscription::getNextAppointm
 std::future<service::ResolverResult> Subscription::resolveNextAppointmentChange(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNextAppointmentChange(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNextAppointmentChange(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Appointment>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -725,7 +754,8 @@ std::future<service::ResolverResult> Subscription::resolveNodeChange(service::Re
 {
 	auto argId = service::ModifiedArgument<response::IdType>::require("id", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNodeChange(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argId));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNodeChange(service::FieldParams(std::move(params), std::move(directives)), std::move(argId));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<service::Object>::convert(std::move(result), std::move(params));
@@ -760,7 +790,8 @@ service::FieldResult<response::IdType> Appointment::getId(service::FieldParams&&
 std::future<service::ResolverResult> Appointment::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -774,7 +805,8 @@ service::FieldResult<std::optional<response::Value>> Appointment::getWhen(servic
 std::future<service::ResolverResult> Appointment::resolveWhen(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getWhen(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getWhen(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::Value>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -788,7 +820,8 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getSubjec
 std::future<service::ResolverResult> Appointment::resolveSubject(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getSubject(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getSubject(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -802,7 +835,8 @@ service::FieldResult<response::BooleanType> Appointment::getIsNow(service::Field
 std::future<service::ResolverResult> Appointment::resolveIsNow(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getIsNow(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getIsNow(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -816,7 +850,8 @@ service::FieldResult<std::optional<response::StringType>> Appointment::getForceE
 std::future<service::ResolverResult> Appointment::resolveForceError(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getForceError(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getForceError(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -849,7 +884,8 @@ service::FieldResult<response::IdType> Task::getId(service::FieldParams&&) const
 std::future<service::ResolverResult> Task::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -863,7 +899,8 @@ service::FieldResult<std::optional<response::StringType>> Task::getTitle(service
 std::future<service::ResolverResult> Task::resolveTitle(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getTitle(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getTitle(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -877,7 +914,8 @@ service::FieldResult<response::BooleanType> Task::getIsComplete(service::FieldPa
 std::future<service::ResolverResult> Task::resolveIsComplete(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getIsComplete(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getIsComplete(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -910,7 +948,8 @@ service::FieldResult<response::IdType> Folder::getId(service::FieldParams&&) con
 std::future<service::ResolverResult> Folder::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -924,7 +963,8 @@ service::FieldResult<std::optional<response::StringType>> Folder::getName(servic
 std::future<service::ResolverResult> Folder::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getName(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -938,7 +978,8 @@ service::FieldResult<response::IntType> Folder::getUnreadCount(service::FieldPar
 std::future<service::ResolverResult> Folder::resolveUnreadCount(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getUnreadCount(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getUnreadCount(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
@@ -968,7 +1009,8 @@ service::FieldResult<response::IntType> NestedType::getDepth(service::FieldParam
 std::future<service::ResolverResult> NestedType::resolveDepth(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDepth(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDepth(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
@@ -982,7 +1024,8 @@ service::FieldResult<std::shared_ptr<NestedType>> NestedType::getNested(service:
 std::future<service::ResolverResult> NestedType::resolveNested(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNested(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNested(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<NestedType>::convert(std::move(result), std::move(params));
@@ -1011,7 +1054,8 @@ service::FieldResult<response::IntType> Expensive::getOrder(service::FieldParams
 std::future<service::ResolverResult> Expensive::resolveOrder(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getOrder(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getOrder(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));

--- a/samples/validation/ValidationSchema.cpp
+++ b/samples/validation/ValidationSchema.cpp
@@ -137,7 +137,8 @@ service::FieldResult<std::shared_ptr<Dog>> Query::getDog(service::FieldParams&&)
 std::future<service::ResolverResult> Query::resolveDog(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDog(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDog(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Dog>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -151,7 +152,8 @@ service::FieldResult<std::shared_ptr<Human>> Query::getHuman(service::FieldParam
 std::future<service::ResolverResult> Query::resolveHuman(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getHuman(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getHuman(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Human>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -165,7 +167,8 @@ service::FieldResult<std::shared_ptr<service::Object>> Query::getPet(service::Fi
 std::future<service::ResolverResult> Query::resolvePet(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPet(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPet(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<service::Object>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -179,7 +182,8 @@ service::FieldResult<std::shared_ptr<service::Object>> Query::getCatOrDog(servic
 std::future<service::ResolverResult> Query::resolveCatOrDog(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getCatOrDog(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getCatOrDog(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<service::Object>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -193,7 +197,8 @@ service::FieldResult<std::shared_ptr<Arguments>> Query::getArguments(service::Fi
 std::future<service::ResolverResult> Query::resolveArguments(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getArguments(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getArguments(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Arguments>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -208,7 +213,8 @@ std::future<service::ResolverResult> Query::resolveFindDog(service::ResolverPara
 {
 	auto argComplex = service::ModifiedArgument<validation::ComplexInput>::require<service::TypeModifier::Nullable>("complex", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getFindDog(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argComplex));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getFindDog(service::FieldParams(std::move(params), std::move(directives)), std::move(argComplex));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Dog>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -223,7 +229,8 @@ std::future<service::ResolverResult> Query::resolveBooleanList(service::Resolver
 {
 	auto argBooleanListArg = service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable, service::TypeModifier::List>("booleanListArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getBooleanList(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argBooleanListArg));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getBooleanList(service::FieldParams(std::move(params), std::move(directives)), std::move(argBooleanListArg));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -274,7 +281,8 @@ service::FieldResult<response::StringType> Dog::getName(service::FieldParams&&) 
 std::future<service::ResolverResult> Dog::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getName(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
@@ -288,7 +296,8 @@ service::FieldResult<std::optional<response::StringType>> Dog::getNickname(servi
 std::future<service::ResolverResult> Dog::resolveNickname(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNickname(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNickname(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -302,7 +311,8 @@ service::FieldResult<std::optional<response::IntType>> Dog::getBarkVolume(servic
 std::future<service::ResolverResult> Dog::resolveBarkVolume(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getBarkVolume(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getBarkVolume(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -317,7 +327,8 @@ std::future<service::ResolverResult> Dog::resolveDoesKnowCommand(service::Resolv
 {
 	auto argDogCommand = service::ModifiedArgument<DogCommand>::require("dogCommand", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDoesKnowCommand(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argDogCommand));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDoesKnowCommand(service::FieldParams(std::move(params), std::move(directives)), std::move(argDogCommand));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -332,7 +343,8 @@ std::future<service::ResolverResult> Dog::resolveIsHousetrained(service::Resolve
 {
 	auto argAtOtherHomes = service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable>("atOtherHomes", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getIsHousetrained(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argAtOtherHomes));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getIsHousetrained(service::FieldParams(std::move(params), std::move(directives)), std::move(argAtOtherHomes));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -346,7 +358,8 @@ service::FieldResult<std::shared_ptr<Human>> Dog::getOwner(service::FieldParams&
 std::future<service::ResolverResult> Dog::resolveOwner(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getOwner(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getOwner(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Human>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -378,7 +391,8 @@ service::FieldResult<response::StringType> Alien::getName(service::FieldParams&&
 std::future<service::ResolverResult> Alien::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getName(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
@@ -392,7 +406,8 @@ service::FieldResult<std::optional<response::StringType>> Alien::getHomePlanet(s
 std::future<service::ResolverResult> Alien::resolveHomePlanet(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getHomePlanet(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getHomePlanet(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -425,7 +440,8 @@ service::FieldResult<response::StringType> Human::getName(service::FieldParams&&
 std::future<service::ResolverResult> Human::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getName(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
@@ -439,7 +455,8 @@ service::FieldResult<std::vector<std::shared_ptr<service::Object>>> Human::getPe
 std::future<service::ResolverResult> Human::resolvePets(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getPets(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getPets(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<service::Object>::convert<service::TypeModifier::List>(std::move(result), std::move(params));
@@ -473,7 +490,8 @@ service::FieldResult<response::StringType> Cat::getName(service::FieldParams&&) 
 std::future<service::ResolverResult> Cat::resolveName(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getName(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getName(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert(std::move(result), std::move(params));
@@ -487,7 +505,8 @@ service::FieldResult<std::optional<response::StringType>> Cat::getNickname(servi
 std::future<service::ResolverResult> Cat::resolveNickname(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNickname(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNickname(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -502,7 +521,8 @@ std::future<service::ResolverResult> Cat::resolveDoesKnowCommand(service::Resolv
 {
 	auto argCatCommand = service::ModifiedArgument<CatCommand>::require("catCommand", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDoesKnowCommand(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argCatCommand));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDoesKnowCommand(service::FieldParams(std::move(params), std::move(directives)), std::move(argCatCommand));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -516,7 +536,8 @@ service::FieldResult<std::optional<response::IntType>> Cat::getMeowVolume(servic
 std::future<service::ResolverResult> Cat::resolveMeowVolume(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getMeowVolume(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getMeowVolume(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -545,7 +566,8 @@ service::FieldResult<std::shared_ptr<MutateDogResult>> Mutation::applyMutateDog(
 std::future<service::ResolverResult> Mutation::resolveMutateDog(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = applyMutateDog(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = applyMutateDog(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<MutateDogResult>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -574,7 +596,8 @@ service::FieldResult<response::IdType> MutateDogResult::getId(service::FieldPara
 std::future<service::ResolverResult> MutateDogResult::resolveId(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getId(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getId(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -604,7 +627,8 @@ service::FieldResult<std::shared_ptr<Message>> Subscription::getNewMessage(servi
 std::future<service::ResolverResult> Subscription::resolveNewMessage(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNewMessage(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNewMessage(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<Message>::convert(std::move(result), std::move(params));
@@ -618,7 +642,8 @@ service::FieldResult<response::BooleanType> Subscription::getDisallowedSecondRoo
 std::future<service::ResolverResult> Subscription::resolveDisallowedSecondRootField(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getDisallowedSecondRootField(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getDisallowedSecondRootField(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -648,7 +673,8 @@ service::FieldResult<std::optional<response::StringType>> Message::getBody(servi
 std::future<service::ResolverResult> Message::resolveBody(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getBody(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getBody(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::StringType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -662,7 +688,8 @@ service::FieldResult<response::IdType> Message::getSender(service::FieldParams&&
 std::future<service::ResolverResult> Message::resolveSender(service::ResolverParams&& params)
 {
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getSender(service::FieldParams(params, std::move(params.fieldDirectives)));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getSender(service::FieldParams(std::move(params), std::move(directives)));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IdType>::convert(std::move(result), std::move(params));
@@ -700,7 +727,8 @@ std::future<service::ResolverResult> Arguments::resolveMultipleReqs(service::Res
 	auto argX = service::ModifiedArgument<response::IntType>::require("x", params.arguments);
 	auto argY = service::ModifiedArgument<response::IntType>::require("y", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getMultipleReqs(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argX), std::move(argY));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getMultipleReqs(service::FieldParams(std::move(params), std::move(directives)), std::move(argX), std::move(argY));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert(std::move(result), std::move(params));
@@ -715,7 +743,8 @@ std::future<service::ResolverResult> Arguments::resolveBooleanArgField(service::
 {
 	auto argBooleanArg = service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable>("booleanArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getBooleanArgField(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argBooleanArg));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getBooleanArgField(service::FieldParams(std::move(params), std::move(directives)), std::move(argBooleanArg));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -730,7 +759,8 @@ std::future<service::ResolverResult> Arguments::resolveFloatArgField(service::Re
 {
 	auto argFloatArg = service::ModifiedArgument<response::FloatType>::require<service::TypeModifier::Nullable>("floatArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getFloatArgField(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argFloatArg));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getFloatArgField(service::FieldParams(std::move(params), std::move(directives)), std::move(argFloatArg));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::FloatType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -745,7 +775,8 @@ std::future<service::ResolverResult> Arguments::resolveIntArgField(service::Reso
 {
 	auto argIntArg = service::ModifiedArgument<response::IntType>::require<service::TypeModifier::Nullable>("intArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getIntArgField(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argIntArg));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getIntArgField(service::FieldParams(std::move(params), std::move(directives)), std::move(argIntArg));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::IntType>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -760,7 +791,8 @@ std::future<service::ResolverResult> Arguments::resolveNonNullBooleanArgField(se
 {
 	auto argNonNullBooleanArg = service::ModifiedArgument<response::BooleanType>::require("nonNullBooleanArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNonNullBooleanArgField(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argNonNullBooleanArg));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNonNullBooleanArgField(service::FieldParams(std::move(params), std::move(directives)), std::move(argNonNullBooleanArg));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));
@@ -775,7 +807,8 @@ std::future<service::ResolverResult> Arguments::resolveNonNullBooleanListField(s
 {
 	auto argNonNullBooleanListArg = service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::Nullable, service::TypeModifier::List>("nonNullBooleanListArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getNonNullBooleanListField(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argNonNullBooleanListArg));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getNonNullBooleanListField(service::FieldParams(std::move(params), std::move(directives)), std::move(argNonNullBooleanListArg));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert<service::TypeModifier::Nullable, service::TypeModifier::List>(std::move(result), std::move(params));
@@ -790,7 +823,8 @@ std::future<service::ResolverResult> Arguments::resolveBooleanListArgField(servi
 {
 	auto argBooleanListArg = service::ModifiedArgument<response::BooleanType>::require<service::TypeModifier::List, service::TypeModifier::Nullable>("booleanListArg", params.arguments);
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getBooleanListArgField(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argBooleanListArg));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getBooleanListArgField(service::FieldParams(std::move(params), std::move(directives)), std::move(argBooleanListArg));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert<service::TypeModifier::Nullable, service::TypeModifier::List, service::TypeModifier::Nullable>(std::move(result), std::move(params));
@@ -819,7 +853,8 @@ std::future<service::ResolverResult> Arguments::resolveOptionalNonNullBooleanArg
 		? std::move(pairOptionalBooleanArg.first)
 		: service::ModifiedArgument<response::BooleanType>::require("optionalBooleanArg", defaultArguments));
 	std::unique_lock resolverLock(_resolverMutex);
-	auto result = getOptionalNonNullBooleanArgField(service::FieldParams(params, std::move(params.fieldDirectives)), std::move(argOptionalBooleanArg));
+	auto directives = std::move(params.fieldDirectives);
+	auto result = getOptionalNonNullBooleanArgField(service::FieldParams(std::move(params), std::move(directives)), std::move(argOptionalBooleanArg));
 	resolverLock.unlock();
 
 	return service::ModifiedResult<response::BooleanType>::convert(std::move(result), std::move(params));

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -1253,14 +1253,14 @@ std::future<ResolverResult> Object::resolve(const SelectionSetParams& selectionS
 				try
 				{
 					auto value = child.second.get();
-					auto itrData = document.data.find(name);
 
-					if (itrData == document.data.end())
+					try
 					{
 						document.data.emplace_back(std::string { name }, std::move(value.data));
 					}
-					else if (itrData->second != value.data)
+					catch (std::runtime_error& e)
 					{
+						// Duplicate Map member
 						std::ostringstream message;
 
 						message << "Ambiguous field error name: " << name;
@@ -1301,9 +1301,13 @@ std::future<ResolverResult> Object::resolve(const SelectionSetParams& selectionS
 						}
 					}
 
-					if (document.data.find(name) == document.data.end())
+					try
 					{
 						document.data.emplace_back(std::string { name }, {});
+					}
+					catch (std::runtime_error& e)
+					{
+						// Duplicate Map member
 					}
 				}
 				catch (const std::exception& ex)
@@ -1320,9 +1324,13 @@ std::future<ResolverResult> Object::resolve(const SelectionSetParams& selectionS
 					document.errors.push_back(
 						{ message.str(), std::move(location), std::move(path) });
 
-					if (document.data.find(name) == document.data.end())
+					try
 					{
 						document.data.emplace_back(std::string { name }, {});
+					}
+					catch (std::runtime_error& e)
+					{
+						// Duplicate Map member
 					}
 				}
 

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -752,11 +752,7 @@ std::future<ResolverResult> ModifiedResult<response::IntType>::convert(
 {
 	blockSubFields(params);
 
-	return resolve(std::move(result),
-		std::move(params),
-		[](response::IntType&& value, const ResolverParams&) {
-			return response::Value(value);
-		});
+	return result.get_future_result();
 }
 
 template <>
@@ -765,11 +761,7 @@ std::future<ResolverResult> ModifiedResult<response::FloatType>::convert(
 {
 	blockSubFields(params);
 
-	return resolve(std::move(result),
-		std::move(params),
-		[](response::FloatType&& value, const ResolverParams&) {
-			return response::Value(value);
-		});
+	return result.get_future_result();
 }
 
 template <>
@@ -778,11 +770,7 @@ std::future<ResolverResult> ModifiedResult<response::StringType>::convert(
 {
 	blockSubFields(params);
 
-	return resolve(std::move(result),
-		std::move(params),
-		[](response::StringType&& value, const ResolverParams&) {
-			return response::Value(std::move(value));
-		});
+	return result.get_future_result();
 }
 
 template <>
@@ -791,11 +779,7 @@ std::future<ResolverResult> ModifiedResult<response::BooleanType>::convert(
 {
 	blockSubFields(params);
 
-	return resolve(std::move(result),
-		std::move(params),
-		[](response::BooleanType&& value, const ResolverParams&) {
-			return response::Value(value);
-		});
+	return result.get_future_result();
 }
 
 template <>
@@ -804,11 +788,7 @@ std::future<ResolverResult> ModifiedResult<response::Value>::convert(
 {
 	blockSubFields(params);
 
-	return resolve(std::move(result),
-		std::move(params),
-		[](response::Value&& value, const ResolverParams&) {
-			return response::Value(std::move(value));
-		});
+	return result.get_future_result();
 }
 
 template <>
@@ -817,11 +797,9 @@ std::future<ResolverResult> ModifiedResult<response::IdType>::convert(
 {
 	blockSubFields(params);
 
-	return resolve(std::move(result),
-		std::move(params),
-		[](response::IdType&& value, const ResolverParams&) {
-			return response::Value(Base64::toBase64(value));
-		});
+	std::string (*converter)(const response::IdType&) = &Base64::toBase64;
+
+	return result.get_future_result(converter);
 }
 
 void requireSubFields(const ResolverParams& params)

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -147,6 +147,12 @@ FieldParams::FieldParams(const SelectionSetParams& selectionSetParams, response:
 {
 }
 
+FieldParams::FieldParams(SelectionSetParams&& selectionSetParams, response::Value&& directives)
+	: SelectionSetParams(std::move(selectionSetParams))
+	, fieldDirectives(std::move(directives))
+{
+}
+
 // ValueVisitor visits the AST and builds a response::Value representation of any value
 // hardcoded or referencing a variable in an operation.
 class ValueVisitor

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -3020,9 +3020,10 @@ std::future<service::ResolverResult> )cpp"
 		}
 
 		sourceFile << R"cpp(	std::unique_lock resolverLock(_resolverMutex);
+	auto directives = std::move(params.fieldDirectives);
 	auto result = )cpp"
 				   << outputField.accessor << fieldName
-				   << R"cpp((service::FieldParams(params, std::move(params.fieldDirectives)))cpp";
+				   << R"cpp((service::FieldParams(std::move(params), std::move(directives)))cpp";
 
 		if (!outputField.arguments.empty())
 		{


### PR DESCRIPTION
This is a remake of my previous PR on top of bd725ac6a74bf7376d108b0f21cc1ee00daac66c to address #138.

`BREAKING SelectionSetParams optimized` is a key commit as it turns the `errorPath` from a vector that is copied to a reference to the parent, creating the array on demand. **HOWEVER** something weird happens: although it uses less memory and works faster, the `t-gmax` DHAT is showing an **increase**, looking at the report I can't see what's happening and I'll investigate further before I open the final PR (still in DRAFT). If you can see something in that commit, let me know.

The last commit `optimize ast_node` is a hackish port of my previous code, I'll clean it up based on the latest changes (unescape). However it does improve the allocations in a good way.

Other commits all improve a little bit the situation, the most important is `optimize converters for FieldResult`.

Closes #138