### PR TITLE
Fix #148

### DIFF
--- a/samples/today/benchmark.cpp
+++ b/samples/today/benchmark.cpp
@@ -5,22 +5,28 @@
 
 #include "graphqlservice/JSONResponse.h"
 
-#include <cstdio>
+#include <chrono>
 #include <iostream>
 #include <iterator>
-#include <sstream>
+#include <numeric>
 #include <stdexcept>
+#include <string>
+#include <string_view>
 
 using namespace graphql;
 
 using namespace std::literals;
 
-int main(int argc, char** argv)
-{
-	response::IdType binAppointmentId;
-	response::IdType binTaskId;
-	response::IdType binFolderId;
+namespace {
 
+response::IdType binAppointmentId;
+response::IdType binTaskId;
+response::IdType binFolderId;
+
+} // namespace
+
+std::shared_ptr<today::Operations> buildService()
+{
 	std::string fakeAppointmentId("fakeAppointmentId");
 	binAppointmentId.resize(fakeAppointmentId.size());
 	std::copy(fakeAppointmentId.cbegin(), fakeAppointmentId.cend(), binAppointmentId.begin());
@@ -34,19 +40,16 @@ int main(int argc, char** argv)
 	std::copy(fakeFolderId.cbegin(), fakeFolderId.cend(), binFolderId.begin());
 
 	auto query = std::make_shared<today::Query>(
-		[&binAppointmentId]() -> std::vector<std::shared_ptr<today::Appointment>> {
-			std::cout << "Called getAppointments..." << std::endl;
+		[]() -> std::vector<std::shared_ptr<today::Appointment>> {
 			return { std::make_shared<today::Appointment>(std::move(binAppointmentId),
 				"tomorrow",
 				"Lunch?",
 				false) };
 		},
-		[&binTaskId]() -> std::vector<std::shared_ptr<today::Task>> {
-			std::cout << "Called getTasks..." << std::endl;
+		[]() -> std::vector<std::shared_ptr<today::Task>> {
 			return { std::make_shared<today::Task>(std::move(binTaskId), "Don't forget", true) };
 		},
-		[&binFolderId]() -> std::vector<std::shared_ptr<today::Folder>> {
-			std::cout << "Called getUnreadCounts..." << std::endl;
+		[]() -> std::vector<std::shared_ptr<today::Folder>> {
 			return { std::make_shared<today::Folder>(std::move(binFolderId), "\"Fake\" Inbox", 3) };
 		});
 	auto mutation = std::make_shared<today::Mutation>(
@@ -60,8 +63,53 @@ int main(int argc, char** argv)
 	auto subscription = std::make_shared<today::Subscription>();
 	auto service = std::make_shared<today::Operations>(query, mutation, subscription);
 
-	std::cout << "Created the service..." << std::endl;
+	return service;
+}
 
+void outputOverview(
+	size_t iterations, const std::chrono::steady_clock::duration& totalDuration) noexcept
+{
+	const auto requestsPerSecond =
+		((static_cast<double>(iterations)
+			 * static_cast<double>(
+				 std::chrono::duration_cast<std::chrono::steady_clock::duration>(1s).count()))
+			/ static_cast<double>(totalDuration.count()));
+	const auto averageRequest =
+		(static_cast<double>(
+			 std::chrono::duration_cast<std::chrono::microseconds>(totalDuration).count())
+			/ static_cast<double>(iterations));
+
+	std::cout << "Throughput: " << requestsPerSecond << " requests/second" << std::endl;
+
+	std::cout << "Overall (microseconds): "
+			  << std::chrono::duration_cast<std::chrono::microseconds>(totalDuration).count()
+			  << " total, " << averageRequest << " average" << std::endl;
+}
+
+void outputSegment(
+	std::string_view name, std::vector<std::chrono::steady_clock::duration>& durations) noexcept
+{
+	std::sort(durations.begin(), durations.end());
+
+	const auto count = durations.size();
+	const auto total =
+		std::accumulate(durations.begin(), durations.end(), std::chrono::steady_clock::duration {});
+
+	std::cout << name << " (microseconds): "
+			  << std::chrono::duration_cast<std::chrono::microseconds>(durations[count / 2]).count()
+			  << " median, "
+			  << std::chrono::duration_cast<std::chrono::microseconds>(durations.front()).count()
+			  << " minimum, "
+			  << std::chrono::duration_cast<std::chrono::microseconds>(durations.back()).count()
+			  << " maximum, "
+			  << (static_cast<double>(
+					  std::chrono::duration_cast<std::chrono::microseconds>(total).count())
+					 / static_cast<double>(count))
+			  << " average" << std::endl;
+}
+
+int main(int argc, char** argv)
+{
 	const size_t iterations = [](const char* arg) noexcept -> size_t {
 		if (arg)
 		{
@@ -77,10 +125,20 @@ int main(int argc, char** argv)
 		return 100;
 	}((argc > 1) ? argv[1] : nullptr);
 
-	for (size_t i = 0; i < iterations; ++i)
+	std::cout << "Iterations: " << iterations << std::endl;
+
+	auto service = buildService();
+	std::vector<std::chrono::steady_clock::duration> durationParse(iterations);
+	std::vector<std::chrono::steady_clock::duration> durationValidate(iterations);
+	std::vector<std::chrono::steady_clock::duration> durationResolve(iterations);
+	std::vector<std::chrono::steady_clock::duration> durationToJson(iterations);
+	const auto startTime = std::chrono::steady_clock::now();
+
+	try
 	{
-		try
+		for (size_t i = 0; i < iterations; ++i)
 		{
+			const auto startParse = std::chrono::steady_clock::now();
 			auto query = peg::parseString(R"gql(query {
 				appointments {
 					pageInfo { hasNextPage }
@@ -94,19 +152,40 @@ int main(int argc, char** argv)
 					}
 				}
 			})gql"sv);
+			const auto startValidate = std::chrono::steady_clock::now();
 
-			std::cout << "Executing query..." << std::endl;
+			service->validate(query);
 
-			std::cout << response::toJSON(
-				service->resolve(nullptr, query, "", response::Value(response::Type::Map)).get())
-					  << std::endl;
-		}
-		catch (const std::runtime_error& ex)
-		{
-			std::cerr << ex.what() << std::endl;
-			return 1;
+			const auto startResolve = std::chrono::steady_clock::now();
+			auto response =
+				service->resolve(nullptr, query, "", response::Value(response::Type::Map)).get();
+			const auto startToJson = std::chrono::steady_clock::now();
+
+			response::toJSON(std::move(response));
+
+			const auto endToJson = std::chrono::steady_clock::now();
+
+			durationParse[i] = startValidate - startParse;
+			durationValidate[i] = startResolve - startValidate;
+			durationResolve[i] = startToJson - startResolve;
+			durationToJson[i] = endToJson - startToJson;
 		}
 	}
+	catch (const std::runtime_error& ex)
+	{
+		std::cerr << ex.what() << std::endl;
+		return 1;
+	}
+
+	const auto endTime = std::chrono::steady_clock::now();
+	const auto totalDuration = endTime - startTime;
+
+	outputOverview(iterations, totalDuration);
+
+	outputSegment("Parse"sv, durationParse);
+	outputSegment("Validate"sv, durationValidate);
+	outputSegment("Resolve"sv, durationResolve);
+	outputSegment("ToJSON"sv, durationToJson);
 
 	return 0;
 }


### PR DESCRIPTION
Refactor `benchmark.cpp` to keep track of the duration of each sub-task in processing a request. It uses more memory than before just because it's tracking the duration of each segment in each iteration, but the increase is always proportional to the number of iterations, so it should still be possible to factor that out in comparisons.

The statistics we get as a result show the median, minimum, maximum, and average durations of each segment along with an overview including the requests/second. You can still specify an iteration count on the command line:

```
./samples/benchmark 1500
Iterations: 1500
Throughput: 1443.11 requests/second
Overall (microseconds): 1039423 total, 692.949 average
Parse (microseconds): 254 median, 248 minimum, 1015 maximum, 261.435 average
Validate (microseconds): 32 median, 32 minimum, 146 maximum, 34.2307 average
Resolve (microseconds): 379 median, 314 minimum, 1467 maximum, 383.689 average
ToJSON (microseconds): 8 median, 8 minimum, 50 maximum, 8.864 average
```