### PR TITLE
Add GitHub Actions workflows for CI and PR validation

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,10 +17,10 @@ jobs:
         submodules: true
 
     - name: Install Dependencies
-      run: sudo apt-get update && sudo apt-get install -yq libgtest-dev libboost-program-options-dev rapidjson-dev
+      run: sudo apt-get update && sudo apt-get install -yq libgtest-dev libboost-program-options-dev rapidjson-dev ninja-build
 
     - name: Build GTest
-      run: cmake -E make_directory gtest && cd gtest && cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} /usr/src/gtest && cmake --build . -j -v && sudo cmake --install .
+      run: cmake -E make_directory gtest && cd gtest && cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -G Ninja /usr/src/gtest && cmake --build . -j -v && sudo cmake --install .
 
     - name: Create Build Environment
       run: cmake -E make_directory build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [Debug, Release]
+        config: [Debug, Release]
 
     runs-on: ubuntu-latest
 
@@ -20,14 +20,14 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -yq libgtest-dev libboost-program-options-dev rapidjson-dev ninja-build
 
     - name: Build GTest
-      run: cmake -E make_directory gtest && cd gtest && cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -G Ninja /usr/src/gtest && cmake --build . -j -v && sudo cmake --install .
+      run: cmake -E make_directory gtest && cd gtest && cmake -DCMAKE_BUILD_TYPE=${{ matrix.config }} -G Ninja /usr/src/gtest && cmake --build . -j -v && sudo cmake --install .
 
     - name: Create Build Environment
       run: cmake -E make_directory build
 
     - name: Configure CMake
       working-directory: build
-      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -G Ninja $GITHUB_WORKSPACE
+      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.config }} -G Ninja $GITHUB_WORKSPACE
 
     - name: Build the Project
       working-directory: build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ jobs:
         submodules: true
 
     - name: Install Dependencies
-      run: sudo apt-get update && sudo apt-get install -yq googletest libboost-program-options-dev rapidjson-dev
+      run: sudo apt-get update && sudo apt-get install -yq libgtest-dev libboost-program-options-dev rapidjson-dev
 
     - name: Create Build Environment
       run: cmake -E make_directory build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,12 +19,15 @@ jobs:
     - name: Install Dependencies
       run: sudo apt-get update && sudo apt-get install -yq libgtest-dev libboost-program-options-dev rapidjson-dev
 
+    - name: Build GTest
+      run: cmake -E make_directory gtest && cd gtest && cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} /usr/src/gtest && cmake --build . -j -v && sudo cmake --install .
+
     - name: Create Build Environment
       run: cmake -E make_directory build
 
     - name: Configure CMake
       working-directory: build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -G Ninja $GITHUB_WORKSPACE
 
     - name: Build the Project
       working-directory: build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,7 +3,7 @@ name: Linux
 on: [push, pull_request]
 
 jobs:
-  Linux:
+  gcc7:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,22 +17,29 @@ jobs:
         submodules: true
 
     - name: Install Dependencies
-      run: sudo apt-get update && sudo apt-get install -yq libgtest-dev libboost-program-options-dev rapidjson-dev ninja-build
+      run: |
+        sudo apt-get update
+        sudo apt-get install -yq libgtest-dev libboost-program-options-dev rapidjson-dev ninja-build
 
     - name: Build GTest
-      run: cmake -E make_directory gtest && cd gtest && cmake -DCMAKE_BUILD_TYPE=${{ matrix.config }} -G Ninja /usr/src/gtest && cmake --build . -j -v && sudo cmake --install .
+      run: |
+        cmake -E make_directory gtest
+        cd gtest
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.config }} -G Ninja /usr/src/gtest
+        cmake --build . -j -v
+        sudo cmake --install .
 
     - name: Create Build Environment
       run: cmake -E make_directory build
 
     - name: Configure CMake
       working-directory: build
-      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.config }} -G Ninja $GITHUB_WORKSPACE
+      run: cmake -G Ninja ${{ github.workspace }}
 
-    - name: Build the Project
+    - name: Build
       working-directory: build
-      run: cmake --build . -j -v
+      run: cmake --build . --config ${{ matrix.config }} -j -v
 
-    - name: Run the Tests
+    - name: Test
       working-directory: build
-      run: ctest --output-on-failure
+      run: ctest -C ${{ matrix.config }} --output-on-failure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,7 +3,7 @@ name: Linux
 on: [push, pull_request]
 
 jobs:
-  linux:
+  Linux:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,13 +33,17 @@ jobs:
       run: cmake -E make_directory build
 
     - name: Configure CMake
-      working-directory: build
-      run: cmake -G Ninja ${{ github.workspace }}
+      shell: pwsh
+      working-directory: build/
+      run: |
+        $cmakeBuildType = '${{ matrix.config }}'
+
+        cmake "-DCMAKE_BUILD_TYPE=$cmakeBuildType" -G Ninja ${{ github.workspace }}
 
     - name: Build
-      working-directory: build
-      run: cmake --build . --config ${{ matrix.config }} -j -v
+      working-directory: build/
+      run: cmake --build . -j -v
 
     - name: Test
-      working-directory: build
-      run: ctest -C ${{ matrix.config }} --output-on-failure
+      working-directory: build/
+      run: ctest --output-on-failure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,33 @@
+name: Linux
+
+on: [push, pull_request]
+
+jobs:
+  linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: sudo apt-get update && sudo apt-get install -yq googletest libboost-program-options-dev rapidjson-dev
+
+    - name: Create Build Environment
+      run: cmake -E make_directory build
+
+    - name: Configure CMake
+      working-directory: build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+    - name: Build the Project
+      working-directory: build
+      run: cmake --build . -j -v
+
+    - name: Run the Tests
+      working-directory: build
+      run: ctest --output-on-failure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
 
     - name: Install Dependencies
       run: sudo apt-get update && sudo apt-get install -yq googletest libboost-program-options-dev rapidjson-dev

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,13 +41,14 @@ jobs:
       working-directory: build/
       run: |
         $vcpkgToolchain = Join-Path '../vcpkg' './scripts/buildsystems/vcpkg.cmake' -Resolve
+        $cmakeBuildType = '${{ matrix.config }}'
 
-        cmake "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" ${{ github.workspace }}
+        cmake "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" "-DCMAKE_BUILD_TYPE=$cmakeBuildType" ${{ github.workspace }}
 
     - name: Build
       working-directory: build/
-      run: cmake --build . --config ${{ matrix.config }} -v
+      run: cmake --build . -j -v
 
     - name: Test
       working-directory: build/
-      run: ctest -C ${{ matrix.config }} --output-on-failure
+      run: ctest --output-on-failure

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,14 +44,10 @@ jobs:
 
         cmake "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" ${{ github.workspace }}
 
-    - name: Configure
-      working-directory: build/
-      run: cmake $GITHUB_WORKSPACE
-
     - name: Build
       working-directory: build/
-      run: cmake --build . --config ${{ matrix.build_type }} -j -v
+      run: cmake --build . --config ${{ matrix.config }} -v
 
     - name: Test
       working-directory: build/
-      run: ctest --config ${{ matrix.build_type }} --output-on-failure
+      run: ctest -C ${{ matrix.config }} --output-on-failure

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,57 @@
+name: macOS
+
+on: [push, pull_request]
+
+jobs:
+  xcode:
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [Debug, Release]
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Cache vcpkg
+      uses: actions/cache@v2
+      id: cache-vcpkg
+      with:
+        path: vcpkg/
+        key: vcpkg-x64-osx
+
+    - name: Install Dependencies
+      if: ${{ !steps.cache-vcpkg.outputs.cache-hit }}
+      shell: pwsh
+      run: |
+        git clone https://github.com/microsoft/vcpkg
+        cd vcpkg
+        ./bootstrap-vcpkg.sh -allowAppleClang
+        ./vcpkg integrate install
+        ./vcpkg install boost-program-options rapidjson gtest
+
+    - name: Create Build Environment
+      run: cmake -E make_directory build
+
+    - name: Configure
+      shell: pwsh
+      working-directory: build/
+      run: |
+        $vcpkgToolchain = Join-Path '../vcpkg' './scripts/buildsystems/vcpkg.cmake' -Resolve
+
+        cmake "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" ${{ github.workspace }}
+
+    - name: Configure
+      working-directory: build/
+      run: cmake $GITHUB_WORKSPACE
+
+    - name: Build
+      working-directory: build/
+      run: cmake --build . --config ${{ matrix.build_type }} -j -v
+
+    - name: Test
+      working-directory: build/
+      run: ctest --config ${{ matrix.build_type }} --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,13 +3,13 @@ name: Windows
 on: [push, pull_request]
 
 jobs:
-  vs2019:
+  Windows:
     strategy:
       fail-fast: false
       matrix:
-        build_type: ['Debug', 'Release']
         arch: ['x86', 'x64']
-        build_dlls: ['$true', '$false']
+        libs: ['shared', 'static']
+        config: ['Debug', 'Release']
 
     runs-on: windows-latest
 
@@ -22,8 +22,8 @@ jobs:
       id: set-variables
       shell: pwsh
       run: |
-        echo "::set-output name=vcpkg_triplet::${{ matrix.arch }}-windows$(if (${{ matrix.build_dlls }}) { '' } else { '-static' })"
-        echo "::set-output name=build_shared::$(if (${{ matrix.build_dlls }}) { 'ON' } else { 'OFF' })"
+        echo "::set-output name=vcpkg_triplet::${{ matrix.arch }}-windows$(if ('${{ matrix.libs }}' -eq 'static') { '-static' })"
+        echo "::set-output name=build_shared::$(if ('${{ matrix.libs }}' -eq 'shared') { 'ON' } else { 'OFF' })"
         echo "::set-output name=build_arch::$(if ('${{ matrix.arch }}' -eq 'x64') { 'X64' } else { 'Win32' })"
 
     - name: Cache vcpkg and dependencies
@@ -47,14 +47,13 @@ jobs:
       run: cmake -E make_directory build
 
     - name: Configure
-      if: ${{ matrix.vcpkg_triplet == 'x86-windows' }}
       working-directory: build/
       run: cmake -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_SHARED_LIBS=${{ steps.set-variables.outputs.vcpkg_triplet }} -DBUILD_SHARED_LIBS=${{ steps.set-variables.outputs.build_shared }} -G "Visual Studio 16 2019" -A ${{ steps.set-variables.outputs.build_arch }} ${{ github.workspace }}
 
     - name: Build
       working-directory: build/
-      run: cmake --build . --config ${{ matrix.build_type }}
+      run: cmake --build . --config ${{ matrix.config }}
 
     - name: Test
       working-directory: build/
-      run: ctest -C ${{ matrix.build_type }} --output-on-failure
+      run: ctest -C ${{ matrix.config }} --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
 
     - name: Cache vcpkg and dependencies
       uses: actions/cache@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Configure
       working-directory: build/
-      run: cmake -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_SHARED_LIBS=${{ steps.set-variables.outputs.vcpkg_triplet }} -DBUILD_SHARED_LIBS=${{ steps.set-variables.outputs.build_shared }} -G "Visual Studio 16 2019" -A ${{ steps.set-variables.outputs.build_arch }} ${{ github.workspace }}
+      run: cmake -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_SHARED_LIBS=${{ steps.set-variables.outputs.build_shared }} -G "Visual Studio 16 2019" -A ${{ steps.set-variables.outputs.build_arch }} ${{ github.workspace }}
 
     - name: Build
       working-directory: build/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,4 +60,4 @@ jobs:
 
     - name: Test
       working-directory: build/
-      run: ctest --output-on-failure
+      run: ctest -C ${{ matrix.config }} --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,15 +18,12 @@ jobs:
       with:
         submodules: true
 
-    - name: Set config variables
+    - name: Set target triplet
       id: set-variables
       shell: pwsh
-      run: |
-        echo "::set-output name=vcpkg_triplet::${{ matrix.arch }}-windows$(if ('${{ matrix.libs }}' -eq 'static') { '-static' })"
-        echo "::set-output name=build_shared::$(if ('${{ matrix.libs }}' -eq 'shared') { 'ON' } else { 'OFF' })"
-        echo "::set-output name=build_arch::$(if ('${{ matrix.arch }}' -eq 'x64') { 'X64' } else { 'Win32' })"
+      run: echo "::set-output name=vcpkg_triplet::${{ matrix.arch }}-windows$(if ('${{ matrix.libs }}' -eq 'static') { '-static' })"
 
-    - name: Cache vcpkg and dependencies
+    - name: Cache vcpkg
       uses: actions/cache@v2
       id: cache-vcpkg
       with:
@@ -39,16 +36,23 @@ jobs:
       run: |
         git clone https://github.com/microsoft/vcpkg
         cd vcpkg
-        ./bootstrap-vcpkg.bat
-        ./vcpkg integrate install
-        ./vcpkg install boost-program-options rapidjson gtest --triplet ${{ steps.set-variables.outputs.vcpkg_triplet }}
+        .\bootstrap-vcpkg.bat
+        .\vcpkg integrate install
+        .\vcpkg install boost-program-options rapidjson gtest --triplet ${{ steps.set-variables.outputs.vcpkg_triplet }}
 
     - name: Create Build Environment
       run: cmake -E make_directory build
 
     - name: Configure
+      shell: pwsh
       working-directory: build/
-      run: cmake -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ steps.set-variables.outputs.vcpkg_triplet }} -DBUILD_SHARED_LIBS=${{ steps.set-variables.outputs.build_shared }} -G "Visual Studio 16 2019" -A ${{ steps.set-variables.outputs.build_arch }} ${{ github.workspace }}
+      run: |
+        $vcpkgToolchain = Join-Path '..\vcpkg' '.\scripts\buildsystems\vcpkg.cmake' -Resolve
+        $vcpkgTriplet = '${{ steps.set-variables.outputs.vcpkg_triplet }}'
+        $cmakeSharedLibs = $(if ('${{ matrix.libs }}' -eq 'shared') { 'ON' } else { 'OFF' })
+        $msbuildArch = $(if ('${{ matrix.arch }}' -eq 'x64') { 'X64' } else { 'Win32' })
+
+        cmake "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" "-DVCPKG_TARGET_TRIPLET=$vcpkgTriplet" "-DBUILD_SHARED_LIBS=$cmakeSharedLibs" -G "Visual Studio 16 2019" -A "$msbuildArch" ${{ github.workspace }}
 
     - name: Build
       working-directory: build/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,8 +56,8 @@ jobs:
 
     - name: Build
       working-directory: build/
-      run: cmake --build . --config ${{ matrix.config }} -v
+      run: cmake --build . --config ${{ matrix.config }} -j -v
 
     - name: Test
       working-directory: build/
-      run: ctest -C ${{ matrix.config }} --output-on-failure
+      run: ctest --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Configure
       working-directory: build/
-      run: cmake -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_SHARED_LIBS=${{ steps.set-variables.outputs.build_shared }} -G "Visual Studio 16 2019" -A ${{ steps.set-variables.outputs.build_arch }} ${{ github.workspace }}
+      run: cmake -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ steps.set-variables.outputs.vcpkg_triplet }} -DBUILD_SHARED_LIBS=${{ steps.set-variables.outputs.build_shared }} -G "Visual Studio 16 2019" -A ${{ steps.set-variables.outputs.build_arch }} ${{ github.workspace }}
 
     - name: Build
       working-directory: build/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,49 @@
+name: Windows
+
+on: [push, pull_request]
+
+jobs:
+  vs2019:
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+        vcpkg_triplet: [x86-windows, x64-windows]
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache vcpkg and dependencies
+      uses: actions/cache@v2
+      id: cache-vcpkg
+      with:
+        path: vcpkg/
+        key: vcpkg-${{ matrix.vcpkg_triplet }}
+
+    - name: Install Dependencies
+      if: ${{ !steps.cache-vcpkg.outputs.cache-hit }}
+      shell: pwsh
+      run: |
+        git clone https://github.com/microsoft/vcpkg
+        cd vcpkg
+        ./bootstrap-vcpkg.bat
+        ./vcpkg integrate install
+        ./vcpkg install boost-program-options rapidjson gtest --triplet ${{ matrix.vcpkg_triplet }}
+
+    - name: Create Build Environment
+      run: cmake -E make_directory build
+
+    - name: Configure
+      shell: bash
+      working-directory: build/
+      run: cmake -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} -G "Visual Studio 16 2019" $GITHUB_WORKSPACE
+
+    - name: Build
+      working-directory: build/
+      run: cmake --build . --config ${{ matrix.build_type }}
+
+    - name: Test
+      working-directory: build/
+      run: ctest -C ${{ matrix.build_type }} --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Build
       working-directory: build/
-      run: cmake --build . --config ${{ matrix.config }} -j -v
+      run: cmake --build . --config ${{ matrix.config }} -v
 
     - name: Test
       working-directory: build/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,14 +7,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [Debug, Release]
-        vcpkg_triplet: [x86-windows, x64-windows]
-      include:
-        - vcpkg_triplet: x86-windows
-          build_arch: Win32
-        - vcpkg_triplet: x64-windows
-          build_arch: X64
-
+        build_type: ['Debug', 'Release']
+        arch: ['x86', 'x64']
+        build_dlls: ['$true', '$false']
 
     runs-on: windows-latest
 
@@ -23,12 +18,20 @@ jobs:
       with:
         submodules: true
 
+    - name: Set config variables
+      id: set-variables
+      shell: pwsh
+      run: |
+        echo "::set-output name=vcpkg_triplet::${{ matrix.arch }}-windows$(if (${{ matrix.build_dlls }}) { '' } else { '-static' })"
+        echo "::set-output name=build_shared::$(if (${{ matrix.build_dlls }}) { 'ON' } else { 'OFF' })"
+        echo "::set-output name=build_arch::$(if ('${{ matrix.arch }}' -eq 'x64') { 'X64' } else { 'Win32' })"
+
     - name: Cache vcpkg and dependencies
       uses: actions/cache@v2
       id: cache-vcpkg
       with:
         path: vcpkg/
-        key: vcpkg-${{ matrix.vcpkg_triplet }}
+        key: vcpkg-${{ steps.set-variables.outputs.vcpkg_triplet }}
 
     - name: Install Dependencies
       if: ${{ !steps.cache-vcpkg.outputs.cache-hit }}
@@ -38,14 +41,15 @@ jobs:
         cd vcpkg
         ./bootstrap-vcpkg.bat
         ./vcpkg integrate install
-        ./vcpkg install boost-program-options rapidjson gtest --triplet ${{ matrix.vcpkg_triplet }}
+        ./vcpkg install boost-program-options rapidjson gtest --triplet ${{ steps.set-variables.outputs.vcpkg_triplet }}
 
     - name: Create Build Environment
       run: cmake -E make_directory build
 
     - name: Configure
+      if: ${{ matrix.vcpkg_triplet == 'x86-windows' }}
       working-directory: build/
-      run: cmake -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} -G "Visual Studio 16 2019" -A ${{ matrix.build_arch }} ${{ github.workspace }}
+      run: cmake -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_SHARED_LIBS=${{ steps.set-variables.outputs.vcpkg_triplet }} -DBUILD_SHARED_LIBS=${{ steps.set-variables.outputs.build_shared }} -G "Visual Studio 16 2019" -A ${{ steps.set-variables.outputs.build_arch }} ${{ github.workspace }}
 
     - name: Build
       working-directory: build/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,12 @@ jobs:
       matrix:
         build_type: [Debug, Release]
         vcpkg_triplet: [x86-windows, x64-windows]
+      include:
+        - vcpkg_triplet: x86-windows
+          build_arch: Win32
+        - vcpkg_triplet: x64-windows
+          build_arch: X64
+
 
     runs-on: windows-latest
 
@@ -38,9 +44,8 @@ jobs:
       run: cmake -E make_directory build
 
     - name: Configure
-      shell: bash
       working-directory: build/
-      run: cmake -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} -G "Visual Studio 16 2019" $GITHUB_WORKSPACE
+      run: cmake -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} -G "Visual Studio 16 2019" -A ${{ matrix.build_arch }} ${{ github.workspace }}
 
     - name: Build
       working-directory: build/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Build
       working-directory: build/
-      run: cmake --build . --config ${{ matrix.config }}
+      run: cmake --build . --config ${{ matrix.config }} -j -v
 
     - name: Test
       working-directory: build/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ name: Windows
 on: [push, pull_request]
 
 jobs:
-  Windows:
+  vs2019:
     strategy:
       fail-fast: false
       matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,11 @@ set(GRAPHQL_INSTALL_CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES} CACHE STRING "Co
 
 option(BUILD_SHARED_LIBS "Build shared libraries instead of static libs" OFF)
 
+# Match the MSVC runtime if we're using VCPKG with static libraries.
+if(MSVC AND VCPKG_TARGET_TRIPLET MATCHES ".*-static$")
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
 function(add_bigobj_flag target)
   if(MSVC)
     # MSVC requires the /bigobj flag if the number of sections gets too big.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+# Enable CMAKE_MSVC_RUNTIME_LIBRARY on Windows.
+cmake_policy(SET CMP0091 NEW)
+
 # Default to the last updated version from version.txt.
 file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.txt" VERSION_FILE)
 file(READ "${VERSION_FILE}" LATEST_VERSION)
@@ -25,20 +28,6 @@ if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   endif()
 endif()
 
-if(VCPKG_TARGET_TRIPLET)
-  message(STATUS "Using ${VCPKG_TARGET_TRIPLET} triplet with vcpkg")
-  if(MSVC)
-    # Match the MSVC runtime if we're using VCPKG with static libraries.
-    cmake_policy(SET CMP0091 NEW)
-    if(VCPKG_TARGET_TRIPLET MATCHES [[^.+-static$]])
-      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-    else()
-      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-    endif()
-    message(STATUS "Using ${CMAKE_MSVC_RUNTIME_LIBRARY} to match ${VCPKG_TARGET_TRIPLET}")
-  endif()
-endif()
-
 project(cppgraphqlgen VERSION ${LATEST_VERSION})
 
 set(CMAKE_CXX_STANDARD 17)
@@ -49,6 +38,24 @@ set(GRAPHQL_INSTALL_CMAKE_DIR lib/cmake CACHE PATH "CMake config files install d
 set(GRAPHQL_INSTALL_CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES} CACHE STRING "Configurations which perform a full install")
 
 option(BUILD_SHARED_LIBS "Build shared libraries instead of static libs" OFF)
+
+if(VCPKG_TARGET_TRIPLET)
+  message(STATUS "Using ${VCPKG_TARGET_TRIPLET} triplet with vcpkg")
+
+  if(MSVC)
+    # Match the MSVC runtime if we're using VCPKG with static libraries.
+    if(VCPKG_TARGET_TRIPLET MATCHES [[^.+-static$]])
+      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+      message(STATUS "Using MSVC runtime static library")
+    else()
+      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+      message(STATUS "Using MSVC runtime DLL")
+    endif()
+
+    add_custom_target(output_msvc_runtime ALL
+      ${CMAKE_COMMAND} -E echo "Using ${CMAKE_MSVC_RUNTIME_LIBRARY} MSVC runtime to match ${VCPKG_TARGET_TRIPLET}")
+  endif()
+endif()
 
 function(add_bigobj_flag target)
   if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,20 @@ if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   endif()
 endif()
 
+if(VCPKG_TARGET_TRIPLET)
+  message(STATUS "Using ${VCPKG_TARGET_TRIPLET} triplet with vcpkg")
+  if(MSVC)
+    # Match the MSVC runtime if we're using VCPKG with static libraries.
+    cmake_policy(SET CMP0091 NEW)
+    if(VCPKG_TARGET_TRIPLET MATCHES [[^.+-static$]])
+      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    else()
+      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    endif()
+    message(STATUS "Using ${CMAKE_MSVC_RUNTIME_LIBRARY} to match ${VCPKG_TARGET_TRIPLET}")
+  endif()
+endif()
+
 project(cppgraphqlgen VERSION ${LATEST_VERSION})
 
 set(CMAKE_CXX_STANDARD 17)
@@ -35,11 +49,6 @@ set(GRAPHQL_INSTALL_CMAKE_DIR lib/cmake CACHE PATH "CMake config files install d
 set(GRAPHQL_INSTALL_CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES} CACHE STRING "Configurations which perform a full install")
 
 option(BUILD_SHARED_LIBS "Build shared libraries instead of static libs" OFF)
-
-# Match the MSVC runtime if we're using VCPKG with static libraries.
-if(MSVC AND VCPKG_TARGET_TRIPLET MATCHES ".*-static$")
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-endif()
 
 function(add_bigobj_flag target)
   if(MSVC)

--- a/include/graphqlservice/GraphQLSchema.h
+++ b/include/graphqlservice/GraphQLSchema.h
@@ -67,12 +67,12 @@ private:
 	std::shared_ptr<const ObjectType> _query;
 	std::shared_ptr<const ObjectType> _mutation;
 	std::shared_ptr<const ObjectType> _subscription;
-	std::unordered_map<std::string_view, size_t> _typeMap;
+	internal::sorted_map<std::string_view, size_t> _typeMap;
 	std::vector<std::pair<std::string_view, std::shared_ptr<const BaseType>>> _types;
 	std::vector<std::shared_ptr<const Directive>> _directives;
-	std::unordered_map<std::shared_ptr<const BaseType>, std::shared_ptr<const BaseType>>
+	internal::sorted_map<std::shared_ptr<const BaseType>, std::shared_ptr<const BaseType>>
 		_nonNullWrappers;
-	std::unordered_map<std::shared_ptr<const BaseType>, std::shared_ptr<const BaseType>>
+	internal::sorted_map<std::shared_ptr<const BaseType>, std::shared_ptr<const BaseType>>
 		_listWrappers;
 };
 

--- a/include/graphqlservice/GraphQLSchema.h
+++ b/include/graphqlservice/GraphQLSchema.h
@@ -45,8 +45,8 @@ public:
 	GRAPHQLSERVICE_EXPORT void AddType(std::string_view name, std::shared_ptr<BaseType> type);
 	GRAPHQLSERVICE_EXPORT const std::shared_ptr<const BaseType>& LookupType(
 		std::string_view name) const;
-	GRAPHQLSERVICE_EXPORT const std::shared_ptr<const BaseType>& WrapType(
-		introspection::TypeKind kind, const std::shared_ptr<const BaseType>& ofType);
+	GRAPHQLSERVICE_EXPORT std::shared_ptr<const BaseType> WrapType(
+		introspection::TypeKind kind, std::shared_ptr<const BaseType> ofType);
 	GRAPHQLSERVICE_EXPORT void AddDirective(std::shared_ptr<Directive> directive);
 
 	// Accessors
@@ -282,7 +282,7 @@ public:
 	explicit WrapperType(init&& params);
 
 	GRAPHQLSERVICE_EXPORT static std::shared_ptr<WrapperType> Make(
-		introspection::TypeKind kind, const std::shared_ptr<const BaseType>& ofType);
+		introspection::TypeKind kind, std::weak_ptr<const BaseType> ofType);
 
 	// Accessors
 	GRAPHQLSERVICE_EXPORT const std::weak_ptr<const BaseType>& ofType() const noexcept final;
@@ -303,7 +303,7 @@ public:
 
 	GRAPHQLSERVICE_EXPORT static std::shared_ptr<Field> Make(std::string_view name,
 		std::string_view description, std::optional<std::string_view> deprecationReason,
-		const std::shared_ptr<const BaseType>& type,
+		std::weak_ptr<const BaseType> type,
 		std::initializer_list<std::shared_ptr<InputValue>> args = {});
 
 	// Accessors
@@ -333,7 +333,7 @@ public:
 	explicit InputValue(init&& params);
 
 	GRAPHQLSERVICE_EXPORT static std::shared_ptr<InputValue> Make(std::string_view name,
-		std::string_view description, const std::shared_ptr<const BaseType>& type,
+		std::string_view description, std::weak_ptr<const BaseType> type,
 		std::string_view defaultValue);
 
 	// Accessors

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -99,7 +99,10 @@ if(GRAPHQL_UPDATE_SAMPLES)
     DEPENDS 
       ${CMAKE_CURRENT_BINARY_DIR}/unified/TodaySchema.cpp
       ${CMAKE_CURRENT_BINARY_DIR}/unified/TodaySchema.h
+      ${CMAKE_CURRENT_BINARY_DIR}/unified_nointrospection/TodaySchema.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/unified_nointrospection/TodaySchema.h
       ${CMAKE_CURRENT_BINARY_DIR}/separate/today_schema_files
+      ${CMAKE_CURRENT_BINARY_DIR}/separate_nointrospection/today_schema_files
       ${CMAKE_CURRENT_BINARY_DIR}/validation/ValidationSchema.cpp
       ${CMAKE_CURRENT_BINARY_DIR}/validation/ValidationSchema.h
     COMMENT "Updating sample files")

--- a/src/GraphQLSchema.cpp
+++ b/src/GraphQLSchema.cpp
@@ -43,7 +43,7 @@ const std::shared_ptr<const BaseType>& Schema::LookupType(std::string_view name)
 {
 	auto itr = _typeMap.find(name);
 
-	if (itr == _typeMap.cend())
+	if (itr == _typeMap.end())
 	{
 		std::ostringstream message;
 
@@ -66,9 +66,9 @@ const std::shared_ptr<const BaseType>& Schema::WrapType(
 	auto& wrappers = (kind == introspection::TypeKind::LIST) ? _listWrappers : _nonNullWrappers;
 	auto itr = wrappers.find(ofType);
 
-	if (itr == wrappers.cend())
+	if (itr == wrappers.end())
 	{
-		std::tie(itr, std::ignore) = wrappers.insert({ ofType, WrapperType::Make(kind, ofType) });
+		std::tie(itr, std::ignore) = wrappers.emplace(ofType, WrapperType::Make(kind, ofType));
 	}
 
 	return itr->second;

--- a/src/GraphQLSchema.cpp
+++ b/src/GraphQLSchema.cpp
@@ -60,8 +60,8 @@ const std::shared_ptr<const BaseType>& Schema::LookupType(std::string_view name)
 	return _types[itr->second].second;
 }
 
-const std::shared_ptr<const BaseType>& Schema::WrapType(
-	introspection::TypeKind kind, const std::shared_ptr<const BaseType>& ofType)
+std::shared_ptr<const BaseType> Schema::WrapType(
+	introspection::TypeKind kind, std::shared_ptr<const BaseType> ofType)
 {
 	auto& wrappers = (kind == introspection::TypeKind::LIST) ? _listWrappers : _nonNullWrappers;
 	auto itr = wrappers.find(ofType);
@@ -387,18 +387,18 @@ const std::vector<std::shared_ptr<const InputValue>>& InputObjectType::inputFiel
 struct WrapperType::init
 {
 	introspection::TypeKind kind;
-	const std::shared_ptr<const BaseType>& ofType;
+	std::weak_ptr<const BaseType> ofType;
 };
 
 std::shared_ptr<WrapperType> WrapperType::Make(
-	introspection::TypeKind kind, const std::shared_ptr<const BaseType>& ofType)
+	introspection::TypeKind kind, std::weak_ptr<const BaseType> ofType)
 {
-	return std::make_shared<WrapperType>(init { kind, ofType });
+	return std::make_shared<WrapperType>(init { kind, std::move(ofType) });
 }
 
 WrapperType::WrapperType(init&& params)
 	: BaseType(params.kind, std::string_view())
-	, _ofType(params.ofType)
+	, _ofType(std::move(params.ofType))
 {
 }
 
@@ -412,15 +412,15 @@ struct Field::init
 	std::string_view name;
 	std::string_view description;
 	std::optional<std::string_view> deprecationReason;
-	const std::shared_ptr<const BaseType>& type;
+	std::weak_ptr<const BaseType> type;
 	std::vector<std::shared_ptr<const InputValue>> args;
 };
 
 std::shared_ptr<Field> Field::Make(std::string_view name, std::string_view description,
-	std::optional<std::string_view> deprecationReason, const std::shared_ptr<const BaseType>& type,
+	std::optional<std::string_view> deprecationReason, std::weak_ptr<const BaseType> type,
 	std::initializer_list<std::shared_ptr<InputValue>> args)
 {
-	init params { name, description, deprecationReason, type };
+	init params { name, description, deprecationReason, std::move(type) };
 
 	params.args.resize(args.size());
 	std::copy(args.begin(), args.end(), params.args.begin());
@@ -432,7 +432,7 @@ Field::Field(init&& params)
 	: _name(params.name)
 	, _description(params.description)
 	, _deprecationReason(params.deprecationReason)
-	, _type(params.type)
+	, _type(std::move(params.type))
 	, _args(std::move(params.args))
 {
 }
@@ -466,20 +466,20 @@ struct InputValue::init
 {
 	std::string_view name;
 	std::string_view description;
-	const std::shared_ptr<const BaseType>& type;
+	std::weak_ptr<const BaseType> type;
 	std::string_view defaultValue;
 };
 
 std::shared_ptr<InputValue> InputValue::Make(std::string_view name, std::string_view description,
-	const std::shared_ptr<const BaseType>& type, std::string_view defaultValue)
+	std::weak_ptr<const BaseType> type, std::string_view defaultValue)
 {
-	return std::make_shared<InputValue>(init { name, description, type, defaultValue });
+	return std::make_shared<InputValue>(init { name, description, std::move(type), defaultValue });
 }
 
 InputValue::InputValue(init&& params)
 	: _name(params.name)
 	, _description(params.description)
-	, _type(params.type)
+	, _type(std::move(params.type))
 	, _defaultValue(params.defaultValue)
 {
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,7 @@ gtest_add_tests(TARGET argument_tests)
 
 add_executable(pegtl_tests PegtlTests.cpp)
 target_link_libraries(pegtl_tests PRIVATE
+  taocpp::pegtl
   GTest::GTest
   GTest::Main)
 target_include_directories(pegtl_tests PUBLIC


### PR DESCRIPTION
Build Windows, Linux, and macOS workflows to build cppgraphqlgen and run all of the unit tests. Dependencies are cached so subsequent runs should be faster.