### PR TITLE
Add backwards compatibility with PEGTL 3.1.0 and fix the header install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ endfunction()
 
 find_package(Threads MODULE REQUIRED)
 
-find_package(pegtl 3.1.1 QUIET CONFIG)
+find_package(pegtl 3.1.0 QUIET CONFIG)
 if(NOT pegtl_FOUND)
   # If a compatible version of PEGTL is not already installed, build and install it from the submodule directory.
   set(PEGTL_BUILD_TESTS OFF CACHE BOOL "Disable PEGTL tests")

--- a/include/graphqlservice/GraphQLTree.h
+++ b/include/graphqlservice/GraphQLTree.h
@@ -13,6 +13,19 @@
 #include <tao/pegtl.hpp>
 #include <tao/pegtl/contrib/parse_tree.hpp>
 
+// Temporarily workaround the tao::demangle namespace in 3.1.0. This was fixed in PEGTL commit
+// https://github.com/taocpp/PEGTL/commit/0cc3128e07734fb72e23e2eeee70b9f1fc13ca5f, which put this
+// in the correct namespace defined by TAO_PEGTL_NAMESPACE (tao::graphqlpeg) and should be included
+// in 3.1.1 or later. Once that version of PEGTL is released, this can be removed.
+#include <tao/pegtl/version.hpp>
+
+#if (TAO_PEGTL_VERSION_MAJOR == 3) && (TAO_PEGTL_VERSION_MINOR == 1)                               \
+	&& (TAO_PEGTL_VERSION_PATCH < 1)
+namespace tao::graphqlpeg {
+using ::tao::demangle;
+}
+#endif
+
 #include <string>
 #include <string_view>
 #include <variant>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -298,7 +298,7 @@ if(BUILD_GRAPHQLJSON)
     LIBRARY DESTINATION lib)
   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/JSONResponse.h
     CONFIGURATIONS ${GRAPHQL_INSTALL_CONFIGURATIONS}
-    DESTINATION ${GRAPHQL_INSTALL_INCLUDE_DIR}/graphqlintrospection)
+    DESTINATION ${GRAPHQL_INSTALL_INCLUDE_DIR}/graphqlservice)
 else()
   set(GRAPHQL_BUILD_TESTS OFF CACHE BOOL "GRAPHQL_BUILD_TESTS depends on BUILD_GRAPHQLJSON" FORCE)
 endif()
@@ -321,7 +321,7 @@ install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/GraphQLGrammar.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/GraphQLTree.h
   CONFIGURATIONS ${GRAPHQL_INSTALL_CONFIGURATIONS}
-  DESTINATION ${GRAPHQL_INSTALL_INCLUDE_DIR}/graphqlintrospection)
+  DESTINATION ${GRAPHQL_INSTALL_INCLUDE_DIR}/graphqlservice)
 
 install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/internal/SortedMap.h
@@ -333,7 +333,7 @@ install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/introspection/Introspection.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphqlservice/introspection/IntrospectionSchema.h
   CONFIGURATIONS ${GRAPHQL_INSTALL_CONFIGURATIONS}
-  DESTINATION ${GRAPHQL_INSTALL_INCLUDE_DIR}/graphqlintrospection/introspection)
+  DESTINATION ${GRAPHQL_INSTALL_INCLUDE_DIR}/graphqlservice/introspection)
 
 install(EXPORT cppgraphqlgen-targets
   NAMESPACE cppgraphqlgen::


### PR DESCRIPTION
PEGTL has a [fix](https://github.com/taocpp/PEGTL/commit/0cc3128e07734fb72e23e2eeee70b9f1fc13ca5f) for the namespace of `::tao::demangle` pending for the 3.1.1 release, but the most recent release is still 3.1.0.  That makes upgrading `cppgraphqlgen` to its most recent releases complicated, so I'm adding a fallback which re-declares `demangle` in the `tao::graphqlpeg` namespace used by `cppgraphqlgen` (defined with `TAO_PEGTL_NAMESPACE`) if the PEGTL version is < 3.1.1.

I introduced #151 with #150 when I missed a couple of global replacements that switched the install target for some of the include files to `graphqlintrospection/...`. This changes those back to `graphqlservice/...` in the `CMakeLists.txt` file, so install should put them in the right place.