### PR TITLE
Allow field getters to return a std::shared_ptr<const response::Value>

### DIFF
--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -131,6 +131,8 @@ struct Value
 	GRAPHQLRESPONSE_EXPORT Value(Value&& other) noexcept;
 	GRAPHQLRESPONSE_EXPORT explicit Value(const Value& other);
 
+	GRAPHQLRESPONSE_EXPORT Value(std::shared_ptr<const Value> other) noexcept;
+
 	GRAPHQLRESPONSE_EXPORT Value& operator=(Value&& rhs) noexcept;
 	Value& operator=(const Value& rhs) = delete;
 
@@ -213,8 +215,12 @@ private:
 		std::unique_ptr<ScalarType> scalar;
 	};
 
+	using SharedData = std::shared_ptr<const Value>;
+
 	using TypeData = std::variant<MapData, ListType, StringData, NullData, BooleanType, IntType,
-		FloatType, EnumData, ScalarData>;
+		FloatType, EnumData, ScalarData, SharedData>;
+
+	const TypeData& data() const noexcept;
 
 	TypeData _data;
 };

--- a/samples/today/TodayMock.cpp
+++ b/samples/today/TodayMock.cpp
@@ -21,22 +21,22 @@ namespace graphql::today {
 Appointment::Appointment(
 	response::IdType&& id, std::string&& when, std::string&& subject, bool isNow)
 	: _id(std::move(id))
-	, _when(std::move(when))
-	, _subject(std::move(subject))
+	, _when(std::make_shared<response::Value>(std::move(when)))
+	, _subject(std::make_shared<response::Value>(std::move(subject)))
 	, _isNow(isNow)
 {
 }
 
 Task::Task(response::IdType&& id, std::string&& title, bool isComplete)
 	: _id(std::move(id))
-	, _title(std::move(title))
+	, _title(std::make_shared<response::Value>(std::move(title)))
 	, _isComplete(isComplete)
 {
 }
 
 Folder::Folder(response::IdType&& id, std::string&& name, int unreadCount)
 	: _id(std::move(id))
-	, _name(std::move(name))
+	, _name(std::make_shared<response::Value>(std::move(name)))
 	, _unreadCount(unreadCount)
 {
 }

--- a/samples/today/TodayMock.h
+++ b/samples/today/TodayMock.h
@@ -8,19 +8,20 @@
 
 #include "TodaySchema.h"
 
-#include "QueryObject.h"
+#include "AppointmentEdgeObject.h"
+#include "AppointmentObject.h"
+#include "FolderEdgeObject.h"
+#include "FolderObject.h"
 #include "MutationObject.h"
-#include "SubscriptionObject.h"
 #include "NodeObject.h"
 #include "PageInfoObject.h"
-#include "AppointmentEdgeObject.h"
+#include "QueryObject.h"
+#include "SubscriptionObject.h"
 #include "TaskEdgeObject.h"
-#include "FolderEdgeObject.h"
-#include "AppointmentObject.h"
 #include "TaskObject.h"
-#include "FolderObject.h"
 
 #include <atomic>
+#include <memory>
 #include <stack>
 
 namespace graphql::today {
@@ -146,14 +147,14 @@ public:
 		return _id;
 	}
 
-	std::optional<response::Value> getWhen() const noexcept
+	std::shared_ptr<const response::Value> getWhen() const noexcept
 	{
-		return std::make_optional<response::Value>(std::string(_when));
+		return _when;
 	}
 
-	std::optional<std::string> getSubject() const noexcept
+	std::shared_ptr<const response::Value> getSubject() const noexcept
 	{
-		return std::make_optional<std::string>(_subject);
+		return _subject;
 	}
 
 	bool getIsNow() const noexcept
@@ -168,8 +169,8 @@ public:
 
 private:
 	response::IdType _id;
-	std::string _when;
-	std::string _subject;
+	std::shared_ptr<const response::Value> _when;
+	std::shared_ptr<const response::Value> _subject;
 	bool _isNow;
 };
 
@@ -247,9 +248,9 @@ public:
 		return _id;
 	}
 
-	std::optional<std::string> getTitle() const noexcept
+	std::shared_ptr<const response::Value> getTitle() const noexcept
 	{
-		return std::make_optional<std::string>(_title);
+		return _title;
 	}
 
 	bool getIsComplete() const noexcept
@@ -259,7 +260,7 @@ public:
 
 private:
 	response::IdType _id;
-	std::string _title;
+	std::shared_ptr<const response::Value> _title;
 	bool _isComplete;
 	TaskState _state = TaskState::New;
 };
@@ -337,9 +338,9 @@ public:
 		return _id;
 	}
 
-	std::optional<std::string> getName() const noexcept
+	std::shared_ptr<const response::Value> getName() const noexcept
 	{
-		return std::make_optional<std::string>(_name);
+		return _name;
 	}
 
 	int getUnreadCount() const noexcept
@@ -349,7 +350,7 @@ public:
 
 private:
 	response::IdType _id;
-	std::string _name;
+	std::shared_ptr<const response::Value> _name;
 	int _unreadCount;
 };
 

--- a/src/GraphQLResponse.cpp
+++ b/src/GraphQLResponse.cpp
@@ -42,6 +42,11 @@ bool Value::ScalarData::operator==(const ScalarData& rhs) const
 template <>
 void Value::set<StringType>(StringType&& value)
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	if (std::holds_alternative<EnumData>(_data))
 	{
 		std::get<EnumData>(_data) = std::move(value);
@@ -59,6 +64,11 @@ void Value::set<StringType>(StringType&& value)
 template <>
 void Value::set<BooleanType>(BooleanType value)
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	if (!std::holds_alternative<BooleanType>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::set for BooleanType");
@@ -70,6 +80,11 @@ void Value::set<BooleanType>(BooleanType value)
 template <>
 void Value::set<IntType>(IntType value)
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	if (std::holds_alternative<FloatType>(_data))
 	{
 		// Coerce IntType to FloatType
@@ -88,6 +103,11 @@ void Value::set<IntType>(IntType value)
 template <>
 void Value::set<FloatType>(FloatType value)
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	if (!std::holds_alternative<FloatType>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::set for FloatType");
@@ -99,6 +119,11 @@ void Value::set<FloatType>(FloatType value)
 template <>
 void Value::set<ScalarType>(ScalarType&& value)
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	if (!std::holds_alternative<ScalarData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::set for ScalarType");
@@ -110,6 +135,11 @@ void Value::set<ScalarType>(ScalarType&& value)
 template <>
 void Value::set<IdType>(const IdType& value)
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	if (!std::holds_alternative<StringData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::set for IdType");
@@ -121,35 +151,41 @@ void Value::set<IdType>(const IdType& value)
 template <>
 const MapType& Value::get<MapType>() const
 {
-	if (!std::holds_alternative<MapData>(_data))
+	const auto& typeData = data();
+
+	if (!std::holds_alternative<MapData>(typeData))
 	{
 		throw std::logic_error("Invalid call to Value::get for MapType");
 	}
 
-	return std::get<MapData>(_data).map;
+	return std::get<MapData>(typeData).map;
 }
 
 template <>
 const ListType& Value::get<ListType>() const
 {
-	if (!std::holds_alternative<ListType>(_data))
+	const auto& typeData = data();
+
+	if (!std::holds_alternative<ListType>(typeData))
 	{
 		throw std::logic_error("Invalid call to Value::get for ListType");
 	}
 
-	return std::get<ListType>(_data);
+	return std::get<ListType>(typeData);
 }
 
 template <>
 const StringType& Value::get<StringType>() const
 {
-	if (std::holds_alternative<EnumData>(_data))
+	const auto& typeData = data();
+
+	if (std::holds_alternative<EnumData>(typeData))
 	{
-		return std::get<EnumData>(_data);
+		return std::get<EnumData>(typeData);
 	}
-	else if (std::holds_alternative<StringData>(_data))
+	else if (std::holds_alternative<StringData>(typeData))
 	{
-		return std::get<StringData>(_data).string;
+		return std::get<StringData>(typeData).string;
 	}
 
 	throw std::logic_error("Invalid call to Value::get for StringType");
@@ -158,51 +194,59 @@ const StringType& Value::get<StringType>() const
 template <>
 BooleanType Value::get<BooleanType>() const
 {
-	if (!std::holds_alternative<BooleanType>(_data))
+	const auto& typeData = data();
+
+	if (!std::holds_alternative<BooleanType>(typeData))
 	{
 		throw std::logic_error("Invalid call to Value::get for BooleanType");
 	}
 
-	return std::get<BooleanType>(_data);
+	return std::get<BooleanType>(typeData);
 }
 
 template <>
 IntType Value::get<IntType>() const
 {
-	if (!std::holds_alternative<IntType>(_data))
+	const auto& typeData = data();
+
+	if (!std::holds_alternative<IntType>(typeData))
 	{
 		throw std::logic_error("Invalid call to Value::get for IntType");
 	}
 
-	return std::get<IntType>(_data);
+	return std::get<IntType>(typeData);
 }
 
 template <>
 FloatType Value::get<FloatType>() const
 {
-	if (std::holds_alternative<IntType>(_data))
+	const auto& typeData = data();
+
+	if (std::holds_alternative<IntType>(typeData))
 	{
 		// Coerce IntType to FloatType
-		return static_cast<FloatType>(std::get<IntType>(_data));
+		return static_cast<FloatType>(std::get<IntType>(typeData));
 	}
 
-	if (!std::holds_alternative<FloatType>(_data))
+	if (!std::holds_alternative<FloatType>(typeData))
 	{
 		throw std::logic_error("Invalid call to Value::get for FloatType");
 	}
 
-	return std::get<FloatType>(_data);
+	return std::get<FloatType>(typeData);
 }
 
 template <>
 const ScalarType& Value::get<ScalarType>() const
 {
-	if (!std::holds_alternative<ScalarData>(_data))
+	const auto& typeData = data();
+
+	if (!std::holds_alternative<ScalarData>(typeData))
 	{
 		throw std::logic_error("Invalid call to Value::get for ScalarType");
 	}
 
-	const auto& scalar = std::get<ScalarData>(_data).scalar;
+	const auto& scalar = std::get<ScalarData>(typeData).scalar;
 
 	if (!scalar)
 	{
@@ -215,17 +259,24 @@ const ScalarType& Value::get<ScalarType>() const
 template <>
 IdType Value::get<IdType>() const
 {
-	if (!std::holds_alternative<StringData>(_data))
+	const auto& typeData = data();
+
+	if (!std::holds_alternative<StringData>(typeData))
 	{
 		throw std::logic_error("Invalid call to Value::get for IdType");
 	}
 
-	return internal::Base64::fromBase64(std::get<StringData>(_data).string);
+	return internal::Base64::fromBase64(std::get<StringData>(typeData).string);
 }
 
 template <>
 MapType Value::release<MapType>()
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	if (!std::holds_alternative<MapData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::release for MapType");
@@ -242,6 +293,11 @@ MapType Value::release<MapType>()
 template <>
 ListType Value::release<ListType>()
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	if (!std::holds_alternative<ListType>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::release for ListType");
@@ -255,6 +311,11 @@ ListType Value::release<ListType>()
 template <>
 StringType Value::release<StringType>()
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	StringType result;
 
 	if (std::holds_alternative<EnumData>(_data))
@@ -279,6 +340,11 @@ StringType Value::release<StringType>()
 template <>
 ScalarType Value::release<ScalarType>()
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	if (!std::holds_alternative<ScalarData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::release for ScalarType");
@@ -299,6 +365,11 @@ ScalarType Value::release<ScalarType>()
 template <>
 IdType Value::release<IdType>()
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	if (!std::holds_alternative<StringData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::release for IdType");
@@ -396,6 +467,12 @@ Value::Value(Value&& other) noexcept
 
 Value::Value(const Value& other)
 {
+	if (std::holds_alternative<SharedData>(other._data))
+	{
+		_data = std::get<SharedData>(other._data);
+		return;
+	}
+
 	switch (other.type())
 	{
 		case Type::Map:
@@ -471,6 +548,16 @@ Value::Value(const Value& other)
 	}
 }
 
+Value::Value(std::shared_ptr<const Value> value) noexcept
+	: _data(TypeData { value })
+{
+}
+
+const Value::TypeData& Value::data() const noexcept
+{
+	return std::holds_alternative<SharedData>(_data) ? std::get<SharedData>(_data)->data() : _data;
+}
+
 Value& Value::operator=(Value&& rhs) noexcept
 {
 	if (&rhs != this)
@@ -483,7 +570,7 @@ Value& Value::operator=(Value&& rhs) noexcept
 
 bool Value::operator==(const Value& rhs) const noexcept
 {
-	return _data == rhs._data;
+	return data() == rhs.data();
 }
 
 bool Value::operator!=(const Value& rhs) const noexcept
@@ -493,6 +580,11 @@ bool Value::operator!=(const Value& rhs) const noexcept
 
 Type Value::type() const noexcept
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		return std::get<SharedData>(_data)->type();
+	}
+
 	// As long as the order of the variant alternatives matches the Type enum, we can cast the index
 	// to the Type in one step.
 	static_assert(
@@ -533,7 +625,11 @@ Type Value::type() const noexcept
 
 Value&& Value::from_json() noexcept
 {
-	if (std::holds_alternative<StringData>(_data))
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		_data = StringData { { get<StringType>() }, true };
+	}
+	else if (std::holds_alternative<StringData>(_data))
 	{
 		std::get<StringData>(_data).from_json = true;
 	}
@@ -543,12 +639,20 @@ Value&& Value::from_json() noexcept
 
 bool Value::maybe_enum() const noexcept
 {
-	return std::holds_alternative<EnumData>(_data)
-		|| (std::holds_alternative<StringData>(_data) && std::get<StringData>(_data).from_json);
+	const auto& typeData = data();
+
+	return std::holds_alternative<EnumData>(typeData)
+		|| (std::holds_alternative<StringData>(typeData)
+			&& std::get<StringData>(typeData).from_json);
 }
 
 void Value::reserve(size_t count)
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	switch (type())
 	{
 		case Type::Map:
@@ -577,12 +681,12 @@ size_t Value::size() const
 	{
 		case Type::Map:
 		{
-			return std::get<MapData>(_data).map.size();
+			return std::get<MapData>(data()).map.size();
 		}
 
 		case Type::List:
 		{
-			return std::get<ListType>(_data).size();
+			return std::get<ListType>(data()).size();
 		}
 
 		default:
@@ -592,6 +696,11 @@ size_t Value::size() const
 
 bool Value::emplace_back(std::string&& name, Value&& value)
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	if (!std::holds_alternative<MapData>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::emplace_back for MapType");
@@ -620,12 +729,14 @@ bool Value::emplace_back(std::string&& name, Value&& value)
 
 MapType::const_iterator Value::find(std::string_view name) const
 {
-	if (!std::holds_alternative<MapData>(_data))
+	const auto& typeData = data();
+
+	if (!std::holds_alternative<MapData>(typeData))
 	{
 		throw std::logic_error("Invalid call to Value::find for MapType");
 	}
 
-	const auto& mapData = std::get<MapData>(_data);
+	const auto& mapData = std::get<MapData>(typeData);
 	const auto [itr, itrEnd] = std::equal_range(mapData.members.cbegin(),
 		mapData.members.cend(),
 		std::nullopt,
@@ -645,22 +756,26 @@ MapType::const_iterator Value::find(std::string_view name) const
 
 MapType::const_iterator Value::begin() const
 {
-	if (!std::holds_alternative<MapData>(_data))
+	const auto& typeData = data();
+
+	if (!std::holds_alternative<MapData>(typeData))
 	{
 		throw std::logic_error("Invalid call to Value::begin for MapType");
 	}
 
-	return std::get<MapData>(_data).map.cbegin();
+	return std::get<MapData>(typeData).map.cbegin();
 }
 
 MapType::const_iterator Value::end() const
 {
-	if (!std::holds_alternative<MapData>(_data))
+	const auto& typeData = data();
+
+	if (!std::holds_alternative<MapData>(typeData))
 	{
 		throw std::logic_error("Invalid call to Value::end for MapType");
 	}
 
-	return std::get<MapData>(_data).map.cend();
+	return std::get<MapData>(typeData).map.cend();
 }
 
 const Value& Value::operator[](std::string_view name) const
@@ -677,6 +792,11 @@ const Value& Value::operator[](std::string_view name) const
 
 void Value::emplace_back(Value&& value)
 {
+	if (std::holds_alternative<SharedData>(_data))
+	{
+		*this = Value { *std::get<SharedData>(_data) };
+	}
+
 	if (!std::holds_alternative<ListType>(_data))
 	{
 		throw std::logic_error("Invalid call to Value::emplace_back for ListType");
@@ -687,12 +807,14 @@ void Value::emplace_back(Value&& value)
 
 const Value& Value::operator[](size_t index) const
 {
-	if (!std::holds_alternative<ListType>(_data))
+	const auto& typeData = data();
+
+	if (!std::holds_alternative<ListType>(typeData))
 	{
 		throw std::logic_error("Invalid call to Value::operator[] for ListType");
 	}
 
-	return std::get<ListType>(_data).at(index);
+	return std::get<ListType>(typeData).at(index);
 }
 
 void Writer::write(Value response) const

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -696,6 +696,13 @@ template <>
 AwaitableResolver ModifiedResult<Object>::convert(
 	FieldResult<std::shared_ptr<Object>> result, ResolverParams params)
 {
+	auto value = result.get_value();
+
+	if (value)
+	{
+		co_return ResolverResult { response::Value { std::shared_ptr { std::move(value) } } };
+	}
+
 	requireSubFields(params);
 
 	co_await params.launch;


### PR DESCRIPTION
In cases where copying elements between `service::ResolverResult` documents and converting to `response::Value` adds a lot of overhead, field getters can now hold on to a pre-converted `std::shared_ptr<const response::Value>` and return that. The `ModifiedResult` and `FieldResult` will prefer that over a value of `T` or `std::future<T>`, and `response::Value` can now perform copy-on-write from a `std::shared_ptr<const response::Value>`, so it doesn't need to repeat any conversion or copying to keep returning the same `shared_ptr`.