### PR TITLE
Fix subscription listeners key

### DIFF
--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -1002,7 +1002,7 @@ private:
 	const TypeMap _operations;
 	std::unique_ptr<ValidateExecutableVisitor> _validation;
 	internal::sorted_map<SubscriptionKey, std::shared_ptr<SubscriptionData>> _subscriptions;
-	internal::string_view_map<internal::sorted_set<SubscriptionKey>> _listeners;
+	internal::sorted_map<SubscriptionName, internal::sorted_set<SubscriptionKey>> _listeners;
 	SubscriptionKey _nextKey = 0;
 };
 


### PR DESCRIPTION
_listeners used a string_view as key, it would point to the first
registration->field value, but once that value is gone, the reference
will point to garbage and the process will crash.

Change it to a string, the copy is harmless given the other costs of
subscription.

Closes: #162