### PR TITLE
Consolidate TodayMock services and protect async loaders with mutex

### DIFF
--- a/samples/client/benchmark.cpp
+++ b/samples/client/benchmark.cpp
@@ -16,55 +16,6 @@ using namespace graphql;
 
 using namespace std::literals;
 
-namespace {
-
-response::IdType binAppointmentId;
-response::IdType binTaskId;
-response::IdType binFolderId;
-
-} // namespace
-
-std::shared_ptr<today::Operations> buildService()
-{
-	std::string fakeAppointmentId("fakeAppointmentId");
-	binAppointmentId.resize(fakeAppointmentId.size());
-	std::copy(fakeAppointmentId.cbegin(), fakeAppointmentId.cend(), binAppointmentId.begin());
-
-	std::string fakeTaskId("fakeTaskId");
-	binTaskId.resize(fakeTaskId.size());
-	std::copy(fakeTaskId.cbegin(), fakeTaskId.cend(), binTaskId.begin());
-
-	std::string fakeFolderId("fakeFolderId");
-	binFolderId.resize(fakeFolderId.size());
-	std::copy(fakeFolderId.cbegin(), fakeFolderId.cend(), binFolderId.begin());
-
-	auto query = std::make_shared<today::Query>(
-		[]() -> std::vector<std::shared_ptr<today::Appointment>> {
-			return { std::make_shared<today::Appointment>(std::move(binAppointmentId),
-				"tomorrow",
-				"Lunch?",
-				false) };
-		},
-		[]() -> std::vector<std::shared_ptr<today::Task>> {
-			return { std::make_shared<today::Task>(std::move(binTaskId), "Don't forget", true) };
-		},
-		[]() -> std::vector<std::shared_ptr<today::Folder>> {
-			return { std::make_shared<today::Folder>(std::move(binFolderId), "\"Fake\" Inbox", 3) };
-		});
-	auto mutation = std::make_shared<today::Mutation>(
-		[](today::CompleteTaskInput&& input) -> std::shared_ptr<today::CompleteTaskPayload> {
-			return std::make_shared<today::CompleteTaskPayload>(
-				std::make_shared<today::Task>(std::move(input.id),
-					"Mutated Task!",
-					*(input.isComplete)),
-				std::move(input.clientMutationId));
-		});
-	auto subscription = std::make_shared<today::Subscription>();
-	auto service = std::make_shared<today::Operations>(query, mutation, subscription);
-
-	return service;
-}
-
 void outputOverview(
 	size_t iterations, const std::chrono::steady_clock::duration& totalDuration) noexcept
 {
@@ -126,7 +77,8 @@ int main(int argc, char** argv)
 
 	std::cout << "Iterations: " << iterations << std::endl;
 
-	auto service = buildService();
+	const auto mockService = today::mock_service();
+	const auto& service = mockService->service;
 	std::vector<std::chrono::steady_clock::duration> durationResolve(iterations);
 	std::vector<std::chrono::steady_clock::duration> durationParseServiceResponse(iterations);
 	std::vector<std::chrono::steady_clock::duration> durationParseResponse(iterations);

--- a/samples/today/TodayMock.h
+++ b/samples/today/TodayMock.h
@@ -26,6 +26,21 @@
 
 namespace graphql::today {
 
+// These IDs are hard-coded in every test which uses TodayMock.
+const response::IdType& getFakeAppointmentId() noexcept;
+const response::IdType& getFakeTaskId() noexcept;
+const response::IdType& getFakeFolderId() noexcept;
+
+struct TodayMockService
+{
+	std::shared_ptr<Operations> service {};
+	size_t getAppointmentsCount {};
+	size_t getTasksCount {};
+	size_t getUnreadCountsCount {};
+};
+
+std::unique_ptr<TodayMockService> mock_service() noexcept;
+
 struct RequestState : service::RequestState
 {
 	RequestState(size_t id)

--- a/samples/today/benchmark.cpp
+++ b/samples/today/benchmark.cpp
@@ -17,55 +17,6 @@ using namespace graphql;
 
 using namespace std::literals;
 
-namespace {
-
-response::IdType binAppointmentId;
-response::IdType binTaskId;
-response::IdType binFolderId;
-
-} // namespace
-
-std::shared_ptr<today::Operations> buildService()
-{
-	std::string fakeAppointmentId("fakeAppointmentId");
-	binAppointmentId.resize(fakeAppointmentId.size());
-	std::copy(fakeAppointmentId.cbegin(), fakeAppointmentId.cend(), binAppointmentId.begin());
-
-	std::string fakeTaskId("fakeTaskId");
-	binTaskId.resize(fakeTaskId.size());
-	std::copy(fakeTaskId.cbegin(), fakeTaskId.cend(), binTaskId.begin());
-
-	std::string fakeFolderId("fakeFolderId");
-	binFolderId.resize(fakeFolderId.size());
-	std::copy(fakeFolderId.cbegin(), fakeFolderId.cend(), binFolderId.begin());
-
-	auto query = std::make_shared<today::Query>(
-		[]() -> std::vector<std::shared_ptr<today::Appointment>> {
-			return { std::make_shared<today::Appointment>(std::move(binAppointmentId),
-				"tomorrow",
-				"Lunch?",
-				false) };
-		},
-		[]() -> std::vector<std::shared_ptr<today::Task>> {
-			return { std::make_shared<today::Task>(std::move(binTaskId), "Don't forget", true) };
-		},
-		[]() -> std::vector<std::shared_ptr<today::Folder>> {
-			return { std::make_shared<today::Folder>(std::move(binFolderId), "\"Fake\" Inbox", 3) };
-		});
-	auto mutation = std::make_shared<today::Mutation>(
-		[](today::CompleteTaskInput&& input) -> std::shared_ptr<today::CompleteTaskPayload> {
-			return std::make_shared<today::CompleteTaskPayload>(
-				std::make_shared<today::Task>(std::move(input.id),
-					"Mutated Task!",
-					*(input.isComplete)),
-				std::move(input.clientMutationId));
-		});
-	auto subscription = std::make_shared<today::Subscription>();
-	auto service = std::make_shared<today::Operations>(query, mutation, subscription);
-
-	return service;
-}
-
 void outputOverview(
 	size_t iterations, const std::chrono::steady_clock::duration& totalDuration) noexcept
 {
@@ -127,7 +78,8 @@ int main(int argc, char** argv)
 
 	std::cout << "Iterations: " << iterations << std::endl;
 
-	auto service = buildService();
+	const auto mockService = today::mock_service();
+	const auto& service = mockService->service;
 	std::vector<std::chrono::steady_clock::duration> durationParse(iterations);
 	std::vector<std::chrono::steady_clock::duration> durationValidate(iterations);
 	std::vector<std::chrono::steady_clock::duration> durationResolve(iterations);

--- a/samples/today/sample.cpp
+++ b/samples/today/sample.cpp
@@ -14,48 +14,8 @@ using namespace graphql;
 
 int main(int argc, char** argv)
 {
-	response::IdType binAppointmentId;
-	response::IdType binTaskId;
-	response::IdType binFolderId;
-
-	std::string fakeAppointmentId("fakeAppointmentId");
-	binAppointmentId.resize(fakeAppointmentId.size());
-	std::copy(fakeAppointmentId.cbegin(), fakeAppointmentId.cend(), binAppointmentId.begin());
-
-	std::string fakeTaskId("fakeTaskId");
-	binTaskId.resize(fakeTaskId.size());
-	std::copy(fakeTaskId.cbegin(), fakeTaskId.cend(), binTaskId.begin());
-
-	std::string fakeFolderId("fakeFolderId");
-	binFolderId.resize(fakeFolderId.size());
-	std::copy(fakeFolderId.cbegin(), fakeFolderId.cend(), binFolderId.begin());
-
-	auto query = std::make_shared<today::Query>(
-		[&binAppointmentId]() -> std::vector<std::shared_ptr<today::Appointment>> {
-			std::cout << "Called getAppointments..." << std::endl;
-			return { std::make_shared<today::Appointment>(std::move(binAppointmentId),
-				"tomorrow",
-				"Lunch?",
-				false) };
-		},
-		[&binTaskId]() -> std::vector<std::shared_ptr<today::Task>> {
-			std::cout << "Called getTasks..." << std::endl;
-			return { std::make_shared<today::Task>(std::move(binTaskId), "Don't forget", true) };
-		},
-		[&binFolderId]() -> std::vector<std::shared_ptr<today::Folder>> {
-			std::cout << "Called getUnreadCounts..." << std::endl;
-			return { std::make_shared<today::Folder>(std::move(binFolderId), "\"Fake\" Inbox", 3) };
-		});
-	auto mutation = std::make_shared<today::Mutation>(
-		[](today::CompleteTaskInput&& input) -> std::shared_ptr<today::CompleteTaskPayload> {
-			return std::make_shared<today::CompleteTaskPayload>(
-				std::make_shared<today::Task>(std::move(input.id),
-					"Mutated Task!",
-					*(input.isComplete)),
-				std::move(input.clientMutationId));
-		});
-	auto subscription = std::make_shared<today::Subscription>();
-	auto service = std::make_shared<today::Operations>(query, mutation, subscription);
+	const auto mockService = today::mock_service();
+	const auto& service = mockService->service;
 
 	std::cout << "Created the service..." << std::endl;
 
@@ -84,8 +44,7 @@ int main(int argc, char** argv)
 
 		std::cout << "Executing query..." << std::endl;
 
-		std::cout << response::toJSON(
-			service->resolve({ ast, ((argc > 2) ? argv[2] : "") }).get())
+		std::cout << response::toJSON(service->resolve({ ast, ((argc > 2) ? argv[2] : "") }).get())
 				  << std::endl;
 	}
 	catch (const std::runtime_error& ex)

--- a/test/ClientTests.cpp
+++ b/test/ClientTests.cpp
@@ -17,89 +17,19 @@ using namespace std::literals;
 class ClientCase : public ::testing::Test
 {
 public:
-	static void SetUpTestCase()
-	{
-		std::string fakeAppointmentId("fakeAppointmentId");
-		_fakeAppointmentId.resize(fakeAppointmentId.size());
-		std::copy(fakeAppointmentId.cbegin(), fakeAppointmentId.cend(), _fakeAppointmentId.begin());
-
-		std::string fakeTaskId("fakeTaskId");
-		_fakeTaskId.resize(fakeTaskId.size());
-		std::copy(fakeTaskId.cbegin(), fakeTaskId.cend(), _fakeTaskId.begin());
-
-		std::string fakeFolderId("fakeFolderId");
-		_fakeFolderId.resize(fakeFolderId.size());
-		std::copy(fakeFolderId.cbegin(), fakeFolderId.cend(), _fakeFolderId.begin());
-	}
-
 	void SetUp() override
 	{
-		auto query = std::make_shared<today::Query>(
-			[this]() -> std::vector<std::shared_ptr<today::Appointment>> {
-				++_getAppointmentsCount;
-				return { std::make_shared<today::Appointment>(response::IdType(_fakeAppointmentId),
-					"tomorrow",
-					"Lunch?",
-					false) };
-			},
-			[this]() -> std::vector<std::shared_ptr<today::Task>> {
-				++_getTasksCount;
-				return { std::make_shared<today::Task>(response::IdType(_fakeTaskId),
-					"Don't forget",
-					true) };
-			},
-			[this]() -> std::vector<std::shared_ptr<today::Folder>> {
-				++_getUnreadCountsCount;
-				return { std::make_shared<today::Folder>(response::IdType(_fakeFolderId),
-					"\"Fake\" Inbox",
-					3) };
-			});
-		auto mutation = std::make_shared<today::Mutation>(
-			[](today::CompleteTaskInput&& input) -> std::shared_ptr<today::CompleteTaskPayload> {
-				return std::make_shared<today::CompleteTaskPayload>(
-					std::make_shared<today::Task>(std::move(input.id),
-						"Mutated Task!",
-						*(input.isComplete)),
-					std::move(input.clientMutationId));
-			});
-		auto subscription = std::make_shared<today::NextAppointmentChange>(
-			[](const std::shared_ptr<service::RequestState>&)
-				-> std::shared_ptr<today::Appointment> {
-				return { std::make_shared<today::Appointment>(response::IdType(_fakeAppointmentId),
-					"tomorrow",
-					"Lunch?",
-					true) };
-			});
-
-		_service = std::make_shared<today::Operations>(query, mutation, subscription);
+		_mockService = today::mock_service();
 	}
 
 	void TearDown() override
 	{
-		_service.reset();
-	}
-
-	static void TearDownTestCase()
-	{
-		_fakeAppointmentId.clear();
-		_fakeTaskId.clear();
-		_fakeFolderId.clear();
+		_mockService.reset();
 	}
 
 protected:
-	static response::IdType _fakeAppointmentId;
-	static response::IdType _fakeTaskId;
-	static response::IdType _fakeFolderId;
-
-	std::shared_ptr<today::Operations> _service {};
-	size_t _getAppointmentsCount {};
-	size_t _getTasksCount {};
-	size_t _getUnreadCountsCount {};
+	std::unique_ptr<today::TodayMockService> _mockService;
 };
-
-response::IdType ClientCase::_fakeAppointmentId;
-response::IdType ClientCase::_fakeTaskId;
-response::IdType ClientCase::_fakeFolderId;
 
 TEST_F(ClientCase, QueryEverything)
 {
@@ -109,13 +39,14 @@ TEST_F(ClientCase, QueryEverything)
 
 	response::Value variables(response::Type::Map);
 	auto state = std::make_shared<today::RequestState>(1);
-	auto result =
-		_service->resolve({ query, {}, std::move(variables), std::launch::async, state }).get();
-	EXPECT_EQ(size_t { 1 }, _getAppointmentsCount)
+	auto result = _mockService->service
+					  ->resolve({ query, {}, std::move(variables), std::launch::async, state })
+					  .get();
+	EXPECT_EQ(size_t { 1 }, _mockService->getAppointmentsCount)
 		<< "today service lazy loads the appointments and caches the result";
-	EXPECT_EQ(size_t { 1 }, _getTasksCount)
+	EXPECT_EQ(size_t { 1 }, _mockService->getTasksCount)
 		<< "today service lazy loads the tasks and caches the result";
-	EXPECT_EQ(size_t { 1 }, _getUnreadCountsCount)
+	EXPECT_EQ(size_t { 1 }, _mockService->getUnreadCountsCount)
 		<< "today service lazy loads the unreadCounts and caches the result";
 	EXPECT_EQ(size_t { 1 }, state->appointmentsRequestId)
 		<< "today service passed the same RequestState";
@@ -140,7 +71,8 @@ TEST_F(ClientCase, QueryEverything)
 		ASSERT_TRUE((*response.appointments.edges)[0].has_value()) << "edge should be set";
 		const auto& appointmentNode = (*response.appointments.edges)[0]->node;
 		ASSERT_TRUE(appointmentNode.has_value()) << "node should be set";
-		EXPECT_EQ(_fakeAppointmentId, appointmentNode->id) << "id should match in base64 encoding";
+		EXPECT_EQ(today::getFakeAppointmentId(), appointmentNode->id)
+			<< "id should match in base64 encoding";
 		ASSERT_TRUE(appointmentNode->subject.has_value()) << "subject should be set";
 		EXPECT_EQ("Lunch?", *(appointmentNode->subject)) << "subject should match";
 		ASSERT_TRUE(appointmentNode->when.has_value()) << "when should be set";
@@ -153,7 +85,7 @@ TEST_F(ClientCase, QueryEverything)
 		ASSERT_TRUE((*response.tasks.edges)[0].has_value()) << "edge should be set";
 		const auto& taskNode = (*response.tasks.edges)[0]->node;
 		ASSERT_TRUE(taskNode.has_value()) << "node should be set";
-		EXPECT_EQ(_fakeTaskId, taskNode->id) << "id should match in base64 encoding";
+		EXPECT_EQ(today::getFakeTaskId(), taskNode->id) << "id should match in base64 encoding";
 		ASSERT_TRUE(taskNode->title.has_value()) << "subject should be set";
 		EXPECT_EQ("Don't forget", *(taskNode->title)) << "title should match";
 		EXPECT_TRUE(taskNode->isComplete) << "isComplete should match";
@@ -165,7 +97,8 @@ TEST_F(ClientCase, QueryEverything)
 		ASSERT_TRUE((*response.unreadCounts.edges)[0].has_value()) << "edge should be set";
 		const auto& unreadCountNode = (*response.unreadCounts.edges)[0]->node;
 		ASSERT_TRUE(unreadCountNode.has_value()) << "node should be set";
-		EXPECT_EQ(_fakeFolderId, unreadCountNode->id) << "id should match in base64 encoding";
+		EXPECT_EQ(today::getFakeFolderId(), unreadCountNode->id)
+			<< "id should match in base64 encoding";
 		ASSERT_TRUE(unreadCountNode->name.has_value()) << "name should be set";
 		EXPECT_EQ("\"Fake\" Inbox", *(unreadCountNode->name)) << "name should match";
 		EXPECT_EQ(3, unreadCountNode->unreadCount) << "unreadCount should match";
@@ -178,7 +111,8 @@ TEST_F(ClientCase, QueryEverything)
 		ASSERT_TRUE(response.anyType[0].has_value()) << "appointment should be set";
 		const auto& anyType = *response.anyType[0];
 		EXPECT_EQ("Appointment", anyType._typename) << "__typename should match";
-		EXPECT_EQ(_fakeAppointmentId, anyType.id) << "id should match in base64 encoding";
+		EXPECT_EQ(today::getFakeAppointmentId(), anyType.id)
+			<< "id should match in base64 encoding";
 		EXPECT_FALSE(anyType.title.has_value()) << "appointment should not have a title";
 		EXPECT_FALSE(anyType.isComplete) << "appointment should not set isComplete";
 		ASSERT_TRUE(anyType.subject.has_value()) << "subject should be set";
@@ -198,13 +132,14 @@ TEST_F(ClientCase, MutateCompleteTask)
 	using namespace client::mutation::CompleteTaskMutation;
 
 	auto query = GetRequestObject();
-	auto variables = serializeVariables({ { _fakeTaskId,
+	auto variables = serializeVariables({ { today::getFakeTaskId(),
 		std::nullopt,
 		std::make_optional(true),
 		std::make_optional("Hi There!"s) } });
 
 	auto state = std::make_shared<today::RequestState>(5);
-	auto result = _service->resolve({ query, {}, std::move(variables), {}, state }).get();
+	auto result =
+		_mockService->service->resolve({ query, {}, std::move(variables), {}, state }).get();
 
 	try
 	{
@@ -217,7 +152,8 @@ TEST_F(ClientCase, MutateCompleteTask)
 		const auto& completedTask = response.completedTask;
 		const auto& task = completedTask.completedTask;
 		ASSERT_TRUE(task.has_value()) << "should get back a task";
-		EXPECT_EQ(_fakeTaskId, task->completedTaskId) << "id should match in base64 encoding";
+		EXPECT_EQ(today::getFakeTaskId(), task->completedTaskId)
+			<< "id should match in base64 encoding";
 		ASSERT_TRUE(task->title.has_value()) << "title should be set";
 		EXPECT_EQ("Mutated Task!", *(task->title)) << "title should match";
 		EXPECT_TRUE(task->isComplete) << "isComplete should match";
@@ -241,7 +177,7 @@ TEST_F(ClientCase, SubscribeNextAppointmentChangeDefault)
 	response::Value variables(response::Type::Map);
 	auto state = std::make_shared<today::RequestState>(6);
 	response::Value result;
-	auto key = _service
+	auto key = _mockService->service
 				   ->subscribe({ [&result](response::Value&& response) {
 									result = std::move(response);
 								},
@@ -251,8 +187,8 @@ TEST_F(ClientCase, SubscribeNextAppointmentChangeDefault)
 					   {},
 					   state })
 				   .get();
-	_service->deliver({ "nextAppointmentChange"sv }).get();
-	_service->unsubscribe({ key }).get();
+	_mockService->service->deliver({ "nextAppointmentChange"sv }).get();
+	_mockService->service->unsubscribe({ key }).get();
 
 	try
 	{
@@ -264,7 +200,7 @@ TEST_F(ClientCase, SubscribeNextAppointmentChangeDefault)
 
 		const auto& appointmentNode = response.nextAppointment;
 		ASSERT_TRUE(appointmentNode.has_value()) << "should get back a task";
-		EXPECT_EQ(_fakeAppointmentId, appointmentNode->nextAppointmentId)
+		EXPECT_EQ(today::getFakeAppointmentId(), appointmentNode->nextAppointmentId)
 			<< "id should match in base64 encoding";
 		ASSERT_TRUE(appointmentNode->subject.has_value()) << "subject should be set";
 		EXPECT_EQ("Lunch?", *(appointmentNode->subject)) << "subject should match";
@@ -277,7 +213,3 @@ TEST_F(ClientCase, SubscribeNextAppointmentChangeDefault)
 		FAIL() << ex.what();
 	}
 }
-
-size_t today::NextAppointmentChange::_notifySubscribeCount = 0;
-size_t today::NextAppointmentChange::_subscriptionCount = 0;
-size_t today::NextAppointmentChange::_notifyUnsubscribeCount = 0;


### PR DESCRIPTION
There's a lot of nearly duplicate code for setting up a TodayMock service for use in benchmarks, samples, and tests, so I centralized that in a factory function and struct in TodayMock itself.

I also put a mutex around each of the loader callbacks, so when resolve is handling multiple fields in parallel there isn't a race condition which loads more than once or fails to update the loading count in the callback. Combined with resetting the test state for each test method, this should fix the lingering intermittent failures. 