### PR TITLE
Distinguish AwaitableScalar from AwaitableObject

### DIFF
--- a/doc/resolvers.md
+++ b/doc/resolvers.md
@@ -73,7 +73,7 @@ service::AwaitableResolver resolveId(service::ResolverParams&& params);
 ```
 In this example, the `resolveId` method invokes `getId`:
 ```cpp
-virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const override;
+virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override;
 ```
 
 There are a couple of interesting quirks in this example:

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -295,19 +295,25 @@ struct FieldParams : SelectionSetParams
 // Field accessors may return either a result of T, an awaitable of T, or a std::future<T>, so at
 // runtime the implementer may choose to return by value or defer/parallelize expensive operations
 // by returning an async future or an awaitable coroutine.
+//
+// If the overhead of conversion to response::Value is too expensive, scalar type field accessors
+// can store and return a std::shared_ptr<const response::Value> directly. However, be careful using
+// this mechanism, because there's no validation that the response::Value you return matches the
+// GraphQL type of this field. It will be inserted directly into the response document without
+// modification.
 template <typename T>
-class FieldResult
+class AwaitableScalar
 {
 public:
 	template <typename U>
-	FieldResult(U&& value)
+	AwaitableScalar(U&& value)
 		: _value { std::forward<U>(value) }
 	{
 	}
 
 	struct promise_type
 	{
-		FieldResult<T> get_return_object() noexcept
+		AwaitableScalar<T> get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
@@ -419,6 +425,108 @@ public:
 
 private:
 	std::variant<T, std::future<T>, std::shared_ptr<const response::Value>> _value;
+};
+
+// Field accessors may return either a result of T, an awaitable of T, or a std::future<T>, so at
+// runtime the implementer may choose to return by value or defer/parallelize expensive operations
+// by returning an async future or an awaitable coroutine.
+template <typename T>
+class AwaitableObject
+{
+public:
+	template <typename U>
+	AwaitableObject(U&& value)
+		: _value { std::forward<U>(value) }
+	{
+	}
+
+	struct promise_type
+	{
+		AwaitableObject<T> get_return_object() noexcept
+		{
+			return { _promise.get_future() };
+		}
+
+		coro::suspend_never initial_suspend() const noexcept
+		{
+			return {};
+		}
+
+		coro::suspend_never final_suspend() const noexcept
+		{
+			return {};
+		}
+
+		void return_value(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
+		{
+			_promise.set_value(value);
+		}
+
+		void return_value(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
+		{
+			_promise.set_value(std::move(value));
+		}
+
+		void unhandled_exception() noexcept
+		{
+			_promise.set_exception(std::current_exception());
+		}
+
+	private:
+		std::promise<T> _promise;
+	};
+
+	bool await_ready() const noexcept
+	{
+		return std::visit(
+			[](const auto& value) noexcept {
+				using value_type = std::decay_t<decltype(value)>;
+
+				if constexpr (std::is_same_v<value_type, T>)
+				{
+					return true;
+				}
+				else if constexpr (std::is_same_v<value_type, std::future<T>>)
+				{
+					using namespace std::literals;
+
+					return value.wait_for(0s) != std::future_status::timeout;
+				}
+			},
+			_value);
+	}
+
+	void await_suspend(coro::coroutine_handle<> h) const
+	{
+		std::thread(
+			[this](coro::coroutine_handle<> h) noexcept {
+				std::get<std::future<T>>(_value).wait();
+				h.resume();
+			},
+			std::move(h))
+			.detach();
+	}
+
+	T await_resume()
+	{
+		return std::visit(
+			[](auto&& value) -> T {
+				using value_type = std::decay_t<decltype(value)>;
+
+				if constexpr (std::is_same_v<value_type, T>)
+				{
+					return T { std::move(value) };
+				}
+				else if constexpr (std::is_same_v<value_type, std::future<T>>)
+				{
+					return value.get();
+				}
+			},
+			std::move(_value));
+	}
+
+private:
+	std::variant<T, std::future<T>> _value;
 };
 
 // Fragments are referenced by name and have a single type condition (except for inline
@@ -708,7 +816,8 @@ struct ModifiedResult
 				std::vector<typename ResultTraits<U, Other...>::type>,
 				typename std::conditional_t<std::is_base_of_v<Object, U>, std::shared_ptr<U>, U>>>;
 
-		using future_type = FieldResult<type>;
+		using future_type = typename std::conditional_t<std::is_base_of_v<Object, U>,
+			AwaitableObject<type>, AwaitableScalar<type>>;
 	};
 
 	template <typename U>
@@ -718,7 +827,7 @@ struct ModifiedResult
 			typename std::conditional_t<std::is_base_of_v<Object, U>, std::shared_ptr<U>, U>;
 
 		using future_type = typename std::conditional_t<std::is_base_of_v<Object, U>,
-			FieldResult<std::shared_ptr<Object>>, FieldResult<type>>;
+			AwaitableObject<std::shared_ptr<Object>>, AwaitableScalar<type>>;
 	};
 
 	// Convert a single value of the specified type to JSON.
@@ -730,19 +839,12 @@ struct ModifiedResult
 	static typename std::enable_if_t<TypeModifier::None == Modifier && sizeof...(Other) == 0
 			&& !std::is_same_v<Object, Type> && std::is_base_of_v<Object, Type>,
 		AwaitableResolver>
-	convert(FieldResult<typename ResultTraits<Type>::type> result, ResolverParams params)
+	convert(AwaitableObject<typename ResultTraits<Type>::type> result, ResolverParams params)
 	{
 		// Call through to the Object specialization with a static_pointer_cast for subclasses of
 		// Object.
 		static_assert(std::is_same_v<std::shared_ptr<Type>, typename ResultTraits<Type>::type>,
 			"this is the derived object type");
-
-		auto value = result.get_value();
-
-		if (value)
-		{
-			co_return ResolverResult { response::Value { std::shared_ptr { std::move(value) } } };
-		}
 
 		co_await params.launch;
 
@@ -772,13 +874,6 @@ struct ModifiedResult
 	convert(
 		typename ResultTraits<Type, Modifier, Other...>::future_type result, ResolverParams params)
 	{
-		auto value = result.get_value();
-
-		if (value)
-		{
-			co_return ResolverResult { response::Value { std::shared_ptr { std::move(value) } } };
-		}
-
 		co_await params.launch;
 
 		auto awaitedResult = co_await std::move(result);
@@ -806,11 +901,15 @@ struct ModifiedResult
 						  typename ResultTraits<Type, Modifier, Other...>::type>,
 			"this is the optional version");
 
-		auto value = result.get_value();
-
-		if (value)
+		if constexpr (!std::is_base_of_v<Object, Type>)
 		{
-			co_return ResolverResult { response::Value { std::shared_ptr { std::move(value) } } };
+			auto value = result.get_value();
+
+			if (value)
+			{
+				co_return ResolverResult { response::Value {
+					std::shared_ptr { std::move(value) } } };
+			}
 		}
 
 		co_await params.launch;
@@ -833,11 +932,15 @@ struct ModifiedResult
 	static typename std::enable_if_t<TypeModifier::List == Modifier, AwaitableResolver> convert(
 		typename ResultTraits<Type, Modifier, Other...>::future_type result, ResolverParams params)
 	{
-		auto value = result.get_value();
-
-		if (value)
+		if constexpr (!std::is_base_of_v<Object, Type>)
 		{
-			co_return ResolverResult { response::Value { std::shared_ptr { std::move(value) } } };
+			auto value = result.get_value();
+
+			if (value)
+			{
+				co_return ResolverResult { response::Value {
+					std::shared_ptr { std::move(value) } } };
+			}
 		}
 
 		std::vector<AwaitableResolver> children;
@@ -988,25 +1091,25 @@ using ObjectResult = ModifiedResult<Object>;
 // Export all of the built-in converters
 template <>
 GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<int>::convert(
-	FieldResult<int> result, ResolverParams params);
+	AwaitableScalar<int> result, ResolverParams params);
 template <>
 GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<double>::convert(
-	FieldResult<double> result, ResolverParams params);
+	AwaitableScalar<double> result, ResolverParams params);
 template <>
 GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<std::string>::convert(
-	FieldResult<std::string> result, ResolverParams params);
+	AwaitableScalar<std::string> result, ResolverParams params);
 template <>
 GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<bool>::convert(
-	FieldResult<bool> result, ResolverParams params);
+	AwaitableScalar<bool> result, ResolverParams params);
 template <>
 GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<response::IdType>::convert(
-	FieldResult<response::IdType> result, ResolverParams params);
+	AwaitableScalar<response::IdType> result, ResolverParams params);
 template <>
 GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<response::Value>::convert(
-	FieldResult<response::Value> result, ResolverParams params);
+	AwaitableScalar<response::Value> result, ResolverParams params);
 template <>
 GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<Object>::convert(
-	FieldResult<std::shared_ptr<Object>> result, ResolverParams params);
+	AwaitableObject<std::shared_ptr<Object>> result, ResolverParams params);
 #endif // GRAPHQL_DLLEXPORTS
 
 // Subscription callbacks receive the response::Value representing the result of evaluating the

--- a/include/graphqlservice/introspection/DirectiveObject.h
+++ b/include/graphqlservice/introspection/DirectiveObject.h
@@ -28,11 +28,11 @@ private:
 	{
 		virtual ~Concept() = default;
 
-		virtual service::FieldResult<std::string> getName() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDescription() const = 0;
-		virtual service::FieldResult<std::vector<DirectiveLocation>> getLocations() const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
-		virtual service::FieldResult<bool> getIsRepeatable() const = 0;
+		virtual service::AwaitableScalar<std::string> getName() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		virtual service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
+		virtual service::AwaitableScalar<bool> getIsRepeatable() const = 0;
 	};
 
 	template <class T>
@@ -44,27 +44,27 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getName() const final
+		service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDescription() const final
+		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::FieldResult<std::vector<DirectiveLocation>> getLocations() const final
+		service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
 		{
 			return { _pimpl->getLocations() };
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		service::FieldResult<bool> getIsRepeatable() const final
+		service::AwaitableScalar<bool> getIsRepeatable() const final
 		{
 			return { _pimpl->getIsRepeatable() };
 		}

--- a/include/graphqlservice/introspection/EnumValueObject.h
+++ b/include/graphqlservice/introspection/EnumValueObject.h
@@ -27,10 +27,10 @@ private:
 	{
 		virtual ~Concept() = default;
 
-		virtual service::FieldResult<std::string> getName() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDescription() const = 0;
-		virtual service::FieldResult<bool> getIsDeprecated() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDeprecationReason() const = 0;
+		virtual service::AwaitableScalar<std::string> getName() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
 	};
 
 	template <class T>
@@ -42,22 +42,22 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getName() const final
+		service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDescription() const final
+		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::FieldResult<bool> getIsDeprecated() const final
+		service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDeprecationReason() const final
+		service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}

--- a/include/graphqlservice/introspection/FieldObject.h
+++ b/include/graphqlservice/introspection/FieldObject.h
@@ -29,12 +29,12 @@ private:
 	{
 		virtual ~Concept() = default;
 
-		virtual service::FieldResult<std::string> getName() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDescription() const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
-		virtual service::FieldResult<std::shared_ptr<Type>> getType() const = 0;
-		virtual service::FieldResult<bool> getIsDeprecated() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDeprecationReason() const = 0;
+		virtual service::AwaitableScalar<std::string> getName() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
+		virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
 	};
 
 	template <class T>
@@ -46,32 +46,32 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getName() const final
+		service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDescription() const final
+		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		service::FieldResult<std::shared_ptr<Type>> getType() const final
+		service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		service::FieldResult<bool> getIsDeprecated() const final
+		service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDeprecationReason() const final
+		service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}

--- a/include/graphqlservice/introspection/InputValueObject.h
+++ b/include/graphqlservice/introspection/InputValueObject.h
@@ -27,10 +27,10 @@ private:
 	{
 		virtual ~Concept() = default;
 
-		virtual service::FieldResult<std::string> getName() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDescription() const = 0;
-		virtual service::FieldResult<std::shared_ptr<Type>> getType() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDefaultValue() const = 0;
+		virtual service::AwaitableScalar<std::string> getName() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const = 0;
 	};
 
 	template <class T>
@@ -42,22 +42,22 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getName() const final
+		service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDescription() const final
+		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::FieldResult<std::shared_ptr<Type>> getType() const final
+		service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDefaultValue() const final
+		service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
 		{
 			return { _pimpl->getDefaultValue() };
 		}

--- a/include/graphqlservice/introspection/IntrospectionSchema.h
+++ b/include/graphqlservice/introspection/IntrospectionSchema.h
@@ -108,11 +108,17 @@ template <>
 GRAPHQLINTROSPECTION_EXPORT AwaitableResolver ModifiedResult<introspection::TypeKind>::convert(
 	AwaitableScalar<introspection::TypeKind> result, ResolverParams params);
 template <>
+GRAPHQLINTROSPECTION_EXPORT void ModifiedResult<introspection::TypeKind>::validateScalar(
+	const response::Value& value);
+template <>
 GRAPHQLINTROSPECTION_EXPORT introspection::DirectiveLocation ModifiedArgument<introspection::DirectiveLocation>::convert(
 	const response::Value& value);
 template <>
 GRAPHQLINTROSPECTION_EXPORT AwaitableResolver ModifiedResult<introspection::DirectiveLocation>::convert(
 	AwaitableScalar<introspection::DirectiveLocation> result, ResolverParams params);
+template <>
+GRAPHQLINTROSPECTION_EXPORT void ModifiedResult<introspection::DirectiveLocation>::validateScalar(
+	const response::Value& value);
 #endif // GRAPHQL_DLLEXPORTS
 
 } // namespace service

--- a/include/graphqlservice/introspection/IntrospectionSchema.h
+++ b/include/graphqlservice/introspection/IntrospectionSchema.h
@@ -106,13 +106,13 @@ GRAPHQLINTROSPECTION_EXPORT introspection::TypeKind ModifiedArgument<introspecti
 	const response::Value& value);
 template <>
 GRAPHQLINTROSPECTION_EXPORT AwaitableResolver ModifiedResult<introspection::TypeKind>::convert(
-	FieldResult<introspection::TypeKind> result, ResolverParams params);
+	AwaitableScalar<introspection::TypeKind> result, ResolverParams params);
 template <>
 GRAPHQLINTROSPECTION_EXPORT introspection::DirectiveLocation ModifiedArgument<introspection::DirectiveLocation>::convert(
 	const response::Value& value);
 template <>
 GRAPHQLINTROSPECTION_EXPORT AwaitableResolver ModifiedResult<introspection::DirectiveLocation>::convert(
-	FieldResult<introspection::DirectiveLocation> result, ResolverParams params);
+	AwaitableScalar<introspection::DirectiveLocation> result, ResolverParams params);
 #endif // GRAPHQL_DLLEXPORTS
 
 } // namespace service

--- a/include/graphqlservice/introspection/SchemaObject.h
+++ b/include/graphqlservice/introspection/SchemaObject.h
@@ -29,12 +29,12 @@ private:
 	{
 		virtual ~Concept() = default;
 
-		virtual service::FieldResult<std::optional<std::string>> getDescription() const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<Type>>> getTypes() const = 0;
-		virtual service::FieldResult<std::shared_ptr<Type>> getQueryType() const = 0;
-		virtual service::FieldResult<std::shared_ptr<Type>> getMutationType() const = 0;
-		virtual service::FieldResult<std::shared_ptr<Type>> getSubscriptionType() const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<Directive>>> getDirectives() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const = 0;
 	};
 
 	template <class T>
@@ -46,32 +46,32 @@ private:
 		{
 		}
 
-		service::FieldResult<std::optional<std::string>> getDescription() const final
+		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<Type>>> getTypes() const final
+		service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
 		{
 			return { _pimpl->getTypes() };
 		}
 
-		service::FieldResult<std::shared_ptr<Type>> getQueryType() const final
+		service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
 		{
 			return { _pimpl->getQueryType() };
 		}
 
-		service::FieldResult<std::shared_ptr<Type>> getMutationType() const final
+		service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
 		{
 			return { _pimpl->getMutationType() };
 		}
 
-		service::FieldResult<std::shared_ptr<Type>> getSubscriptionType() const final
+		service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
 		{
 			return { _pimpl->getSubscriptionType() };
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
+		service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
 		{
 			return { _pimpl->getDirectives() };
 		}

--- a/include/graphqlservice/introspection/TypeObject.h
+++ b/include/graphqlservice/introspection/TypeObject.h
@@ -33,16 +33,16 @@ private:
 	{
 		virtual ~Concept() = default;
 
-		virtual service::FieldResult<TypeKind> getKind() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getName() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDescription() const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const = 0;
-		virtual service::FieldResult<std::shared_ptr<Type>> getOfType() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getSpecifiedByURL() const = 0;
+		virtual service::AwaitableScalar<TypeKind> getKind() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getName() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Type>> getOfType() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const = 0;
 	};
 
 	template <class T>
@@ -54,52 +54,52 @@ private:
 		{
 		}
 
-		service::FieldResult<TypeKind> getKind() const final
+		service::AwaitableScalar<TypeKind> getKind() const final
 		{
 			return { _pimpl->getKind() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getName() const final
+		service::AwaitableScalar<std::optional<std::string>> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDescription() const final
+		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getFields(std::move(includeDeprecatedArg)) };
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
 		{
 			return { _pimpl->getInterfaces() };
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
 		{
 			return { _pimpl->getPossibleTypes() };
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getEnumValues(std::move(includeDeprecatedArg)) };
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
 		{
 			return { _pimpl->getInputFields() };
 		}
 
-		service::FieldResult<std::shared_ptr<Type>> getOfType() const final
+		service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
 		{
 			return { _pimpl->getOfType() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getSpecifiedByURL() const final
+		service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
 		{
 			return { _pimpl->getSpecifiedByURL() };
 		}

--- a/samples/learn/schema/DroidObject.h
+++ b/samples/learn/schema/DroidObject.h
@@ -23,61 +23,61 @@ namespace methods::DroidHas {
 template <class TImpl>
 concept getIdWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::string> { impl.getId(std::move(params)) } };
+	{ service::AwaitableScalar<std::string> { impl.getId(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getId = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::string> { impl.getId() } };
+	{ service::AwaitableScalar<std::string> { impl.getId() } };
 };
 
 template <class TImpl>
 concept getNameWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getName(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getName(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getName = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getName() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getName() } };
 };
 
 template <class TImpl>
 concept getFriendsWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<Character>>>> { impl.getFriends(std::move(params)) } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> { impl.getFriends(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getFriends = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<Character>>>> { impl.getFriends() } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> { impl.getFriends() } };
 };
 
 template <class TImpl>
 concept getAppearsInWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::optional<Episode>>>> { impl.getAppearsIn(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> { impl.getAppearsIn(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getAppearsIn = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::optional<Episode>>>> { impl.getAppearsIn() } };
+	{ service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> { impl.getAppearsIn() } };
 };
 
 template <class TImpl>
 concept getPrimaryFunctionWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getPrimaryFunction(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getPrimaryFunction(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getPrimaryFunction = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getPrimaryFunction() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getPrimaryFunction() } };
 };
 
 template <class TImpl>
@@ -113,11 +113,11 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::string> getId(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::string> getId(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -129,7 +129,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getId(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::string> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getIdWithParams<T>)
 			{
@@ -142,7 +142,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getNameWithParams<T>)
 			{
@@ -155,7 +155,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getFriendsWithParams<T>)
 			{
@@ -168,7 +168,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getAppearsInWithParams<T>)
 			{
@@ -181,7 +181,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getPrimaryFunctionWithParams<T>)
 			{

--- a/samples/learn/schema/HumanObject.h
+++ b/samples/learn/schema/HumanObject.h
@@ -23,61 +23,61 @@ namespace methods::HumanHas {
 template <class TImpl>
 concept getIdWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::string> { impl.getId(std::move(params)) } };
+	{ service::AwaitableScalar<std::string> { impl.getId(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getId = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::string> { impl.getId() } };
+	{ service::AwaitableScalar<std::string> { impl.getId() } };
 };
 
 template <class TImpl>
 concept getNameWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getName(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getName(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getName = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getName() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getName() } };
 };
 
 template <class TImpl>
 concept getFriendsWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<Character>>>> { impl.getFriends(std::move(params)) } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> { impl.getFriends(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getFriends = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<Character>>>> { impl.getFriends() } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> { impl.getFriends() } };
 };
 
 template <class TImpl>
 concept getAppearsInWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::optional<Episode>>>> { impl.getAppearsIn(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> { impl.getAppearsIn(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getAppearsIn = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::optional<Episode>>>> { impl.getAppearsIn() } };
+	{ service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> { impl.getAppearsIn() } };
 };
 
 template <class TImpl>
 concept getHomePlanetWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getHomePlanet(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getHomePlanet(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getHomePlanet = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getHomePlanet() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getHomePlanet() } };
 };
 
 template <class TImpl>
@@ -113,11 +113,11 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::string> getId(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::string> getId(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -129,7 +129,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getId(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::string> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getIdWithParams<T>)
 			{
@@ -142,7 +142,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getNameWithParams<T>)
 			{
@@ -155,7 +155,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getFriendsWithParams<T>)
 			{
@@ -168,7 +168,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getAppearsInWithParams<T>)
 			{
@@ -181,7 +181,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getHomePlanetWithParams<T>)
 			{

--- a/samples/learn/schema/MutationObject.h
+++ b/samples/learn/schema/MutationObject.h
@@ -16,13 +16,13 @@ namespace methods::MutationHas {
 template <class TImpl>
 concept applyCreateReviewWithParams = requires (TImpl impl, service::FieldParams params, Episode epArg, ReviewInput reviewArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Review>> { impl.applyCreateReview(std::move(params), std::move(epArg), std::move(reviewArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Review>> { impl.applyCreateReview(std::move(params), std::move(epArg), std::move(reviewArg)) } };
 };
 
 template <class TImpl>
 concept applyCreateReview = requires (TImpl impl, Episode epArg, ReviewInput reviewArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Review>> { impl.applyCreateReview(std::move(epArg), std::move(reviewArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Review>> { impl.applyCreateReview(std::move(epArg), std::move(reviewArg)) } };
 };
 
 template <class TImpl>
@@ -54,7 +54,7 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const = 0;
 	};
 
 	template <class T>
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const final
+		service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const final
 		{
 			if constexpr (methods::MutationHas::applyCreateReviewWithParams<T>)
 			{

--- a/samples/learn/schema/QueryObject.h
+++ b/samples/learn/schema/QueryObject.h
@@ -16,37 +16,37 @@ namespace methods::QueryHas {
 template <class TImpl>
 concept getHeroWithParams = requires (TImpl impl, service::FieldParams params, std::optional<Episode> episodeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Character>> { impl.getHero(std::move(params), std::move(episodeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Character>> { impl.getHero(std::move(params), std::move(episodeArg)) } };
 };
 
 template <class TImpl>
 concept getHero = requires (TImpl impl, std::optional<Episode> episodeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Character>> { impl.getHero(std::move(episodeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Character>> { impl.getHero(std::move(episodeArg)) } };
 };
 
 template <class TImpl>
 concept getHumanWithParams = requires (TImpl impl, service::FieldParams params, std::string idArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Human>> { impl.getHuman(std::move(params), std::move(idArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Human>> { impl.getHuman(std::move(params), std::move(idArg)) } };
 };
 
 template <class TImpl>
 concept getHuman = requires (TImpl impl, std::string idArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Human>> { impl.getHuman(std::move(idArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Human>> { impl.getHuman(std::move(idArg)) } };
 };
 
 template <class TImpl>
 concept getDroidWithParams = requires (TImpl impl, service::FieldParams params, std::string idArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Droid>> { impl.getDroid(std::move(params), std::move(idArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Droid>> { impl.getDroid(std::move(params), std::move(idArg)) } };
 };
 
 template <class TImpl>
 concept getDroid = requires (TImpl impl, std::string idArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Droid>> { impl.getDroid(std::move(idArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Droid>> { impl.getDroid(std::move(idArg)) } };
 };
 
 template <class TImpl>
@@ -84,9 +84,9 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const = 0;
-		virtual service::FieldResult<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, std::string&& idArg) const = 0;
-		virtual service::FieldResult<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, std::string&& idArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, std::string&& idArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, std::string&& idArg) const = 0;
 	};
 
 	template <class T>
@@ -98,7 +98,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const final
+		service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const final
 		{
 			if constexpr (methods::QueryHas::getHeroWithParams<T>)
 			{
@@ -111,7 +111,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, std::string&& idArg) const final
+		service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, std::string&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getHumanWithParams<T>)
 			{
@@ -124,7 +124,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, std::string&& idArg) const final
+		service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, std::string&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getDroidWithParams<T>)
 			{

--- a/samples/learn/schema/ReviewObject.h
+++ b/samples/learn/schema/ReviewObject.h
@@ -16,25 +16,25 @@ namespace methods::ReviewHas {
 template <class TImpl>
 concept getStarsWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<int> { impl.getStars(std::move(params)) } };
+	{ service::AwaitableScalar<int> { impl.getStars(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getStars = requires (TImpl impl) 
 {
-	{ service::FieldResult<int> { impl.getStars() } };
+	{ service::AwaitableScalar<int> { impl.getStars() } };
 };
 
 template <class TImpl>
 concept getCommentaryWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getCommentary(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getCommentary(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getCommentary = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getCommentary() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getCommentary() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<int> getStars(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getCommentary(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<int> getStars(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<int> getStars(service::FieldParams&& params) const final
+		service::AwaitableScalar<int> getStars(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ReviewHas::getStarsWithParams<T>)
 			{
@@ -93,7 +93,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getCommentary(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ReviewHas::getCommentaryWithParams<T>)
 			{

--- a/samples/learn/schema/StarWarsSchema.cpp
+++ b/samples/learn/schema/StarWarsSchema.cpp
@@ -49,7 +49,7 @@ learn::Episode ModifiedArgument<learn::Episode>::convert(const response::Value& 
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<learn::Episode>::convert(service::FieldResult<learn::Episode> result, ResolverParams params)
+service::AwaitableResolver ModifiedResult<learn::Episode>::convert(service::AwaitableScalar<learn::Episode> result, ResolverParams params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](learn::Episode value, const ResolverParams&)

--- a/samples/learn/schema/StarWarsSchema.cpp
+++ b/samples/learn/schema/StarWarsSchema.cpp
@@ -63,6 +63,22 @@ service::AwaitableResolver ModifiedResult<learn::Episode>::convert(service::Awai
 }
 
 template <>
+void ModifiedResult<learn::Episode>::validateScalar(const response::Value& value)
+{
+	if (!value.maybe_enum())
+	{
+		throw service::schema_exception { { R"ex(not a valid Episode value)ex" } };
+	}
+
+	const auto itr = std::find(s_namesEpisode.cbegin(), s_namesEpisode.cend(), value.get<std::string>());
+
+	if (itr == s_namesEpisode.cend())
+	{
+		throw service::schema_exception { { R"ex(not a valid Episode value)ex" } };
+	}
+}
+
+template <>
 learn::ReviewInput ModifiedArgument<learn::ReviewInput>::convert(const response::Value& value)
 {
 	auto valueStars = service::ModifiedArgument<int>::require("stars", value);

--- a/samples/today/TodayMock.cpp
+++ b/samples/today/TodayMock.cpp
@@ -174,7 +174,7 @@ auto operator co_await(std::chrono::duration<_Rep, _Period> delay)
 	return awaiter { delay };
 }
 
-service::FieldResult<std::shared_ptr<object::Node>> Query::getNode(
+service::AwaitableObject<std::shared_ptr<object::Node>> Query::getNode(
 	service::FieldParams params, response::IdType id)
 {
 	// query { node(id: "ZmFrZVRhc2tJZA==") { ...on Task { title } } }

--- a/samples/today/TodayMock.h
+++ b/samples/today/TodayMock.h
@@ -59,7 +59,7 @@ public:
 	explicit Query(appointmentsLoader&& getAppointments, tasksLoader&& getTasks,
 		unreadCountsLoader&& getUnreadCounts);
 
-	service::FieldResult<std::shared_ptr<object::Node>> getNode(
+	service::AwaitableObject<std::shared_ptr<object::Node>> getNode(
 		service::FieldParams params, response::IdType id);
 	std::future<std::shared_ptr<object::AppointmentConnection>> getAppointments(
 		const service::FieldParams& params, std::optional<int> first,
@@ -142,7 +142,7 @@ public:
 		return _id;
 	}
 
-	service::FieldResult<response::IdType> getId() const noexcept
+	service::AwaitableScalar<response::IdType> getId() const noexcept
 	{
 		return _id;
 	}
@@ -187,7 +187,7 @@ public:
 		return std::make_shared<object::Appointment>(_appointment);
 	}
 
-	service::FieldResult<response::Value> getCursor() const
+	service::AwaitableScalar<response::Value> getCursor() const
 	{
 		co_return response::Value(co_await _appointment->getId());
 	}
@@ -243,7 +243,7 @@ public:
 		return _id;
 	}
 
-	service::FieldResult<response::IdType> getId() const noexcept
+	service::AwaitableScalar<response::IdType> getId() const noexcept
 	{
 		return _id;
 	}
@@ -278,7 +278,7 @@ public:
 		return std::make_shared<object::Task>(_task);
 	}
 
-	service::FieldResult<response::Value> getCursor() const noexcept
+	service::AwaitableScalar<response::Value> getCursor() const noexcept
 	{
 		co_return response::Value(co_await _task->getId());
 	}
@@ -333,7 +333,7 @@ public:
 		return _id;
 	}
 
-	service::FieldResult<response::IdType> getId() const noexcept
+	service::AwaitableScalar<response::IdType> getId() const noexcept
 	{
 		return _id;
 	}
@@ -367,7 +367,7 @@ public:
 		return std::make_shared<object::Folder>(_folder);
 	}
 
-	service::FieldResult<response::Value> getCursor() const noexcept
+	service::AwaitableScalar<response::Value> getCursor() const noexcept
 	{
 		co_return response::Value(co_await _folder->getId());
 	}

--- a/samples/today/nointrospection/AppointmentConnectionObject.h
+++ b/samples/today/nointrospection/AppointmentConnectionObject.h
@@ -16,25 +16,25 @@ namespace methods::AppointmentConnectionHas {
 template <class TImpl>
 concept getPageInfoWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<PageInfo>> { impl.getPageInfo(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<PageInfo>> { impl.getPageInfo(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getPageInfo = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<PageInfo>> { impl.getPageInfo() } };
+	{ service::AwaitableObject<std::shared_ptr<PageInfo>> { impl.getPageInfo() } };
 };
 
 template <class TImpl>
 concept getEdgesWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> { impl.getEdges(std::move(params)) } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> { impl.getEdges(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getEdges = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> { impl.getEdges() } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> { impl.getEdges() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getEdgesWithParams<T>)
 			{

--- a/samples/today/nointrospection/AppointmentEdgeObject.h
+++ b/samples/today/nointrospection/AppointmentEdgeObject.h
@@ -16,25 +16,25 @@ namespace methods::AppointmentEdgeHas {
 template <class TImpl>
 concept getNodeWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Appointment>> { impl.getNode(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Appointment>> { impl.getNode(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNode = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Appointment>> { impl.getNode() } };
+	{ service::AwaitableObject<std::shared_ptr<Appointment>> { impl.getNode() } };
 };
 
 template <class TImpl>
 concept getCursorWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::Value> { impl.getCursor(std::move(params)) } };
+	{ service::AwaitableScalar<response::Value> { impl.getCursor(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getCursor = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::Value> { impl.getCursor() } };
+	{ service::AwaitableScalar<response::Value> { impl.getCursor() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getCursorWithParams<T>)
 			{

--- a/samples/today/nointrospection/AppointmentObject.h
+++ b/samples/today/nointrospection/AppointmentObject.h
@@ -23,61 +23,61 @@ namespace methods::AppointmentHas {
 template <class TImpl>
 concept getIdWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId(std::move(params)) } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getId = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId() } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId() } };
 };
 
 template <class TImpl>
 concept getWhenWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<response::Value>> { impl.getWhen(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<response::Value>> { impl.getWhen(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getWhen = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<response::Value>> { impl.getWhen() } };
+	{ service::AwaitableScalar<std::optional<response::Value>> { impl.getWhen() } };
 };
 
 template <class TImpl>
 concept getSubjectWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getSubject(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getSubject(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getSubject = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getSubject() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getSubject() } };
 };
 
 template <class TImpl>
 concept getIsNowWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<bool> { impl.getIsNow(std::move(params)) } };
+	{ service::AwaitableScalar<bool> { impl.getIsNow(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getIsNow = requires (TImpl impl) 
 {
-	{ service::FieldResult<bool> { impl.getIsNow() } };
+	{ service::AwaitableScalar<bool> { impl.getIsNow() } };
 };
 
 template <class TImpl>
 concept getForceErrorWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getForceError(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getForceError(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getForceError = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getForceError() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getForceError() } };
 };
 
 template <class TImpl>
@@ -113,11 +113,11 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<response::Value>> getWhen(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getSubject(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<bool> getIsNow(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getForceError(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -129,7 +129,7 @@ private:
 		{
 		}
 
-		service::FieldResult<response::IdType> getId(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIdWithParams<T>)
 			{
@@ -145,7 +145,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getWhenWithParams<T>)
 			{
@@ -161,7 +161,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getSubjectWithParams<T>)
 			{
@@ -177,7 +177,7 @@ private:
 			}
 		}
 
-		service::FieldResult<bool> getIsNow(service::FieldParams&& params) const final
+		service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIsNowWithParams<T>)
 			{
@@ -193,7 +193,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getForceErrorWithParams<T>)
 			{

--- a/samples/today/nointrospection/CompleteTaskPayloadObject.h
+++ b/samples/today/nointrospection/CompleteTaskPayloadObject.h
@@ -16,25 +16,25 @@ namespace methods::CompleteTaskPayloadHas {
 template <class TImpl>
 concept getTaskWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Task>> { impl.getTask(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Task>> { impl.getTask(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getTask = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Task>> { impl.getTask() } };
+	{ service::AwaitableObject<std::shared_ptr<Task>> { impl.getTask() } };
 };
 
 template <class TImpl>
 concept getClientMutationIdWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getClientMutationId(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getClientMutationId(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getClientMutationId = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getClientMutationId() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getClientMutationId() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getClientMutationIdWithParams<T>)
 			{

--- a/samples/today/nointrospection/ExpensiveObject.h
+++ b/samples/today/nointrospection/ExpensiveObject.h
@@ -16,13 +16,13 @@ namespace methods::ExpensiveHas {
 template <class TImpl>
 concept getOrderWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<int> { impl.getOrder(std::move(params)) } };
+	{ service::AwaitableScalar<int> { impl.getOrder(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getOrder = requires (TImpl impl) 
 {
-	{ service::FieldResult<int> { impl.getOrder() } };
+	{ service::AwaitableScalar<int> { impl.getOrder() } };
 };
 
 template <class TImpl>
@@ -54,7 +54,7 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<int> getOrder(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		service::FieldResult<int> getOrder(service::FieldParams&& params) const final
+		service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::getOrderWithParams<T>)
 			{

--- a/samples/today/nointrospection/FolderConnectionObject.h
+++ b/samples/today/nointrospection/FolderConnectionObject.h
@@ -16,25 +16,25 @@ namespace methods::FolderConnectionHas {
 template <class TImpl>
 concept getPageInfoWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<PageInfo>> { impl.getPageInfo(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<PageInfo>> { impl.getPageInfo(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getPageInfo = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<PageInfo>> { impl.getPageInfo() } };
+	{ service::AwaitableObject<std::shared_ptr<PageInfo>> { impl.getPageInfo() } };
 };
 
 template <class TImpl>
 concept getEdgesWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> { impl.getEdges(std::move(params)) } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> { impl.getEdges(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getEdges = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> { impl.getEdges() } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> { impl.getEdges() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getEdgesWithParams<T>)
 			{

--- a/samples/today/nointrospection/FolderEdgeObject.h
+++ b/samples/today/nointrospection/FolderEdgeObject.h
@@ -16,25 +16,25 @@ namespace methods::FolderEdgeHas {
 template <class TImpl>
 concept getNodeWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Folder>> { impl.getNode(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Folder>> { impl.getNode(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNode = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Folder>> { impl.getNode() } };
+	{ service::AwaitableObject<std::shared_ptr<Folder>> { impl.getNode() } };
 };
 
 template <class TImpl>
 concept getCursorWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::Value> { impl.getCursor(std::move(params)) } };
+	{ service::AwaitableScalar<response::Value> { impl.getCursor(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getCursor = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::Value> { impl.getCursor() } };
+	{ service::AwaitableScalar<response::Value> { impl.getCursor() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getCursorWithParams<T>)
 			{

--- a/samples/today/nointrospection/FolderObject.h
+++ b/samples/today/nointrospection/FolderObject.h
@@ -23,37 +23,37 @@ namespace methods::FolderHas {
 template <class TImpl>
 concept getIdWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId(std::move(params)) } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getId = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId() } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId() } };
 };
 
 template <class TImpl>
 concept getNameWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getName(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getName(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getName = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getName() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getName() } };
 };
 
 template <class TImpl>
 concept getUnreadCountWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<int> { impl.getUnreadCount(std::move(params)) } };
+	{ service::AwaitableScalar<int> { impl.getUnreadCount(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getUnreadCount = requires (TImpl impl) 
 {
-	{ service::FieldResult<int> { impl.getUnreadCount() } };
+	{ service::AwaitableScalar<int> { impl.getUnreadCount() } };
 };
 
 template <class TImpl>
@@ -87,9 +87,9 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<int> getUnreadCount(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -101,7 +101,7 @@ private:
 		{
 		}
 
-		service::FieldResult<response::IdType> getId(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getNameWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		service::FieldResult<int> getUnreadCount(service::FieldParams&& params) const final
+		service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getUnreadCountWithParams<T>)
 			{

--- a/samples/today/nointrospection/MutationObject.h
+++ b/samples/today/nointrospection/MutationObject.h
@@ -16,25 +16,25 @@ namespace methods::MutationHas {
 template <class TImpl>
 concept applyCompleteTaskWithParams = requires (TImpl impl, service::FieldParams params, CompleteTaskInput inputArg) 
 {
-	{ service::FieldResult<std::shared_ptr<CompleteTaskPayload>> { impl.applyCompleteTask(std::move(params), std::move(inputArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> { impl.applyCompleteTask(std::move(params), std::move(inputArg)) } };
 };
 
 template <class TImpl>
 concept applyCompleteTask = requires (TImpl impl, CompleteTaskInput inputArg) 
 {
-	{ service::FieldResult<std::shared_ptr<CompleteTaskPayload>> { impl.applyCompleteTask(std::move(inputArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> { impl.applyCompleteTask(std::move(inputArg)) } };
 };
 
 template <class TImpl>
 concept applySetFloatWithParams = requires (TImpl impl, service::FieldParams params, double valueArg) 
 {
-	{ service::FieldResult<double> { impl.applySetFloat(std::move(params), std::move(valueArg)) } };
+	{ service::AwaitableScalar<double> { impl.applySetFloat(std::move(params), std::move(valueArg)) } };
 };
 
 template <class TImpl>
 concept applySetFloat = requires (TImpl impl, double valueArg) 
 {
-	{ service::FieldResult<double> { impl.applySetFloat(std::move(valueArg)) } };
+	{ service::AwaitableScalar<double> { impl.applySetFloat(std::move(valueArg)) } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const = 0;
-		virtual service::FieldResult<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const = 0;
+		virtual service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
+		service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
 		{
 			if constexpr (methods::MutationHas::applyCompleteTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
+		service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
 		{
 			if constexpr (methods::MutationHas::applySetFloatWithParams<T>)
 			{

--- a/samples/today/nointrospection/NestedTypeObject.h
+++ b/samples/today/nointrospection/NestedTypeObject.h
@@ -16,25 +16,25 @@ namespace methods::NestedTypeHas {
 template <class TImpl>
 concept getDepthWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<int> { impl.getDepth(std::move(params)) } };
+	{ service::AwaitableScalar<int> { impl.getDepth(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getDepth = requires (TImpl impl) 
 {
-	{ service::FieldResult<int> { impl.getDepth() } };
+	{ service::AwaitableScalar<int> { impl.getDepth() } };
 };
 
 template <class TImpl>
 concept getNestedWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<NestedType>> { impl.getNested(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<NestedType>> { impl.getNested(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNested = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<NestedType>> { impl.getNested() } };
+	{ service::AwaitableObject<std::shared_ptr<NestedType>> { impl.getNested() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<int> getDepth(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<int> getDepth(service::FieldParams&& params) const final
+		service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getDepthWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getNestedWithParams<T>)
 			{

--- a/samples/today/nointrospection/PageInfoObject.h
+++ b/samples/today/nointrospection/PageInfoObject.h
@@ -16,25 +16,25 @@ namespace methods::PageInfoHas {
 template <class TImpl>
 concept getHasNextPageWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<bool> { impl.getHasNextPage(std::move(params)) } };
+	{ service::AwaitableScalar<bool> { impl.getHasNextPage(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getHasNextPage = requires (TImpl impl) 
 {
-	{ service::FieldResult<bool> { impl.getHasNextPage() } };
+	{ service::AwaitableScalar<bool> { impl.getHasNextPage() } };
 };
 
 template <class TImpl>
 concept getHasPreviousPageWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<bool> { impl.getHasPreviousPage(std::move(params)) } };
+	{ service::AwaitableScalar<bool> { impl.getHasPreviousPage(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getHasPreviousPage = requires (TImpl impl) 
 {
-	{ service::FieldResult<bool> { impl.getHasPreviousPage() } };
+	{ service::AwaitableScalar<bool> { impl.getHasPreviousPage() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<bool> getHasNextPage(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<bool> getHasPreviousPage(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<bool> getHasNextPage(service::FieldParams&& params) const final
+		service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasNextPageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<bool> getHasPreviousPage(service::FieldParams&& params) const final
+		service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasPreviousPageWithParams<T>)
 			{

--- a/samples/today/nointrospection/QueryObject.h
+++ b/samples/today/nointrospection/QueryObject.h
@@ -16,145 +16,145 @@ namespace methods::QueryHas {
 template <class TImpl>
 concept getNodeWithParams = requires (TImpl impl, service::FieldParams params, response::IdType idArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Node>> { impl.getNode(std::move(params), std::move(idArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Node>> { impl.getNode(std::move(params), std::move(idArg)) } };
 };
 
 template <class TImpl>
 concept getNode = requires (TImpl impl, response::IdType idArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Node>> { impl.getNode(std::move(idArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Node>> { impl.getNode(std::move(idArg)) } };
 };
 
 template <class TImpl>
 concept getAppointmentsWithParams = requires (TImpl impl, service::FieldParams params, std::optional<int> firstArg, std::optional<response::Value> afterArg, std::optional<int> lastArg, std::optional<response::Value> beforeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<AppointmentConnection>> { impl.getAppointments(std::move(params), std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<AppointmentConnection>> { impl.getAppointments(std::move(params), std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
 };
 
 template <class TImpl>
 concept getAppointments = requires (TImpl impl, std::optional<int> firstArg, std::optional<response::Value> afterArg, std::optional<int> lastArg, std::optional<response::Value> beforeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<AppointmentConnection>> { impl.getAppointments(std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<AppointmentConnection>> { impl.getAppointments(std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
 };
 
 template <class TImpl>
 concept getTasksWithParams = requires (TImpl impl, service::FieldParams params, std::optional<int> firstArg, std::optional<response::Value> afterArg, std::optional<int> lastArg, std::optional<response::Value> beforeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<TaskConnection>> { impl.getTasks(std::move(params), std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<TaskConnection>> { impl.getTasks(std::move(params), std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
 };
 
 template <class TImpl>
 concept getTasks = requires (TImpl impl, std::optional<int> firstArg, std::optional<response::Value> afterArg, std::optional<int> lastArg, std::optional<response::Value> beforeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<TaskConnection>> { impl.getTasks(std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<TaskConnection>> { impl.getTasks(std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
 };
 
 template <class TImpl>
 concept getUnreadCountsWithParams = requires (TImpl impl, service::FieldParams params, std::optional<int> firstArg, std::optional<response::Value> afterArg, std::optional<int> lastArg, std::optional<response::Value> beforeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<FolderConnection>> { impl.getUnreadCounts(std::move(params), std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<FolderConnection>> { impl.getUnreadCounts(std::move(params), std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
 };
 
 template <class TImpl>
 concept getUnreadCounts = requires (TImpl impl, std::optional<int> firstArg, std::optional<response::Value> afterArg, std::optional<int> lastArg, std::optional<response::Value> beforeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<FolderConnection>> { impl.getUnreadCounts(std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<FolderConnection>> { impl.getUnreadCounts(std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
 };
 
 template <class TImpl>
 concept getAppointmentsByIdWithParams = requires (TImpl impl, service::FieldParams params, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Appointment>>> { impl.getAppointmentsById(std::move(params), std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> { impl.getAppointmentsById(std::move(params), std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getAppointmentsById = requires (TImpl impl, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Appointment>>> { impl.getAppointmentsById(std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> { impl.getAppointmentsById(std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getTasksByIdWithParams = requires (TImpl impl, service::FieldParams params, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Task>>> { impl.getTasksById(std::move(params), std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Task>>> { impl.getTasksById(std::move(params), std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getTasksById = requires (TImpl impl, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Task>>> { impl.getTasksById(std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Task>>> { impl.getTasksById(std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getUnreadCountsByIdWithParams = requires (TImpl impl, service::FieldParams params, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Folder>>> { impl.getUnreadCountsById(std::move(params), std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> { impl.getUnreadCountsById(std::move(params), std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getUnreadCountsById = requires (TImpl impl, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Folder>>> { impl.getUnreadCountsById(std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> { impl.getUnreadCountsById(std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getNestedWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<NestedType>> { impl.getNested(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<NestedType>> { impl.getNested(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNested = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<NestedType>> { impl.getNested() } };
+	{ service::AwaitableObject<std::shared_ptr<NestedType>> { impl.getNested() } };
 };
 
 template <class TImpl>
 concept getUnimplementedWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::string> { impl.getUnimplemented(std::move(params)) } };
+	{ service::AwaitableScalar<std::string> { impl.getUnimplemented(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getUnimplemented = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::string> { impl.getUnimplemented() } };
+	{ service::AwaitableScalar<std::string> { impl.getUnimplemented() } };
 };
 
 template <class TImpl>
 concept getExpensiveWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Expensive>>> { impl.getExpensive(std::move(params)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> { impl.getExpensive(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getExpensive = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Expensive>>> { impl.getExpensive() } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> { impl.getExpensive() } };
 };
 
 template <class TImpl>
 concept getTestTaskStateWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<TaskState> { impl.getTestTaskState(std::move(params)) } };
+	{ service::AwaitableScalar<TaskState> { impl.getTestTaskState(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getTestTaskState = requires (TImpl impl) 
 {
-	{ service::FieldResult<TaskState> { impl.getTestTaskState() } };
+	{ service::AwaitableScalar<TaskState> { impl.getTestTaskState() } };
 };
 
 template <class TImpl>
 concept getAnyTypeWithParams = requires (TImpl impl, service::FieldParams params, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<UnionType>>> { impl.getAnyType(std::move(params), std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> { impl.getAnyType(std::move(params), std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getAnyType = requires (TImpl impl, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<UnionType>>> { impl.getAnyType(std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> { impl.getAnyType(std::move(idsArg)) } };
 };
 
 template <class TImpl>
@@ -197,18 +197,18 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const = 0;
-		virtual service::FieldResult<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		virtual service::FieldResult<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		virtual service::FieldResult<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::string> getUnimplemented(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<TaskState> getTestTaskState(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
 	};
 
 	template <class T>
@@ -220,7 +220,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
+		service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getNodeWithParams<T>)
 			{
@@ -236,7 +236,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsWithParams<T>)
 			{
@@ -252,7 +252,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksWithParams<T>)
 			{
@@ -268,7 +268,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsWithParams<T>)
 			{
@@ -284,7 +284,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsByIdWithParams<T>)
 			{
@@ -300,7 +300,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksByIdWithParams<T>)
 			{
@@ -316,7 +316,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsByIdWithParams<T>)
 			{
@@ -332,7 +332,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getNestedWithParams<T>)
 			{
@@ -348,7 +348,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::string> getUnimplemented(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getUnimplementedWithParams<T>)
 			{
@@ -364,7 +364,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
+		service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getExpensiveWithParams<T>)
 			{
@@ -380,7 +380,7 @@ private:
 			}
 		}
 
-		service::FieldResult<TaskState> getTestTaskState(service::FieldParams&& params) const final
+		service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getTestTaskStateWithParams<T>)
 			{
@@ -396,7 +396,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAnyTypeWithParams<T>)
 			{

--- a/samples/today/nointrospection/SubscriptionObject.h
+++ b/samples/today/nointrospection/SubscriptionObject.h
@@ -16,25 +16,25 @@ namespace methods::SubscriptionHas {
 template <class TImpl>
 concept getNextAppointmentChangeWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Appointment>> { impl.getNextAppointmentChange(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Appointment>> { impl.getNextAppointmentChange(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNextAppointmentChange = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Appointment>> { impl.getNextAppointmentChange() } };
+	{ service::AwaitableObject<std::shared_ptr<Appointment>> { impl.getNextAppointmentChange() } };
 };
 
 template <class TImpl>
 concept getNodeChangeWithParams = requires (TImpl impl, service::FieldParams params, response::IdType idArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Node>> { impl.getNodeChange(std::move(params), std::move(idArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Node>> { impl.getNodeChange(std::move(params), std::move(idArg)) } };
 };
 
 template <class TImpl>
 concept getNodeChange = requires (TImpl impl, response::IdType idArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Node>> { impl.getNodeChange(std::move(idArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Node>> { impl.getNodeChange(std::move(idArg)) } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNextAppointmentChangeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
+		service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNodeChangeWithParams<T>)
 			{

--- a/samples/today/nointrospection/TaskConnectionObject.h
+++ b/samples/today/nointrospection/TaskConnectionObject.h
@@ -16,25 +16,25 @@ namespace methods::TaskConnectionHas {
 template <class TImpl>
 concept getPageInfoWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<PageInfo>> { impl.getPageInfo(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<PageInfo>> { impl.getPageInfo(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getPageInfo = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<PageInfo>> { impl.getPageInfo() } };
+	{ service::AwaitableObject<std::shared_ptr<PageInfo>> { impl.getPageInfo() } };
 };
 
 template <class TImpl>
 concept getEdgesWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> { impl.getEdges(std::move(params)) } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> { impl.getEdges(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getEdges = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> { impl.getEdges() } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> { impl.getEdges() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getEdgesWithParams<T>)
 			{

--- a/samples/today/nointrospection/TaskEdgeObject.h
+++ b/samples/today/nointrospection/TaskEdgeObject.h
@@ -16,25 +16,25 @@ namespace methods::TaskEdgeHas {
 template <class TImpl>
 concept getNodeWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Task>> { impl.getNode(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Task>> { impl.getNode(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNode = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Task>> { impl.getNode() } };
+	{ service::AwaitableObject<std::shared_ptr<Task>> { impl.getNode() } };
 };
 
 template <class TImpl>
 concept getCursorWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::Value> { impl.getCursor(std::move(params)) } };
+	{ service::AwaitableScalar<response::Value> { impl.getCursor(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getCursor = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::Value> { impl.getCursor() } };
+	{ service::AwaitableScalar<response::Value> { impl.getCursor() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getCursorWithParams<T>)
 			{

--- a/samples/today/nointrospection/TaskObject.h
+++ b/samples/today/nointrospection/TaskObject.h
@@ -23,37 +23,37 @@ namespace methods::TaskHas {
 template <class TImpl>
 concept getIdWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId(std::move(params)) } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getId = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId() } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId() } };
 };
 
 template <class TImpl>
 concept getTitleWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getTitle(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getTitle(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getTitle = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getTitle() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getTitle() } };
 };
 
 template <class TImpl>
 concept getIsCompleteWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<bool> { impl.getIsComplete(std::move(params)) } };
+	{ service::AwaitableScalar<bool> { impl.getIsComplete(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getIsComplete = requires (TImpl impl) 
 {
-	{ service::FieldResult<bool> { impl.getIsComplete() } };
+	{ service::AwaitableScalar<bool> { impl.getIsComplete() } };
 };
 
 template <class TImpl>
@@ -87,9 +87,9 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getTitle(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<bool> getIsComplete(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -101,7 +101,7 @@ private:
 		{
 		}
 
-		service::FieldResult<response::IdType> getId(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getTitleWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		service::FieldResult<bool> getIsComplete(service::FieldParams&& params) const final
+		service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIsCompleteWithParams<T>)
 			{

--- a/samples/today/nointrospection/TodaySchema.cpp
+++ b/samples/today/nointrospection/TodaySchema.cpp
@@ -65,6 +65,22 @@ service::AwaitableResolver ModifiedResult<today::TaskState>::convert(service::Aw
 }
 
 template <>
+void ModifiedResult<today::TaskState>::validateScalar(const response::Value& value)
+{
+	if (!value.maybe_enum())
+	{
+		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
+	}
+
+	const auto itr = std::find(s_namesTaskState.cbegin(), s_namesTaskState.cend(), value.get<std::string>());
+
+	if (itr == s_namesTaskState.cend())
+	{
+		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
+	}
+}
+
+template <>
 today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(const response::Value& value)
 {
 	const auto defaultValue = []()

--- a/samples/today/nointrospection/TodaySchema.cpp
+++ b/samples/today/nointrospection/TodaySchema.cpp
@@ -51,7 +51,7 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Val
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<today::TaskState>::convert(service::FieldResult<today::TaskState> result, ResolverParams params)
+service::AwaitableResolver ModifiedResult<today::TaskState>::convert(service::AwaitableScalar<today::TaskState> result, ResolverParams params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](today::TaskState value, const ResolverParams&)

--- a/samples/today/schema/AppointmentConnectionObject.h
+++ b/samples/today/schema/AppointmentConnectionObject.h
@@ -16,25 +16,25 @@ namespace methods::AppointmentConnectionHas {
 template <class TImpl>
 concept getPageInfoWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<PageInfo>> { impl.getPageInfo(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<PageInfo>> { impl.getPageInfo(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getPageInfo = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<PageInfo>> { impl.getPageInfo() } };
+	{ service::AwaitableObject<std::shared_ptr<PageInfo>> { impl.getPageInfo() } };
 };
 
 template <class TImpl>
 concept getEdgesWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> { impl.getEdges(std::move(params)) } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> { impl.getEdges(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getEdges = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> { impl.getEdges() } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> { impl.getEdges() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getEdgesWithParams<T>)
 			{

--- a/samples/today/schema/AppointmentEdgeObject.h
+++ b/samples/today/schema/AppointmentEdgeObject.h
@@ -16,25 +16,25 @@ namespace methods::AppointmentEdgeHas {
 template <class TImpl>
 concept getNodeWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Appointment>> { impl.getNode(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Appointment>> { impl.getNode(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNode = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Appointment>> { impl.getNode() } };
+	{ service::AwaitableObject<std::shared_ptr<Appointment>> { impl.getNode() } };
 };
 
 template <class TImpl>
 concept getCursorWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::Value> { impl.getCursor(std::move(params)) } };
+	{ service::AwaitableScalar<response::Value> { impl.getCursor(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getCursor = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::Value> { impl.getCursor() } };
+	{ service::AwaitableScalar<response::Value> { impl.getCursor() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getCursorWithParams<T>)
 			{

--- a/samples/today/schema/AppointmentObject.h
+++ b/samples/today/schema/AppointmentObject.h
@@ -23,61 +23,61 @@ namespace methods::AppointmentHas {
 template <class TImpl>
 concept getIdWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId(std::move(params)) } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getId = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId() } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId() } };
 };
 
 template <class TImpl>
 concept getWhenWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<response::Value>> { impl.getWhen(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<response::Value>> { impl.getWhen(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getWhen = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<response::Value>> { impl.getWhen() } };
+	{ service::AwaitableScalar<std::optional<response::Value>> { impl.getWhen() } };
 };
 
 template <class TImpl>
 concept getSubjectWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getSubject(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getSubject(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getSubject = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getSubject() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getSubject() } };
 };
 
 template <class TImpl>
 concept getIsNowWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<bool> { impl.getIsNow(std::move(params)) } };
+	{ service::AwaitableScalar<bool> { impl.getIsNow(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getIsNow = requires (TImpl impl) 
 {
-	{ service::FieldResult<bool> { impl.getIsNow() } };
+	{ service::AwaitableScalar<bool> { impl.getIsNow() } };
 };
 
 template <class TImpl>
 concept getForceErrorWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getForceError(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getForceError(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getForceError = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getForceError() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getForceError() } };
 };
 
 template <class TImpl>
@@ -113,11 +113,11 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<response::Value>> getWhen(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getSubject(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<bool> getIsNow(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getForceError(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -129,7 +129,7 @@ private:
 		{
 		}
 
-		service::FieldResult<response::IdType> getId(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIdWithParams<T>)
 			{
@@ -145,7 +145,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getWhenWithParams<T>)
 			{
@@ -161,7 +161,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getSubjectWithParams<T>)
 			{
@@ -177,7 +177,7 @@ private:
 			}
 		}
 
-		service::FieldResult<bool> getIsNow(service::FieldParams&& params) const final
+		service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIsNowWithParams<T>)
 			{
@@ -193,7 +193,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getForceErrorWithParams<T>)
 			{

--- a/samples/today/schema/CompleteTaskPayloadObject.h
+++ b/samples/today/schema/CompleteTaskPayloadObject.h
@@ -16,25 +16,25 @@ namespace methods::CompleteTaskPayloadHas {
 template <class TImpl>
 concept getTaskWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Task>> { impl.getTask(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Task>> { impl.getTask(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getTask = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Task>> { impl.getTask() } };
+	{ service::AwaitableObject<std::shared_ptr<Task>> { impl.getTask() } };
 };
 
 template <class TImpl>
 concept getClientMutationIdWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getClientMutationId(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getClientMutationId(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getClientMutationId = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getClientMutationId() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getClientMutationId() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getClientMutationIdWithParams<T>)
 			{

--- a/samples/today/schema/ExpensiveObject.h
+++ b/samples/today/schema/ExpensiveObject.h
@@ -16,13 +16,13 @@ namespace methods::ExpensiveHas {
 template <class TImpl>
 concept getOrderWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<int> { impl.getOrder(std::move(params)) } };
+	{ service::AwaitableScalar<int> { impl.getOrder(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getOrder = requires (TImpl impl) 
 {
-	{ service::FieldResult<int> { impl.getOrder() } };
+	{ service::AwaitableScalar<int> { impl.getOrder() } };
 };
 
 template <class TImpl>
@@ -54,7 +54,7 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<int> getOrder(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		service::FieldResult<int> getOrder(service::FieldParams&& params) const final
+		service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::getOrderWithParams<T>)
 			{

--- a/samples/today/schema/FolderConnectionObject.h
+++ b/samples/today/schema/FolderConnectionObject.h
@@ -16,25 +16,25 @@ namespace methods::FolderConnectionHas {
 template <class TImpl>
 concept getPageInfoWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<PageInfo>> { impl.getPageInfo(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<PageInfo>> { impl.getPageInfo(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getPageInfo = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<PageInfo>> { impl.getPageInfo() } };
+	{ service::AwaitableObject<std::shared_ptr<PageInfo>> { impl.getPageInfo() } };
 };
 
 template <class TImpl>
 concept getEdgesWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> { impl.getEdges(std::move(params)) } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> { impl.getEdges(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getEdges = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> { impl.getEdges() } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> { impl.getEdges() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getEdgesWithParams<T>)
 			{

--- a/samples/today/schema/FolderEdgeObject.h
+++ b/samples/today/schema/FolderEdgeObject.h
@@ -16,25 +16,25 @@ namespace methods::FolderEdgeHas {
 template <class TImpl>
 concept getNodeWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Folder>> { impl.getNode(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Folder>> { impl.getNode(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNode = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Folder>> { impl.getNode() } };
+	{ service::AwaitableObject<std::shared_ptr<Folder>> { impl.getNode() } };
 };
 
 template <class TImpl>
 concept getCursorWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::Value> { impl.getCursor(std::move(params)) } };
+	{ service::AwaitableScalar<response::Value> { impl.getCursor(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getCursor = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::Value> { impl.getCursor() } };
+	{ service::AwaitableScalar<response::Value> { impl.getCursor() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getCursorWithParams<T>)
 			{

--- a/samples/today/schema/FolderObject.h
+++ b/samples/today/schema/FolderObject.h
@@ -23,37 +23,37 @@ namespace methods::FolderHas {
 template <class TImpl>
 concept getIdWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId(std::move(params)) } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getId = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId() } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId() } };
 };
 
 template <class TImpl>
 concept getNameWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getName(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getName(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getName = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getName() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getName() } };
 };
 
 template <class TImpl>
 concept getUnreadCountWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<int> { impl.getUnreadCount(std::move(params)) } };
+	{ service::AwaitableScalar<int> { impl.getUnreadCount(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getUnreadCount = requires (TImpl impl) 
 {
-	{ service::FieldResult<int> { impl.getUnreadCount() } };
+	{ service::AwaitableScalar<int> { impl.getUnreadCount() } };
 };
 
 template <class TImpl>
@@ -87,9 +87,9 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<int> getUnreadCount(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -101,7 +101,7 @@ private:
 		{
 		}
 
-		service::FieldResult<response::IdType> getId(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getNameWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		service::FieldResult<int> getUnreadCount(service::FieldParams&& params) const final
+		service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getUnreadCountWithParams<T>)
 			{

--- a/samples/today/schema/MutationObject.h
+++ b/samples/today/schema/MutationObject.h
@@ -16,25 +16,25 @@ namespace methods::MutationHas {
 template <class TImpl>
 concept applyCompleteTaskWithParams = requires (TImpl impl, service::FieldParams params, CompleteTaskInput inputArg) 
 {
-	{ service::FieldResult<std::shared_ptr<CompleteTaskPayload>> { impl.applyCompleteTask(std::move(params), std::move(inputArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> { impl.applyCompleteTask(std::move(params), std::move(inputArg)) } };
 };
 
 template <class TImpl>
 concept applyCompleteTask = requires (TImpl impl, CompleteTaskInput inputArg) 
 {
-	{ service::FieldResult<std::shared_ptr<CompleteTaskPayload>> { impl.applyCompleteTask(std::move(inputArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> { impl.applyCompleteTask(std::move(inputArg)) } };
 };
 
 template <class TImpl>
 concept applySetFloatWithParams = requires (TImpl impl, service::FieldParams params, double valueArg) 
 {
-	{ service::FieldResult<double> { impl.applySetFloat(std::move(params), std::move(valueArg)) } };
+	{ service::AwaitableScalar<double> { impl.applySetFloat(std::move(params), std::move(valueArg)) } };
 };
 
 template <class TImpl>
 concept applySetFloat = requires (TImpl impl, double valueArg) 
 {
-	{ service::FieldResult<double> { impl.applySetFloat(std::move(valueArg)) } };
+	{ service::AwaitableScalar<double> { impl.applySetFloat(std::move(valueArg)) } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const = 0;
-		virtual service::FieldResult<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const = 0;
+		virtual service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
+		service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
 		{
 			if constexpr (methods::MutationHas::applyCompleteTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
+		service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
 		{
 			if constexpr (methods::MutationHas::applySetFloatWithParams<T>)
 			{

--- a/samples/today/schema/NestedTypeObject.h
+++ b/samples/today/schema/NestedTypeObject.h
@@ -16,25 +16,25 @@ namespace methods::NestedTypeHas {
 template <class TImpl>
 concept getDepthWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<int> { impl.getDepth(std::move(params)) } };
+	{ service::AwaitableScalar<int> { impl.getDepth(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getDepth = requires (TImpl impl) 
 {
-	{ service::FieldResult<int> { impl.getDepth() } };
+	{ service::AwaitableScalar<int> { impl.getDepth() } };
 };
 
 template <class TImpl>
 concept getNestedWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<NestedType>> { impl.getNested(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<NestedType>> { impl.getNested(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNested = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<NestedType>> { impl.getNested() } };
+	{ service::AwaitableObject<std::shared_ptr<NestedType>> { impl.getNested() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<int> getDepth(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<int> getDepth(service::FieldParams&& params) const final
+		service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getDepthWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getNestedWithParams<T>)
 			{

--- a/samples/today/schema/PageInfoObject.h
+++ b/samples/today/schema/PageInfoObject.h
@@ -16,25 +16,25 @@ namespace methods::PageInfoHas {
 template <class TImpl>
 concept getHasNextPageWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<bool> { impl.getHasNextPage(std::move(params)) } };
+	{ service::AwaitableScalar<bool> { impl.getHasNextPage(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getHasNextPage = requires (TImpl impl) 
 {
-	{ service::FieldResult<bool> { impl.getHasNextPage() } };
+	{ service::AwaitableScalar<bool> { impl.getHasNextPage() } };
 };
 
 template <class TImpl>
 concept getHasPreviousPageWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<bool> { impl.getHasPreviousPage(std::move(params)) } };
+	{ service::AwaitableScalar<bool> { impl.getHasPreviousPage(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getHasPreviousPage = requires (TImpl impl) 
 {
-	{ service::FieldResult<bool> { impl.getHasPreviousPage() } };
+	{ service::AwaitableScalar<bool> { impl.getHasPreviousPage() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<bool> getHasNextPage(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<bool> getHasPreviousPage(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<bool> getHasNextPage(service::FieldParams&& params) const final
+		service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasNextPageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<bool> getHasPreviousPage(service::FieldParams&& params) const final
+		service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasPreviousPageWithParams<T>)
 			{

--- a/samples/today/schema/QueryObject.h
+++ b/samples/today/schema/QueryObject.h
@@ -16,145 +16,145 @@ namespace methods::QueryHas {
 template <class TImpl>
 concept getNodeWithParams = requires (TImpl impl, service::FieldParams params, response::IdType idArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Node>> { impl.getNode(std::move(params), std::move(idArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Node>> { impl.getNode(std::move(params), std::move(idArg)) } };
 };
 
 template <class TImpl>
 concept getNode = requires (TImpl impl, response::IdType idArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Node>> { impl.getNode(std::move(idArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Node>> { impl.getNode(std::move(idArg)) } };
 };
 
 template <class TImpl>
 concept getAppointmentsWithParams = requires (TImpl impl, service::FieldParams params, std::optional<int> firstArg, std::optional<response::Value> afterArg, std::optional<int> lastArg, std::optional<response::Value> beforeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<AppointmentConnection>> { impl.getAppointments(std::move(params), std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<AppointmentConnection>> { impl.getAppointments(std::move(params), std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
 };
 
 template <class TImpl>
 concept getAppointments = requires (TImpl impl, std::optional<int> firstArg, std::optional<response::Value> afterArg, std::optional<int> lastArg, std::optional<response::Value> beforeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<AppointmentConnection>> { impl.getAppointments(std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<AppointmentConnection>> { impl.getAppointments(std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
 };
 
 template <class TImpl>
 concept getTasksWithParams = requires (TImpl impl, service::FieldParams params, std::optional<int> firstArg, std::optional<response::Value> afterArg, std::optional<int> lastArg, std::optional<response::Value> beforeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<TaskConnection>> { impl.getTasks(std::move(params), std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<TaskConnection>> { impl.getTasks(std::move(params), std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
 };
 
 template <class TImpl>
 concept getTasks = requires (TImpl impl, std::optional<int> firstArg, std::optional<response::Value> afterArg, std::optional<int> lastArg, std::optional<response::Value> beforeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<TaskConnection>> { impl.getTasks(std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<TaskConnection>> { impl.getTasks(std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
 };
 
 template <class TImpl>
 concept getUnreadCountsWithParams = requires (TImpl impl, service::FieldParams params, std::optional<int> firstArg, std::optional<response::Value> afterArg, std::optional<int> lastArg, std::optional<response::Value> beforeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<FolderConnection>> { impl.getUnreadCounts(std::move(params), std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<FolderConnection>> { impl.getUnreadCounts(std::move(params), std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
 };
 
 template <class TImpl>
 concept getUnreadCounts = requires (TImpl impl, std::optional<int> firstArg, std::optional<response::Value> afterArg, std::optional<int> lastArg, std::optional<response::Value> beforeArg) 
 {
-	{ service::FieldResult<std::shared_ptr<FolderConnection>> { impl.getUnreadCounts(std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<FolderConnection>> { impl.getUnreadCounts(std::move(firstArg), std::move(afterArg), std::move(lastArg), std::move(beforeArg)) } };
 };
 
 template <class TImpl>
 concept getAppointmentsByIdWithParams = requires (TImpl impl, service::FieldParams params, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Appointment>>> { impl.getAppointmentsById(std::move(params), std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> { impl.getAppointmentsById(std::move(params), std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getAppointmentsById = requires (TImpl impl, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Appointment>>> { impl.getAppointmentsById(std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> { impl.getAppointmentsById(std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getTasksByIdWithParams = requires (TImpl impl, service::FieldParams params, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Task>>> { impl.getTasksById(std::move(params), std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Task>>> { impl.getTasksById(std::move(params), std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getTasksById = requires (TImpl impl, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Task>>> { impl.getTasksById(std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Task>>> { impl.getTasksById(std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getUnreadCountsByIdWithParams = requires (TImpl impl, service::FieldParams params, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Folder>>> { impl.getUnreadCountsById(std::move(params), std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> { impl.getUnreadCountsById(std::move(params), std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getUnreadCountsById = requires (TImpl impl, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Folder>>> { impl.getUnreadCountsById(std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> { impl.getUnreadCountsById(std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getNestedWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<NestedType>> { impl.getNested(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<NestedType>> { impl.getNested(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNested = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<NestedType>> { impl.getNested() } };
+	{ service::AwaitableObject<std::shared_ptr<NestedType>> { impl.getNested() } };
 };
 
 template <class TImpl>
 concept getUnimplementedWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::string> { impl.getUnimplemented(std::move(params)) } };
+	{ service::AwaitableScalar<std::string> { impl.getUnimplemented(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getUnimplemented = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::string> { impl.getUnimplemented() } };
+	{ service::AwaitableScalar<std::string> { impl.getUnimplemented() } };
 };
 
 template <class TImpl>
 concept getExpensiveWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Expensive>>> { impl.getExpensive(std::move(params)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> { impl.getExpensive(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getExpensive = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Expensive>>> { impl.getExpensive() } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> { impl.getExpensive() } };
 };
 
 template <class TImpl>
 concept getTestTaskStateWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<TaskState> { impl.getTestTaskState(std::move(params)) } };
+	{ service::AwaitableScalar<TaskState> { impl.getTestTaskState(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getTestTaskState = requires (TImpl impl) 
 {
-	{ service::FieldResult<TaskState> { impl.getTestTaskState() } };
+	{ service::AwaitableScalar<TaskState> { impl.getTestTaskState() } };
 };
 
 template <class TImpl>
 concept getAnyTypeWithParams = requires (TImpl impl, service::FieldParams params, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<UnionType>>> { impl.getAnyType(std::move(params), std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> { impl.getAnyType(std::move(params), std::move(idsArg)) } };
 };
 
 template <class TImpl>
 concept getAnyType = requires (TImpl impl, std::vector<response::IdType> idsArg) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<UnionType>>> { impl.getAnyType(std::move(idsArg)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> { impl.getAnyType(std::move(idsArg)) } };
 };
 
 template <class TImpl>
@@ -201,18 +201,18 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const = 0;
-		virtual service::FieldResult<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		virtual service::FieldResult<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		virtual service::FieldResult<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::string> getUnimplemented(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<TaskState> getTestTaskState(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
 	};
 
 	template <class T>
@@ -224,7 +224,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
+		service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getNodeWithParams<T>)
 			{
@@ -240,7 +240,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsWithParams<T>)
 			{
@@ -256,7 +256,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksWithParams<T>)
 			{
@@ -272,7 +272,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsWithParams<T>)
 			{
@@ -288,7 +288,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsByIdWithParams<T>)
 			{
@@ -304,7 +304,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksByIdWithParams<T>)
 			{
@@ -320,7 +320,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsByIdWithParams<T>)
 			{
@@ -336,7 +336,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getNestedWithParams<T>)
 			{
@@ -352,7 +352,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::string> getUnimplemented(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getUnimplementedWithParams<T>)
 			{
@@ -368,7 +368,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
+		service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getExpensiveWithParams<T>)
 			{
@@ -384,7 +384,7 @@ private:
 			}
 		}
 
-		service::FieldResult<TaskState> getTestTaskState(service::FieldParams&& params) const final
+		service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getTestTaskStateWithParams<T>)
 			{
@@ -400,7 +400,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAnyTypeWithParams<T>)
 			{

--- a/samples/today/schema/SubscriptionObject.h
+++ b/samples/today/schema/SubscriptionObject.h
@@ -16,25 +16,25 @@ namespace methods::SubscriptionHas {
 template <class TImpl>
 concept getNextAppointmentChangeWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Appointment>> { impl.getNextAppointmentChange(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Appointment>> { impl.getNextAppointmentChange(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNextAppointmentChange = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Appointment>> { impl.getNextAppointmentChange() } };
+	{ service::AwaitableObject<std::shared_ptr<Appointment>> { impl.getNextAppointmentChange() } };
 };
 
 template <class TImpl>
 concept getNodeChangeWithParams = requires (TImpl impl, service::FieldParams params, response::IdType idArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Node>> { impl.getNodeChange(std::move(params), std::move(idArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Node>> { impl.getNodeChange(std::move(params), std::move(idArg)) } };
 };
 
 template <class TImpl>
 concept getNodeChange = requires (TImpl impl, response::IdType idArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Node>> { impl.getNodeChange(std::move(idArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Node>> { impl.getNodeChange(std::move(idArg)) } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNextAppointmentChangeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
+		service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNodeChangeWithParams<T>)
 			{

--- a/samples/today/schema/TaskConnectionObject.h
+++ b/samples/today/schema/TaskConnectionObject.h
@@ -16,25 +16,25 @@ namespace methods::TaskConnectionHas {
 template <class TImpl>
 concept getPageInfoWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<PageInfo>> { impl.getPageInfo(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<PageInfo>> { impl.getPageInfo(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getPageInfo = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<PageInfo>> { impl.getPageInfo() } };
+	{ service::AwaitableObject<std::shared_ptr<PageInfo>> { impl.getPageInfo() } };
 };
 
 template <class TImpl>
 concept getEdgesWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> { impl.getEdges(std::move(params)) } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> { impl.getEdges(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getEdges = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> { impl.getEdges() } };
+	{ service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> { impl.getEdges() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getEdgesWithParams<T>)
 			{

--- a/samples/today/schema/TaskEdgeObject.h
+++ b/samples/today/schema/TaskEdgeObject.h
@@ -16,25 +16,25 @@ namespace methods::TaskEdgeHas {
 template <class TImpl>
 concept getNodeWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Task>> { impl.getNode(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Task>> { impl.getNode(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNode = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Task>> { impl.getNode() } };
+	{ service::AwaitableObject<std::shared_ptr<Task>> { impl.getNode() } };
 };
 
 template <class TImpl>
 concept getCursorWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::Value> { impl.getCursor(std::move(params)) } };
+	{ service::AwaitableScalar<response::Value> { impl.getCursor(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getCursor = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::Value> { impl.getCursor() } };
+	{ service::AwaitableScalar<response::Value> { impl.getCursor() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<response::Value> getCursor(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getCursorWithParams<T>)
 			{

--- a/samples/today/schema/TaskObject.h
+++ b/samples/today/schema/TaskObject.h
@@ -23,37 +23,37 @@ namespace methods::TaskHas {
 template <class TImpl>
 concept getIdWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId(std::move(params)) } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getId = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId() } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId() } };
 };
 
 template <class TImpl>
 concept getTitleWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getTitle(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getTitle(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getTitle = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getTitle() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getTitle() } };
 };
 
 template <class TImpl>
 concept getIsCompleteWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<bool> { impl.getIsComplete(std::move(params)) } };
+	{ service::AwaitableScalar<bool> { impl.getIsComplete(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getIsComplete = requires (TImpl impl) 
 {
-	{ service::FieldResult<bool> { impl.getIsComplete() } };
+	{ service::AwaitableScalar<bool> { impl.getIsComplete() } };
 };
 
 template <class TImpl>
@@ -87,9 +87,9 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getTitle(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<bool> getIsComplete(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -101,7 +101,7 @@ private:
 		{
 		}
 
-		service::FieldResult<response::IdType> getId(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getTitleWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		service::FieldResult<bool> getIsComplete(service::FieldParams&& params) const final
+		service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIsCompleteWithParams<T>)
 			{

--- a/samples/today/schema/TodaySchema.cpp
+++ b/samples/today/schema/TodaySchema.cpp
@@ -65,6 +65,22 @@ service::AwaitableResolver ModifiedResult<today::TaskState>::convert(service::Aw
 }
 
 template <>
+void ModifiedResult<today::TaskState>::validateScalar(const response::Value& value)
+{
+	if (!value.maybe_enum())
+	{
+		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
+	}
+
+	const auto itr = std::find(s_namesTaskState.cbegin(), s_namesTaskState.cend(), value.get<std::string>());
+
+	if (itr == s_namesTaskState.cend())
+	{
+		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
+	}
+}
+
+template <>
 today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(const response::Value& value)
 {
 	const auto defaultValue = []()

--- a/samples/today/schema/TodaySchema.cpp
+++ b/samples/today/schema/TodaySchema.cpp
@@ -51,7 +51,7 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Val
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<today::TaskState>::convert(service::FieldResult<today::TaskState> result, ResolverParams params)
+service::AwaitableResolver ModifiedResult<today::TaskState>::convert(service::AwaitableScalar<today::TaskState> result, ResolverParams params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](today::TaskState value, const ResolverParams&)

--- a/samples/validation/schema/AlienObject.h
+++ b/samples/validation/schema/AlienObject.h
@@ -23,25 +23,25 @@ namespace methods::AlienHas {
 template <class TImpl>
 concept getNameWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::string> { impl.getName(std::move(params)) } };
+	{ service::AwaitableScalar<std::string> { impl.getName(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getName = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::string> { impl.getName() } };
+	{ service::AwaitableScalar<std::string> { impl.getName() } };
 };
 
 template <class TImpl>
 concept getHomePlanetWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getHomePlanet(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getHomePlanet(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getHomePlanet = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getHomePlanet() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getHomePlanet() } };
 };
 
 template <class TImpl>
@@ -74,8 +74,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::string> getName(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -87,7 +87,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getName(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AlienHas::getNameWithParams<T>)
 			{
@@ -103,7 +103,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AlienHas::getHomePlanetWithParams<T>)
 			{

--- a/samples/validation/schema/ArgumentsObject.h
+++ b/samples/validation/schema/ArgumentsObject.h
@@ -16,97 +16,97 @@ namespace methods::ArgumentsHas {
 template <class TImpl>
 concept getMultipleReqsWithParams = requires (TImpl impl, service::FieldParams params, int xArg, int yArg) 
 {
-	{ service::FieldResult<int> { impl.getMultipleReqs(std::move(params), std::move(xArg), std::move(yArg)) } };
+	{ service::AwaitableScalar<int> { impl.getMultipleReqs(std::move(params), std::move(xArg), std::move(yArg)) } };
 };
 
 template <class TImpl>
 concept getMultipleReqs = requires (TImpl impl, int xArg, int yArg) 
 {
-	{ service::FieldResult<int> { impl.getMultipleReqs(std::move(xArg), std::move(yArg)) } };
+	{ service::AwaitableScalar<int> { impl.getMultipleReqs(std::move(xArg), std::move(yArg)) } };
 };
 
 template <class TImpl>
 concept getBooleanArgFieldWithParams = requires (TImpl impl, service::FieldParams params, std::optional<bool> booleanArgArg) 
 {
-	{ service::FieldResult<std::optional<bool>> { impl.getBooleanArgField(std::move(params), std::move(booleanArgArg)) } };
+	{ service::AwaitableScalar<std::optional<bool>> { impl.getBooleanArgField(std::move(params), std::move(booleanArgArg)) } };
 };
 
 template <class TImpl>
 concept getBooleanArgField = requires (TImpl impl, std::optional<bool> booleanArgArg) 
 {
-	{ service::FieldResult<std::optional<bool>> { impl.getBooleanArgField(std::move(booleanArgArg)) } };
+	{ service::AwaitableScalar<std::optional<bool>> { impl.getBooleanArgField(std::move(booleanArgArg)) } };
 };
 
 template <class TImpl>
 concept getFloatArgFieldWithParams = requires (TImpl impl, service::FieldParams params, std::optional<double> floatArgArg) 
 {
-	{ service::FieldResult<std::optional<double>> { impl.getFloatArgField(std::move(params), std::move(floatArgArg)) } };
+	{ service::AwaitableScalar<std::optional<double>> { impl.getFloatArgField(std::move(params), std::move(floatArgArg)) } };
 };
 
 template <class TImpl>
 concept getFloatArgField = requires (TImpl impl, std::optional<double> floatArgArg) 
 {
-	{ service::FieldResult<std::optional<double>> { impl.getFloatArgField(std::move(floatArgArg)) } };
+	{ service::AwaitableScalar<std::optional<double>> { impl.getFloatArgField(std::move(floatArgArg)) } };
 };
 
 template <class TImpl>
 concept getIntArgFieldWithParams = requires (TImpl impl, service::FieldParams params, std::optional<int> intArgArg) 
 {
-	{ service::FieldResult<std::optional<int>> { impl.getIntArgField(std::move(params), std::move(intArgArg)) } };
+	{ service::AwaitableScalar<std::optional<int>> { impl.getIntArgField(std::move(params), std::move(intArgArg)) } };
 };
 
 template <class TImpl>
 concept getIntArgField = requires (TImpl impl, std::optional<int> intArgArg) 
 {
-	{ service::FieldResult<std::optional<int>> { impl.getIntArgField(std::move(intArgArg)) } };
+	{ service::AwaitableScalar<std::optional<int>> { impl.getIntArgField(std::move(intArgArg)) } };
 };
 
 template <class TImpl>
 concept getNonNullBooleanArgFieldWithParams = requires (TImpl impl, service::FieldParams params, bool nonNullBooleanArgArg) 
 {
-	{ service::FieldResult<bool> { impl.getNonNullBooleanArgField(std::move(params), std::move(nonNullBooleanArgArg)) } };
+	{ service::AwaitableScalar<bool> { impl.getNonNullBooleanArgField(std::move(params), std::move(nonNullBooleanArgArg)) } };
 };
 
 template <class TImpl>
 concept getNonNullBooleanArgField = requires (TImpl impl, bool nonNullBooleanArgArg) 
 {
-	{ service::FieldResult<bool> { impl.getNonNullBooleanArgField(std::move(nonNullBooleanArgArg)) } };
+	{ service::AwaitableScalar<bool> { impl.getNonNullBooleanArgField(std::move(nonNullBooleanArgArg)) } };
 };
 
 template <class TImpl>
 concept getNonNullBooleanListFieldWithParams = requires (TImpl impl, service::FieldParams params, std::optional<std::vector<bool>> nonNullBooleanListArgArg) 
 {
-	{ service::FieldResult<std::optional<std::vector<bool>>> { impl.getNonNullBooleanListField(std::move(params), std::move(nonNullBooleanListArgArg)) } };
+	{ service::AwaitableScalar<std::optional<std::vector<bool>>> { impl.getNonNullBooleanListField(std::move(params), std::move(nonNullBooleanListArgArg)) } };
 };
 
 template <class TImpl>
 concept getNonNullBooleanListField = requires (TImpl impl, std::optional<std::vector<bool>> nonNullBooleanListArgArg) 
 {
-	{ service::FieldResult<std::optional<std::vector<bool>>> { impl.getNonNullBooleanListField(std::move(nonNullBooleanListArgArg)) } };
+	{ service::AwaitableScalar<std::optional<std::vector<bool>>> { impl.getNonNullBooleanListField(std::move(nonNullBooleanListArgArg)) } };
 };
 
 template <class TImpl>
 concept getBooleanListArgFieldWithParams = requires (TImpl impl, service::FieldParams params, std::vector<std::optional<bool>> booleanListArgArg) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::optional<bool>>>> { impl.getBooleanListArgField(std::move(params), std::move(booleanListArgArg)) } };
+	{ service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> { impl.getBooleanListArgField(std::move(params), std::move(booleanListArgArg)) } };
 };
 
 template <class TImpl>
 concept getBooleanListArgField = requires (TImpl impl, std::vector<std::optional<bool>> booleanListArgArg) 
 {
-	{ service::FieldResult<std::optional<std::vector<std::optional<bool>>>> { impl.getBooleanListArgField(std::move(booleanListArgArg)) } };
+	{ service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> { impl.getBooleanListArgField(std::move(booleanListArgArg)) } };
 };
 
 template <class TImpl>
 concept getOptionalNonNullBooleanArgFieldWithParams = requires (TImpl impl, service::FieldParams params, bool optionalBooleanArgArg) 
 {
-	{ service::FieldResult<bool> { impl.getOptionalNonNullBooleanArgField(std::move(params), std::move(optionalBooleanArgArg)) } };
+	{ service::AwaitableScalar<bool> { impl.getOptionalNonNullBooleanArgField(std::move(params), std::move(optionalBooleanArgArg)) } };
 };
 
 template <class TImpl>
 concept getOptionalNonNullBooleanArgField = requires (TImpl impl, bool optionalBooleanArgArg) 
 {
-	{ service::FieldResult<bool> { impl.getOptionalNonNullBooleanArgField(std::move(optionalBooleanArgArg)) } };
+	{ service::AwaitableScalar<bool> { impl.getOptionalNonNullBooleanArgField(std::move(optionalBooleanArgArg)) } };
 };
 
 template <class TImpl>
@@ -145,14 +145,14 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const = 0;
-		virtual service::FieldResult<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const = 0;
-		virtual service::FieldResult<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const = 0;
-		virtual service::FieldResult<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const = 0;
-		virtual service::FieldResult<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const = 0;
-		virtual service::FieldResult<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const = 0;
+		virtual service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const = 0;
+		virtual service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const = 0;
+		virtual service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const = 0;
+		virtual service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const = 0;
+		virtual service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const = 0;
+		virtual service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const = 0;
 	};
 
 	template <class T>
@@ -164,7 +164,7 @@ private:
 		{
 		}
 
-		service::FieldResult<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const final
+		service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getMultipleReqsWithParams<T>)
 			{
@@ -180,7 +180,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const final
+		service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getBooleanArgFieldWithParams<T>)
 			{
@@ -196,7 +196,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const final
+		service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getFloatArgFieldWithParams<T>)
 			{
@@ -212,7 +212,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const final
+		service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getIntArgFieldWithParams<T>)
 			{
@@ -228,7 +228,7 @@ private:
 			}
 		}
 
-		service::FieldResult<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const final
+		service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getNonNullBooleanArgFieldWithParams<T>)
 			{
@@ -244,7 +244,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const final
+		service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getNonNullBooleanListFieldWithParams<T>)
 			{
@@ -260,7 +260,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const final
+		service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getBooleanListArgFieldWithParams<T>)
 			{
@@ -276,7 +276,7 @@ private:
 			}
 		}
 
-		service::FieldResult<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const final
+		service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getOptionalNonNullBooleanArgFieldWithParams<T>)
 			{

--- a/samples/validation/schema/CatObject.h
+++ b/samples/validation/schema/CatObject.h
@@ -23,49 +23,49 @@ namespace methods::CatHas {
 template <class TImpl>
 concept getNameWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::string> { impl.getName(std::move(params)) } };
+	{ service::AwaitableScalar<std::string> { impl.getName(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getName = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::string> { impl.getName() } };
+	{ service::AwaitableScalar<std::string> { impl.getName() } };
 };
 
 template <class TImpl>
 concept getNicknameWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getNickname(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getNickname(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNickname = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getNickname() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getNickname() } };
 };
 
 template <class TImpl>
 concept getDoesKnowCommandWithParams = requires (TImpl impl, service::FieldParams params, CatCommand catCommandArg) 
 {
-	{ service::FieldResult<bool> { impl.getDoesKnowCommand(std::move(params), std::move(catCommandArg)) } };
+	{ service::AwaitableScalar<bool> { impl.getDoesKnowCommand(std::move(params), std::move(catCommandArg)) } };
 };
 
 template <class TImpl>
 concept getDoesKnowCommand = requires (TImpl impl, CatCommand catCommandArg) 
 {
-	{ service::FieldResult<bool> { impl.getDoesKnowCommand(std::move(catCommandArg)) } };
+	{ service::AwaitableScalar<bool> { impl.getDoesKnowCommand(std::move(catCommandArg)) } };
 };
 
 template <class TImpl>
 concept getMeowVolumeWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<int>> { impl.getMeowVolume(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<int>> { impl.getMeowVolume(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getMeowVolume = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<int>> { impl.getMeowVolume() } };
+	{ service::AwaitableScalar<std::optional<int>> { impl.getMeowVolume() } };
 };
 
 template <class TImpl>
@@ -100,10 +100,10 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::string> getName(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getNickname(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const = 0;
-		virtual service::FieldResult<std::optional<int>> getMeowVolume(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const = 0;
+		virtual service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -115,7 +115,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getName(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CatHas::getNameWithParams<T>)
 			{
@@ -131,7 +131,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CatHas::getNicknameWithParams<T>)
 			{
@@ -147,7 +147,7 @@ private:
 			}
 		}
 
-		service::FieldResult<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const final
+		service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const final
 		{
 			if constexpr (methods::CatHas::getDoesKnowCommandWithParams<T>)
 			{
@@ -163,7 +163,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<int>> getMeowVolume(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CatHas::getMeowVolumeWithParams<T>)
 			{

--- a/samples/validation/schema/DogObject.h
+++ b/samples/validation/schema/DogObject.h
@@ -23,73 +23,73 @@ namespace methods::DogHas {
 template <class TImpl>
 concept getNameWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::string> { impl.getName(std::move(params)) } };
+	{ service::AwaitableScalar<std::string> { impl.getName(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getName = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::string> { impl.getName() } };
+	{ service::AwaitableScalar<std::string> { impl.getName() } };
 };
 
 template <class TImpl>
 concept getNicknameWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getNickname(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getNickname(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNickname = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getNickname() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getNickname() } };
 };
 
 template <class TImpl>
 concept getBarkVolumeWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<int>> { impl.getBarkVolume(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<int>> { impl.getBarkVolume(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getBarkVolume = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<int>> { impl.getBarkVolume() } };
+	{ service::AwaitableScalar<std::optional<int>> { impl.getBarkVolume() } };
 };
 
 template <class TImpl>
 concept getDoesKnowCommandWithParams = requires (TImpl impl, service::FieldParams params, DogCommand dogCommandArg) 
 {
-	{ service::FieldResult<bool> { impl.getDoesKnowCommand(std::move(params), std::move(dogCommandArg)) } };
+	{ service::AwaitableScalar<bool> { impl.getDoesKnowCommand(std::move(params), std::move(dogCommandArg)) } };
 };
 
 template <class TImpl>
 concept getDoesKnowCommand = requires (TImpl impl, DogCommand dogCommandArg) 
 {
-	{ service::FieldResult<bool> { impl.getDoesKnowCommand(std::move(dogCommandArg)) } };
+	{ service::AwaitableScalar<bool> { impl.getDoesKnowCommand(std::move(dogCommandArg)) } };
 };
 
 template <class TImpl>
 concept getIsHousetrainedWithParams = requires (TImpl impl, service::FieldParams params, std::optional<bool> atOtherHomesArg) 
 {
-	{ service::FieldResult<bool> { impl.getIsHousetrained(std::move(params), std::move(atOtherHomesArg)) } };
+	{ service::AwaitableScalar<bool> { impl.getIsHousetrained(std::move(params), std::move(atOtherHomesArg)) } };
 };
 
 template <class TImpl>
 concept getIsHousetrained = requires (TImpl impl, std::optional<bool> atOtherHomesArg) 
 {
-	{ service::FieldResult<bool> { impl.getIsHousetrained(std::move(atOtherHomesArg)) } };
+	{ service::AwaitableScalar<bool> { impl.getIsHousetrained(std::move(atOtherHomesArg)) } };
 };
 
 template <class TImpl>
 concept getOwnerWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Human>> { impl.getOwner(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Human>> { impl.getOwner(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getOwner = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Human>> { impl.getOwner() } };
+	{ service::AwaitableObject<std::shared_ptr<Human>> { impl.getOwner() } };
 };
 
 template <class TImpl>
@@ -126,12 +126,12 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::string> getName(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getNickname(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::optional<int>> getBarkVolume(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const = 0;
-		virtual service::FieldResult<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const = 0;
-		virtual service::FieldResult<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const = 0;
+		virtual service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -143,7 +143,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getName(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getNameWithParams<T>)
 			{
@@ -159,7 +159,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getNicknameWithParams<T>)
 			{
@@ -175,7 +175,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<int>> getBarkVolume(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getBarkVolumeWithParams<T>)
 			{
@@ -191,7 +191,7 @@ private:
 			}
 		}
 
-		service::FieldResult<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const final
+		service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const final
 		{
 			if constexpr (methods::DogHas::getDoesKnowCommandWithParams<T>)
 			{
@@ -207,7 +207,7 @@ private:
 			}
 		}
 
-		service::FieldResult<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const final
+		service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const final
 		{
 			if constexpr (methods::DogHas::getIsHousetrainedWithParams<T>)
 			{
@@ -223,7 +223,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getOwnerWithParams<T>)
 			{

--- a/samples/validation/schema/HumanObject.h
+++ b/samples/validation/schema/HumanObject.h
@@ -23,25 +23,25 @@ namespace methods::HumanHas {
 template <class TImpl>
 concept getNameWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::string> { impl.getName(std::move(params)) } };
+	{ service::AwaitableScalar<std::string> { impl.getName(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getName = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::string> { impl.getName() } };
+	{ service::AwaitableScalar<std::string> { impl.getName() } };
 };
 
 template <class TImpl>
 concept getPetsWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Pet>>> { impl.getPets(std::move(params)) } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> { impl.getPets(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getPets = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::vector<std::shared_ptr<Pet>>> { impl.getPets() } };
+	{ service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> { impl.getPets() } };
 };
 
 template <class TImpl>
@@ -74,8 +74,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::string> getName(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -87,7 +87,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getName(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getNameWithParams<T>)
 			{
@@ -103,7 +103,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const final
+		service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getPetsWithParams<T>)
 			{

--- a/samples/validation/schema/MessageObject.h
+++ b/samples/validation/schema/MessageObject.h
@@ -16,25 +16,25 @@ namespace methods::MessageHas {
 template <class TImpl>
 concept getBodyWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getBody(std::move(params)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getBody(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getBody = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::optional<std::string>> { impl.getBody() } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getBody() } };
 };
 
 template <class TImpl>
 concept getSenderWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::IdType> { impl.getSender(std::move(params)) } };
+	{ service::AwaitableScalar<response::IdType> { impl.getSender(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getSender = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::IdType> { impl.getSender() } };
+	{ service::AwaitableScalar<response::IdType> { impl.getSender() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::optional<std::string>> getBody(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<response::IdType> getSender(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::optional<std::string>> getBody(service::FieldParams&& params) const final
+		service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MessageHas::getBodyWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<response::IdType> getSender(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MessageHas::getSenderWithParams<T>)
 			{

--- a/samples/validation/schema/MutateDogResultObject.h
+++ b/samples/validation/schema/MutateDogResultObject.h
@@ -16,13 +16,13 @@ namespace methods::MutateDogResultHas {
 template <class TImpl>
 concept getIdWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId(std::move(params)) } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getId = requires (TImpl impl) 
 {
-	{ service::FieldResult<response::IdType> { impl.getId() } };
+	{ service::AwaitableScalar<response::IdType> { impl.getId() } };
 };
 
 template <class TImpl>
@@ -54,7 +54,7 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<response::IdType> getId(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		service::FieldResult<response::IdType> getId(service::FieldParams&& params) const final
+		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MutateDogResultHas::getIdWithParams<T>)
 			{

--- a/samples/validation/schema/MutationObject.h
+++ b/samples/validation/schema/MutationObject.h
@@ -16,13 +16,13 @@ namespace methods::MutationHas {
 template <class TImpl>
 concept applyMutateDogWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<MutateDogResult>> { impl.applyMutateDog(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<MutateDogResult>> { impl.applyMutateDog(std::move(params)) } };
 };
 
 template <class TImpl>
 concept applyMutateDog = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<MutateDogResult>> { impl.applyMutateDog() } };
+	{ service::AwaitableObject<std::shared_ptr<MutateDogResult>> { impl.applyMutateDog() } };
 };
 
 template <class TImpl>
@@ -54,7 +54,7 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MutationHas::applyMutateDogWithParams<T>)
 			{

--- a/samples/validation/schema/QueryObject.h
+++ b/samples/validation/schema/QueryObject.h
@@ -16,97 +16,97 @@ namespace methods::QueryHas {
 template <class TImpl>
 concept getDogWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Dog>> { impl.getDog(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Dog>> { impl.getDog(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getDog = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Dog>> { impl.getDog() } };
+	{ service::AwaitableObject<std::shared_ptr<Dog>> { impl.getDog() } };
 };
 
 template <class TImpl>
 concept getHumanWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Human>> { impl.getHuman(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Human>> { impl.getHuman(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getHuman = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Human>> { impl.getHuman() } };
+	{ service::AwaitableObject<std::shared_ptr<Human>> { impl.getHuman() } };
 };
 
 template <class TImpl>
 concept getPetWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Pet>> { impl.getPet(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Pet>> { impl.getPet(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getPet = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Pet>> { impl.getPet() } };
+	{ service::AwaitableObject<std::shared_ptr<Pet>> { impl.getPet() } };
 };
 
 template <class TImpl>
 concept getCatOrDogWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<CatOrDog>> { impl.getCatOrDog(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<CatOrDog>> { impl.getCatOrDog(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getCatOrDog = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<CatOrDog>> { impl.getCatOrDog() } };
+	{ service::AwaitableObject<std::shared_ptr<CatOrDog>> { impl.getCatOrDog() } };
 };
 
 template <class TImpl>
 concept getArgumentsWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Arguments>> { impl.getArguments(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Arguments>> { impl.getArguments(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getArguments = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Arguments>> { impl.getArguments() } };
+	{ service::AwaitableObject<std::shared_ptr<Arguments>> { impl.getArguments() } };
 };
 
 template <class TImpl>
 concept getResourceWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Resource>> { impl.getResource(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Resource>> { impl.getResource(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getResource = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Resource>> { impl.getResource() } };
+	{ service::AwaitableObject<std::shared_ptr<Resource>> { impl.getResource() } };
 };
 
 template <class TImpl>
 concept getFindDogWithParams = requires (TImpl impl, service::FieldParams params, std::optional<ComplexInput> complexArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Dog>> { impl.getFindDog(std::move(params), std::move(complexArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Dog>> { impl.getFindDog(std::move(params), std::move(complexArg)) } };
 };
 
 template <class TImpl>
 concept getFindDog = requires (TImpl impl, std::optional<ComplexInput> complexArg) 
 {
-	{ service::FieldResult<std::shared_ptr<Dog>> { impl.getFindDog(std::move(complexArg)) } };
+	{ service::AwaitableObject<std::shared_ptr<Dog>> { impl.getFindDog(std::move(complexArg)) } };
 };
 
 template <class TImpl>
 concept getBooleanListWithParams = requires (TImpl impl, service::FieldParams params, std::optional<std::vector<bool>> booleanListArgArg) 
 {
-	{ service::FieldResult<std::optional<bool>> { impl.getBooleanList(std::move(params), std::move(booleanListArgArg)) } };
+	{ service::AwaitableScalar<std::optional<bool>> { impl.getBooleanList(std::move(params), std::move(booleanListArgArg)) } };
 };
 
 template <class TImpl>
 concept getBooleanList = requires (TImpl impl, std::optional<std::vector<bool>> booleanListArgArg) 
 {
-	{ service::FieldResult<std::optional<bool>> { impl.getBooleanList(std::move(booleanListArgArg)) } };
+	{ service::AwaitableScalar<std::optional<bool>> { impl.getBooleanList(std::move(booleanListArgArg)) } };
 };
 
 template <class TImpl>
@@ -145,14 +145,14 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::optional<ComplexInput>&& complexArg) const = 0;
-		virtual service::FieldResult<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::optional<ComplexInput>&& complexArg) const = 0;
+		virtual service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const = 0;
 	};
 
 	template <class T>
@@ -164,7 +164,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getDogWithParams<T>)
 			{
@@ -180,7 +180,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getHumanWithParams<T>)
 			{
@@ -196,7 +196,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getPetWithParams<T>)
 			{
@@ -212,7 +212,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getCatOrDogWithParams<T>)
 			{
@@ -228,7 +228,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getArgumentsWithParams<T>)
 			{
@@ -244,7 +244,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getResourceWithParams<T>)
 			{
@@ -260,7 +260,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::optional<ComplexInput>&& complexArg) const final
+		service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::optional<ComplexInput>&& complexArg) const final
 		{
 			if constexpr (methods::QueryHas::getFindDogWithParams<T>)
 			{
@@ -276,7 +276,7 @@ private:
 			}
 		}
 
-		service::FieldResult<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const final
+		service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const final
 		{
 			if constexpr (methods::QueryHas::getBooleanListWithParams<T>)
 			{

--- a/samples/validation/schema/SubscriptionObject.h
+++ b/samples/validation/schema/SubscriptionObject.h
@@ -16,25 +16,25 @@ namespace methods::SubscriptionHas {
 template <class TImpl>
 concept getNewMessageWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<std::shared_ptr<Message>> { impl.getNewMessage(std::move(params)) } };
+	{ service::AwaitableObject<std::shared_ptr<Message>> { impl.getNewMessage(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getNewMessage = requires (TImpl impl) 
 {
-	{ service::FieldResult<std::shared_ptr<Message>> { impl.getNewMessage() } };
+	{ service::AwaitableObject<std::shared_ptr<Message>> { impl.getNewMessage() } };
 };
 
 template <class TImpl>
 concept getDisallowedSecondRootFieldWithParams = requires (TImpl impl, service::FieldParams params) 
 {
-	{ service::FieldResult<bool> { impl.getDisallowedSecondRootField(std::move(params)) } };
+	{ service::AwaitableScalar<bool> { impl.getDisallowedSecondRootField(std::move(params)) } };
 };
 
 template <class TImpl>
 concept getDisallowedSecondRootField = requires (TImpl impl) 
 {
-	{ service::FieldResult<bool> { impl.getDisallowedSecondRootField() } };
+	{ service::AwaitableScalar<bool> { impl.getDisallowedSecondRootField() } };
 };
 
 template <class TImpl>
@@ -67,8 +67,8 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::FieldResult<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const = 0;
-		virtual service::FieldResult<bool> getDisallowedSecondRootField(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const = 0;
+		virtual service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::FieldResult<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const final
+		service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNewMessageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::FieldResult<bool> getDisallowedSecondRootField(service::FieldParams&& params) const final
+		service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getDisallowedSecondRootFieldWithParams<T>)
 			{

--- a/samples/validation/schema/ValidationSchema.cpp
+++ b/samples/validation/schema/ValidationSchema.cpp
@@ -63,6 +63,22 @@ service::AwaitableResolver ModifiedResult<validation::DogCommand>::convert(servi
 		});
 }
 
+template <>
+void ModifiedResult<validation::DogCommand>::validateScalar(const response::Value& value)
+{
+	if (!value.maybe_enum())
+	{
+		throw service::schema_exception { { R"ex(not a valid DogCommand value)ex" } };
+	}
+
+	const auto itr = std::find(s_namesDogCommand.cbegin(), s_namesDogCommand.cend(), value.get<std::string>());
+
+	if (itr == s_namesDogCommand.cend())
+	{
+		throw service::schema_exception { { R"ex(not a valid DogCommand value)ex" } };
+	}
+}
+
 static const std::array<std::string_view, 1> s_namesCatCommand = {
 	R"gql(JUMP)gql"sv
 };
@@ -97,6 +113,22 @@ service::AwaitableResolver ModifiedResult<validation::CatCommand>::convert(servi
 
 			return result;
 		});
+}
+
+template <>
+void ModifiedResult<validation::CatCommand>::validateScalar(const response::Value& value)
+{
+	if (!value.maybe_enum())
+	{
+		throw service::schema_exception { { R"ex(not a valid CatCommand value)ex" } };
+	}
+
+	const auto itr = std::find(s_namesCatCommand.cbegin(), s_namesCatCommand.cend(), value.get<std::string>());
+
+	if (itr == s_namesCatCommand.cend())
+	{
+		throw service::schema_exception { { R"ex(not a valid CatCommand value)ex" } };
+	}
 }
 
 template <>

--- a/samples/validation/schema/ValidationSchema.cpp
+++ b/samples/validation/schema/ValidationSchema.cpp
@@ -50,7 +50,7 @@ validation::DogCommand ModifiedArgument<validation::DogCommand>::convert(const r
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<validation::DogCommand>::convert(service::FieldResult<validation::DogCommand> result, ResolverParams params)
+service::AwaitableResolver ModifiedResult<validation::DogCommand>::convert(service::AwaitableScalar<validation::DogCommand> result, ResolverParams params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](validation::DogCommand value, const ResolverParams&)
@@ -86,7 +86,7 @@ validation::CatCommand ModifiedArgument<validation::CatCommand>::convert(const r
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<validation::CatCommand>::convert(service::FieldResult<validation::CatCommand> result, ResolverParams params)
+service::AwaitableResolver ModifiedResult<validation::CatCommand>::convert(service::AwaitableScalar<validation::CatCommand> result, ResolverParams params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](validation::CatCommand value, const ResolverParams&)

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -716,6 +716,66 @@ AwaitableResolver ModifiedResult<Object>::convert(
 	co_return std::move(document);
 }
 
+template <>
+void ModifiedResult<int>::validateScalar(const response::Value& value)
+{
+	if (value.type() != response::Type::Int)
+	{
+		throw schema_exception { { R"ex(not a valid Int value)ex" } };
+	}
+}
+
+template <>
+void ModifiedResult<double>::validateScalar(const response::Value& value)
+{
+	if (value.type() != response::Type::Float)
+	{
+		throw schema_exception { { R"ex(not a valid Float value)ex" } };
+	}
+}
+
+template <>
+void ModifiedResult<std::string>::validateScalar(const response::Value& value)
+{
+	if (value.type() != response::Type::String)
+	{
+		throw schema_exception { { R"ex(not a valid String value)ex" } };
+	}
+}
+
+template <>
+void ModifiedResult<bool>::validateScalar(const response::Value& value)
+{
+	if (value.type() != response::Type::Boolean)
+	{
+		throw schema_exception { { R"ex(not a valid Boolean value)ex" } };
+	}
+}
+
+template <>
+void ModifiedResult<response::IdType>::validateScalar(const response::Value& value)
+{
+	if (value.type() != response::Type::String)
+	{
+		throw schema_exception { { R"ex(not a valid String value)ex" } };
+	}
+
+	try
+	{
+		const auto result = value.get<response::IdType>();
+	}
+	catch (const std::logic_error& ex)
+	{
+		throw schema_exception { { ex.what() } };
+	}
+}
+
+template <>
+void ModifiedResult<response::Value>::validateScalar(const response::Value&)
+{
+	// Any response::Value is valid for a custom scalar type.
+}
+
 // SelectionVisitor visits the AST and resolves a field or fragment, unless it's skipped by
 // a directive or type condition.
 class SelectionVisitor

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -608,7 +608,7 @@ void blockSubFields(const ResolverParams& params)
 }
 
 template <>
-AwaitableResolver ModifiedResult<int>::convert(FieldResult<int> result, ResolverParams params)
+AwaitableResolver ModifiedResult<int>::convert(AwaitableScalar<int> result, ResolverParams params)
 {
 	blockSubFields(params);
 
@@ -618,7 +618,8 @@ AwaitableResolver ModifiedResult<int>::convert(FieldResult<int> result, Resolver
 }
 
 template <>
-AwaitableResolver ModifiedResult<double>::convert(FieldResult<double> result, ResolverParams params)
+AwaitableResolver ModifiedResult<double>::convert(
+	AwaitableScalar<double> result, ResolverParams params)
 {
 	blockSubFields(params);
 
@@ -629,7 +630,7 @@ AwaitableResolver ModifiedResult<double>::convert(FieldResult<double> result, Re
 
 template <>
 AwaitableResolver ModifiedResult<std::string>::convert(
-	FieldResult<std::string> result, ResolverParams params)
+	AwaitableScalar<std::string> result, ResolverParams params)
 {
 	blockSubFields(params);
 
@@ -641,7 +642,7 @@ AwaitableResolver ModifiedResult<std::string>::convert(
 }
 
 template <>
-AwaitableResolver ModifiedResult<bool>::convert(FieldResult<bool> result, ResolverParams params)
+AwaitableResolver ModifiedResult<bool>::convert(AwaitableScalar<bool> result, ResolverParams params)
 {
 	blockSubFields(params);
 
@@ -652,7 +653,7 @@ AwaitableResolver ModifiedResult<bool>::convert(FieldResult<bool> result, Resolv
 
 template <>
 AwaitableResolver ModifiedResult<response::Value>::convert(
-	FieldResult<response::Value> result, ResolverParams params)
+	AwaitableScalar<response::Value> result, ResolverParams params)
 {
 	blockSubFields(params);
 
@@ -665,7 +666,7 @@ AwaitableResolver ModifiedResult<response::Value>::convert(
 
 template <>
 AwaitableResolver ModifiedResult<response::IdType>::convert(
-	FieldResult<response::IdType> result, ResolverParams params)
+	AwaitableScalar<response::IdType> result, ResolverParams params)
 {
 	blockSubFields(params);
 
@@ -694,15 +695,8 @@ void requireSubFields(const ResolverParams& params)
 
 template <>
 AwaitableResolver ModifiedResult<Object>::convert(
-	FieldResult<std::shared_ptr<Object>> result, ResolverParams params)
+	AwaitableObject<std::shared_ptr<Object>> result, ResolverParams params)
 {
-	auto value = result.get_value();
-
-	if (value)
-	{
-		co_return ResolverResult { response::Value { std::shared_ptr { std::move(value) } } };
-	}
-
 	requireSubFields(params);
 
 	co_await params.launch;

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -478,7 +478,7 @@ template <>
 GRAPHQLINTROSPECTION_EXPORT AwaitableResolver ModifiedResult<)cpp"
 						   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << enumType.cppType
 						   << R"cpp(>::convert(
-	FieldResult<)cpp" << _loader.getSchemaNamespace()
+	AwaitableScalar<)cpp" << _loader.getSchemaNamespace()
 						   << R"cpp(::)cpp" << enumType.cppType
 						   << R"cpp(> result, ResolverParams params);
 )cpp";
@@ -658,8 +658,8 @@ concept )cpp" << outputField.accessor
 
 		headerFile << R"cpp() 
 {
-	{ service::FieldResult<)cpp"
-				   << _loader.getOutputCppType(outputField) << R"cpp(> { impl.)cpp"
+	{ )cpp"
+				   << _loader.getOutputCppType(outputField) << R"cpp( { impl.)cpp"
 				   << outputField.accessor << fieldName << R"cpp((std::move(params))cpp";
 
 		if (!passedArguments.empty())
@@ -681,8 +681,8 @@ concept )cpp" << outputField.accessor
 
 		headerFile << R"cpp() 
 {
-	{ service::FieldResult<)cpp"
-				   << _loader.getOutputCppType(outputField) << R"cpp(> { impl.)cpp"
+	{ )cpp"
+				   << _loader.getOutputCppType(outputField) << R"cpp( { impl.)cpp"
 				   << outputField.accessor << fieldName << R"cpp(()cpp";
 
 		if (!passedArguments.empty())
@@ -779,8 +779,8 @@ private:
 		fieldName[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(fieldName[0])));
 
 		headerFile << R"cpp(
-		service::FieldResult<)cpp"
-				   << _loader.getOutputCppType(outputField) << R"cpp(> )cpp" << outputField.accessor
+		)cpp"
+				   << _loader.getOutputCppType(outputField) << R"cpp( )cpp" << outputField.accessor
 				   << fieldName << R"cpp(()cpp";
 
 		bool firstArgument = _loader.isIntrospection();
@@ -1033,8 +1033,8 @@ std::string Generator::getFieldDeclaration(const OutputField& outputField) const
 	std::string fieldName { outputField.cppName };
 
 	fieldName[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(fieldName[0])));
-	output << R"cpp(		virtual service::FieldResult<)cpp"
-		   << _loader.getOutputCppType(outputField) << R"cpp(> )cpp" << outputField.accessor
+	output << R"cpp(		virtual )cpp"
+		   << _loader.getOutputCppType(outputField) << R"cpp( )cpp" << outputField.accessor
 		   << fieldName << R"cpp(()cpp";
 
 	bool firstArgument = _loader.isIntrospection();
@@ -1186,7 +1186,7 @@ template <>
 template <>
 service::AwaitableResolver ModifiedResult<)cpp"
 					   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << enumType.cppType
-					   << R"cpp(>::convert(service::FieldResult<)cpp"
+					   << R"cpp(>::convert(service::AwaitableScalar<)cpp"
 					   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << enumType.cppType
 					   << R"cpp(> result, ResolverParams params)
 {

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -481,6 +481,11 @@ GRAPHQLINTROSPECTION_EXPORT AwaitableResolver ModifiedResult<)cpp"
 	AwaitableScalar<)cpp" << _loader.getSchemaNamespace()
 						   << R"cpp(::)cpp" << enumType.cppType
 						   << R"cpp(> result, ResolverParams params);
+template <>
+GRAPHQLINTROSPECTION_EXPORT void ModifiedResult<)cpp"
+						   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << enumType.cppType
+						   << R"cpp(>::validateScalar(
+	const response::Value& value);
 )cpp";
 			}
 
@@ -658,9 +663,9 @@ concept )cpp" << outputField.accessor
 
 		headerFile << R"cpp() 
 {
-	{ )cpp"
-				   << _loader.getOutputCppType(outputField) << R"cpp( { impl.)cpp"
-				   << outputField.accessor << fieldName << R"cpp((std::move(params))cpp";
+	{ )cpp" << _loader.getOutputCppType(outputField)
+				   << R"cpp( { impl.)cpp" << outputField.accessor << fieldName
+				   << R"cpp((std::move(params))cpp";
 
 		if (!passedArguments.empty())
 		{
@@ -681,9 +686,8 @@ concept )cpp" << outputField.accessor
 
 		headerFile << R"cpp() 
 {
-	{ )cpp"
-				   << _loader.getOutputCppType(outputField) << R"cpp( { impl.)cpp"
-				   << outputField.accessor << fieldName << R"cpp(()cpp";
+	{ )cpp" << _loader.getOutputCppType(outputField)
+				   << R"cpp( { impl.)cpp" << outputField.accessor << fieldName << R"cpp(()cpp";
 
 		if (!passedArguments.empty())
 		{
@@ -779,9 +783,8 @@ private:
 		fieldName[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(fieldName[0])));
 
 		headerFile << R"cpp(
-		)cpp"
-				   << _loader.getOutputCppType(outputField) << R"cpp( )cpp" << outputField.accessor
-				   << fieldName << R"cpp(()cpp";
+		)cpp" << _loader.getOutputCppType(outputField)
+				   << R"cpp( )cpp" << outputField.accessor << fieldName << R"cpp(()cpp";
 
 		bool firstArgument = _loader.isIntrospection();
 
@@ -1033,9 +1036,8 @@ std::string Generator::getFieldDeclaration(const OutputField& outputField) const
 	std::string fieldName { outputField.cppName };
 
 	fieldName[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(fieldName[0])));
-	output << R"cpp(		virtual )cpp"
-		   << _loader.getOutputCppType(outputField) << R"cpp( )cpp" << outputField.accessor
-		   << fieldName << R"cpp(()cpp";
+	output << R"cpp(		virtual )cpp" << _loader.getOutputCppType(outputField) << R"cpp( )cpp"
+		   << outputField.accessor << fieldName << R"cpp(()cpp";
 
 	bool firstArgument = _loader.isIntrospection();
 
@@ -1201,6 +1203,29 @@ service::AwaitableResolver ModifiedResult<)cpp"
 
 			return result;
 		});
+}
+
+template <>
+void ModifiedResult<)cpp"
+					   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << enumType.cppType
+					   << R"cpp(>::validateScalar(const response::Value& value)
+{
+	if (!value.maybe_enum())
+	{
+		throw service::schema_exception { { R"ex(not a valid )cpp"
+					   << enumType.type << R"cpp( value)ex" } };
+	}
+
+	const auto itr = std::find(s_names)cpp"
+					   << enumType.cppType << R"cpp(.cbegin(), s_names)cpp" << enumType.cppType
+					   << R"cpp(.cend(), value.get<std::string>());
+
+	if (itr == s_names)cpp"
+					   << enumType.cppType << R"cpp(.cend())
+	{
+		throw service::schema_exception { { R"ex(not a valid )cpp"
+					   << enumType.type << R"cpp( value)ex" } };
+	}
 }
 
 )cpp";

--- a/src/SchemaLoader.cpp
+++ b/src/SchemaLoader.cpp
@@ -1604,6 +1604,22 @@ std::string SchemaLoader::getOutputCppType(const OutputField& field) const noexc
 	size_t templateCount = 0;
 	std::ostringstream outputType;
 
+	switch (field.fieldType)
+	{
+		case OutputFieldType::Object:
+		case OutputFieldType::Union:
+		case OutputFieldType::Interface:
+			// Even if it's non-nullable, we still want to return a shared_ptr for complex types
+			outputType << R"cpp(service::AwaitableObject<)cpp";
+			++templateCount;
+			break;
+
+		default:
+			outputType << R"cpp(service::AwaitableScalar<)cpp";
+			++templateCount;
+			break;
+	}
+
 	for (auto modifier : field.modifiers)
 	{
 		if (!nonNull)

--- a/src/introspection/DirectiveObject.h
+++ b/src/introspection/DirectiveObject.h
@@ -28,11 +28,11 @@ private:
 	{
 		virtual ~Concept() = default;
 
-		virtual service::FieldResult<std::string> getName() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDescription() const = 0;
-		virtual service::FieldResult<std::vector<DirectiveLocation>> getLocations() const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
-		virtual service::FieldResult<bool> getIsRepeatable() const = 0;
+		virtual service::AwaitableScalar<std::string> getName() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		virtual service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
+		virtual service::AwaitableScalar<bool> getIsRepeatable() const = 0;
 	};
 
 	template <class T>
@@ -44,27 +44,27 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getName() const final
+		service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDescription() const final
+		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::FieldResult<std::vector<DirectiveLocation>> getLocations() const final
+		service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
 		{
 			return { _pimpl->getLocations() };
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		service::FieldResult<bool> getIsRepeatable() const final
+		service::AwaitableScalar<bool> getIsRepeatable() const final
 		{
 			return { _pimpl->getIsRepeatable() };
 		}

--- a/src/introspection/EnumValueObject.h
+++ b/src/introspection/EnumValueObject.h
@@ -27,10 +27,10 @@ private:
 	{
 		virtual ~Concept() = default;
 
-		virtual service::FieldResult<std::string> getName() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDescription() const = 0;
-		virtual service::FieldResult<bool> getIsDeprecated() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDeprecationReason() const = 0;
+		virtual service::AwaitableScalar<std::string> getName() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
 	};
 
 	template <class T>
@@ -42,22 +42,22 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getName() const final
+		service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDescription() const final
+		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::FieldResult<bool> getIsDeprecated() const final
+		service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDeprecationReason() const final
+		service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}

--- a/src/introspection/FieldObject.h
+++ b/src/introspection/FieldObject.h
@@ -29,12 +29,12 @@ private:
 	{
 		virtual ~Concept() = default;
 
-		virtual service::FieldResult<std::string> getName() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDescription() const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
-		virtual service::FieldResult<std::shared_ptr<Type>> getType() const = 0;
-		virtual service::FieldResult<bool> getIsDeprecated() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDeprecationReason() const = 0;
+		virtual service::AwaitableScalar<std::string> getName() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
+		virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
 	};
 
 	template <class T>
@@ -46,32 +46,32 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getName() const final
+		service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDescription() const final
+		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		service::FieldResult<std::shared_ptr<Type>> getType() const final
+		service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		service::FieldResult<bool> getIsDeprecated() const final
+		service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDeprecationReason() const final
+		service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}

--- a/src/introspection/InputValueObject.h
+++ b/src/introspection/InputValueObject.h
@@ -27,10 +27,10 @@ private:
 	{
 		virtual ~Concept() = default;
 
-		virtual service::FieldResult<std::string> getName() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDescription() const = 0;
-		virtual service::FieldResult<std::shared_ptr<Type>> getType() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDefaultValue() const = 0;
+		virtual service::AwaitableScalar<std::string> getName() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const = 0;
 	};
 
 	template <class T>
@@ -42,22 +42,22 @@ private:
 		{
 		}
 
-		service::FieldResult<std::string> getName() const final
+		service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDescription() const final
+		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::FieldResult<std::shared_ptr<Type>> getType() const final
+		service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDefaultValue() const final
+		service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
 		{
 			return { _pimpl->getDefaultValue() };
 		}

--- a/src/introspection/IntrospectionSchema.cpp
+++ b/src/introspection/IntrospectionSchema.cpp
@@ -49,7 +49,7 @@ introspection::TypeKind ModifiedArgument<introspection::TypeKind>::convert(const
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<introspection::TypeKind>::convert(service::FieldResult<introspection::TypeKind> result, ResolverParams params)
+service::AwaitableResolver ModifiedResult<introspection::TypeKind>::convert(service::AwaitableScalar<introspection::TypeKind> result, ResolverParams params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](introspection::TypeKind value, const ResolverParams&)
@@ -103,7 +103,7 @@ introspection::DirectiveLocation ModifiedArgument<introspection::DirectiveLocati
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<introspection::DirectiveLocation>::convert(service::FieldResult<introspection::DirectiveLocation> result, ResolverParams params)
+service::AwaitableResolver ModifiedResult<introspection::DirectiveLocation>::convert(service::AwaitableScalar<introspection::DirectiveLocation> result, ResolverParams params)
 {
 	return resolve(std::move(result), std::move(params),
 		[](introspection::DirectiveLocation value, const ResolverParams&)

--- a/src/introspection/IntrospectionSchema.cpp
+++ b/src/introspection/IntrospectionSchema.cpp
@@ -62,6 +62,22 @@ service::AwaitableResolver ModifiedResult<introspection::TypeKind>::convert(serv
 		});
 }
 
+template <>
+void ModifiedResult<introspection::TypeKind>::validateScalar(const response::Value& value)
+{
+	if (!value.maybe_enum())
+	{
+		throw service::schema_exception { { R"ex(not a valid __TypeKind value)ex" } };
+	}
+
+	const auto itr = std::find(s_namesTypeKind.cbegin(), s_namesTypeKind.cend(), value.get<std::string>());
+
+	if (itr == s_namesTypeKind.cend())
+	{
+		throw service::schema_exception { { R"ex(not a valid __TypeKind value)ex" } };
+	}
+}
+
 static const std::array<std::string_view, 19> s_namesDirectiveLocation = {
 	R"gql(QUERY)gql"sv,
 	R"gql(MUTATION)gql"sv,
@@ -114,6 +130,22 @@ service::AwaitableResolver ModifiedResult<introspection::DirectiveLocation>::con
 
 			return result;
 		});
+}
+
+template <>
+void ModifiedResult<introspection::DirectiveLocation>::validateScalar(const response::Value& value)
+{
+	if (!value.maybe_enum())
+	{
+		throw service::schema_exception { { R"ex(not a valid __DirectiveLocation value)ex" } };
+	}
+
+	const auto itr = std::find(s_namesDirectiveLocation.cbegin(), s_namesDirectiveLocation.cend(), value.get<std::string>());
+
+	if (itr == s_namesDirectiveLocation.cend())
+	{
+		throw service::schema_exception { { R"ex(not a valid __DirectiveLocation value)ex" } };
+	}
 }
 
 } // namespace service

--- a/src/introspection/IntrospectionSchema.h
+++ b/src/introspection/IntrospectionSchema.h
@@ -108,11 +108,17 @@ template <>
 GRAPHQLINTROSPECTION_EXPORT AwaitableResolver ModifiedResult<introspection::TypeKind>::convert(
 	AwaitableScalar<introspection::TypeKind> result, ResolverParams params);
 template <>
+GRAPHQLINTROSPECTION_EXPORT void ModifiedResult<introspection::TypeKind>::validateScalar(
+	const response::Value& value);
+template <>
 GRAPHQLINTROSPECTION_EXPORT introspection::DirectiveLocation ModifiedArgument<introspection::DirectiveLocation>::convert(
 	const response::Value& value);
 template <>
 GRAPHQLINTROSPECTION_EXPORT AwaitableResolver ModifiedResult<introspection::DirectiveLocation>::convert(
 	AwaitableScalar<introspection::DirectiveLocation> result, ResolverParams params);
+template <>
+GRAPHQLINTROSPECTION_EXPORT void ModifiedResult<introspection::DirectiveLocation>::validateScalar(
+	const response::Value& value);
 #endif // GRAPHQL_DLLEXPORTS
 
 } // namespace service

--- a/src/introspection/IntrospectionSchema.h
+++ b/src/introspection/IntrospectionSchema.h
@@ -106,13 +106,13 @@ GRAPHQLINTROSPECTION_EXPORT introspection::TypeKind ModifiedArgument<introspecti
 	const response::Value& value);
 template <>
 GRAPHQLINTROSPECTION_EXPORT AwaitableResolver ModifiedResult<introspection::TypeKind>::convert(
-	FieldResult<introspection::TypeKind> result, ResolverParams params);
+	AwaitableScalar<introspection::TypeKind> result, ResolverParams params);
 template <>
 GRAPHQLINTROSPECTION_EXPORT introspection::DirectiveLocation ModifiedArgument<introspection::DirectiveLocation>::convert(
 	const response::Value& value);
 template <>
 GRAPHQLINTROSPECTION_EXPORT AwaitableResolver ModifiedResult<introspection::DirectiveLocation>::convert(
-	FieldResult<introspection::DirectiveLocation> result, ResolverParams params);
+	AwaitableScalar<introspection::DirectiveLocation> result, ResolverParams params);
 #endif // GRAPHQL_DLLEXPORTS
 
 } // namespace service

--- a/src/introspection/SchemaObject.h
+++ b/src/introspection/SchemaObject.h
@@ -29,12 +29,12 @@ private:
 	{
 		virtual ~Concept() = default;
 
-		virtual service::FieldResult<std::optional<std::string>> getDescription() const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<Type>>> getTypes() const = 0;
-		virtual service::FieldResult<std::shared_ptr<Type>> getQueryType() const = 0;
-		virtual service::FieldResult<std::shared_ptr<Type>> getMutationType() const = 0;
-		virtual service::FieldResult<std::shared_ptr<Type>> getSubscriptionType() const = 0;
-		virtual service::FieldResult<std::vector<std::shared_ptr<Directive>>> getDirectives() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const = 0;
+		virtual service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const = 0;
 	};
 
 	template <class T>
@@ -46,32 +46,32 @@ private:
 		{
 		}
 
-		service::FieldResult<std::optional<std::string>> getDescription() const final
+		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<Type>>> getTypes() const final
+		service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
 		{
 			return { _pimpl->getTypes() };
 		}
 
-		service::FieldResult<std::shared_ptr<Type>> getQueryType() const final
+		service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
 		{
 			return { _pimpl->getQueryType() };
 		}
 
-		service::FieldResult<std::shared_ptr<Type>> getMutationType() const final
+		service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
 		{
 			return { _pimpl->getMutationType() };
 		}
 
-		service::FieldResult<std::shared_ptr<Type>> getSubscriptionType() const final
+		service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
 		{
 			return { _pimpl->getSubscriptionType() };
 		}
 
-		service::FieldResult<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
+		service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
 		{
 			return { _pimpl->getDirectives() };
 		}

--- a/src/introspection/TypeObject.h
+++ b/src/introspection/TypeObject.h
@@ -33,16 +33,16 @@ private:
 	{
 		virtual ~Concept() = default;
 
-		virtual service::FieldResult<TypeKind> getKind() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getName() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getDescription() const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const = 0;
-		virtual service::FieldResult<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const = 0;
-		virtual service::FieldResult<std::shared_ptr<Type>> getOfType() const = 0;
-		virtual service::FieldResult<std::optional<std::string>> getSpecifiedByURL() const = 0;
+		virtual service::AwaitableScalar<TypeKind> getKind() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getName() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const = 0;
+		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const = 0;
+		virtual service::AwaitableObject<std::shared_ptr<Type>> getOfType() const = 0;
+		virtual service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const = 0;
 	};
 
 	template <class T>
@@ -54,52 +54,52 @@ private:
 		{
 		}
 
-		service::FieldResult<TypeKind> getKind() const final
+		service::AwaitableScalar<TypeKind> getKind() const final
 		{
 			return { _pimpl->getKind() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getName() const final
+		service::AwaitableScalar<std::optional<std::string>> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getDescription() const final
+		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getFields(std::move(includeDeprecatedArg)) };
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
 		{
 			return { _pimpl->getInterfaces() };
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
 		{
 			return { _pimpl->getPossibleTypes() };
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getEnumValues(std::move(includeDeprecatedArg)) };
 		}
 
-		service::FieldResult<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
+		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
 		{
 			return { _pimpl->getInputFields() };
 		}
 
-		service::FieldResult<std::shared_ptr<Type>> getOfType() const final
+		service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
 		{
 			return { _pimpl->getOfType() };
 		}
 
-		service::FieldResult<std::optional<std::string>> getSpecifiedByURL() const final
+		service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
 		{
 			return { _pimpl->getSpecifiedByURL() };
 		}


### PR DESCRIPTION
Pull request #181 added support for returning `std::shared_ptr<const response::Value>`, this limits that feature to scalar types. It also adds validation that the `response::Value` can be parsed as the expected type.