### PR TITLE
Fix #158

### DIFF
--- a/include/graphqlservice/GraphQLSchema.h
+++ b/include/graphqlservice/GraphQLSchema.h
@@ -9,6 +9,7 @@
 #include "graphqlservice/GraphQLService.h"
 
 #include <initializer_list>
+#include <shared_mutex>
 
 namespace graphql {
 namespace introspection {
@@ -70,8 +71,10 @@ private:
 	internal::string_view_map<size_t> _typeMap;
 	std::vector<std::pair<std::string_view, std::shared_ptr<const BaseType>>> _types;
 	std::vector<std::shared_ptr<const Directive>> _directives;
+	std::shared_mutex _nonNullWrappersMutex;
 	internal::sorted_map<std::shared_ptr<const BaseType>, std::shared_ptr<const BaseType>>
 		_nonNullWrappers;
+	std::shared_mutex _listWrappersMutex;
 	internal::sorted_map<std::shared_ptr<const BaseType>, std::shared_ptr<const BaseType>>
 		_listWrappers;
 };


### PR DESCRIPTION
There's a race condition in `Schema::WrapType` where it caches the `WrapperType` in a map, keyed off of the original type. If you perform query validation on multiple threads, they may simultaneously lookup and emplace new values in the cache, invalidating the iterators on one of them, possibly resulting in duplicate entries.

I'm using a `std::shared_mutex` as a reader/writer lock on each of these maps. It can find a match with a `std::shared_lock`, and if there is no match, it'll trade that for a `std::unique_lock` and perform the `emplace`, which is equivalent to a `find` if the key was added on another thread before acquiring the `std::unique_lock`.