### PR TITLE
add virtual dtor

### DIFF
--- a/include/graphqlservice/GraphQLSchema.h
+++ b/include/graphqlservice/GraphQLSchema.h
@@ -82,6 +82,8 @@ private:
 class BaseType : public std::enable_shared_from_this<BaseType>
 {
 public:
+	GRAPHQLSERVICE_EXPORT virtual ~BaseType() = default;
+
 	// Accessors
 	GRAPHQLSERVICE_EXPORT introspection::TypeKind kind() const noexcept;
 	GRAPHQLSERVICE_EXPORT virtual std::string_view name() const noexcept;


### PR DESCRIPTION
fixes build error:
```
 graphqlservice/GraphQLSchema.h:126:7: error: base class 'class graphql::schema::BaseType' has accessible non-virtual destructor [-Werror=non-virtual-dtor]
```