### PR TITLE
Don't add Variables:: scope to scalar and built-in types in clientgen

### DIFF
--- a/samples/client/benchmark/BenchmarkClient.cpp
+++ b/samples/client/benchmark/BenchmarkClient.cpp
@@ -7,8 +7,8 @@
 
 #include <algorithm>
 #include <array>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 #include <string_view>
 
 using namespace std::literals;

--- a/samples/client/mutate/MutateClient.cpp
+++ b/samples/client/mutate/MutateClient.cpp
@@ -7,8 +7,8 @@
 
 #include <algorithm>
 #include <array>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 #include <string_view>
 
 using namespace std::literals;

--- a/samples/client/mutate/MutateClient.cpp
+++ b/samples/client/mutate/MutateClient.cpp
@@ -132,14 +132,14 @@ const std::string& GetRequestText() noexcept
 		# Copyright (c) Microsoft Corporation. All rights reserved.
 		# Licensed under the MIT License.
 		
-		mutation CompleteTaskMutation($input: CompleteTaskInput! = {id: "ZmFrZVRhc2tJZA==", isComplete: true, clientMutationId: "Hi There!"}) {
+		mutation CompleteTaskMutation($input: CompleteTaskInput! = {id: "ZmFrZVRhc2tJZA==", isComplete: true, clientMutationId: "Hi There!"}, $skipClientMutationId: Boolean!) {
 		  completedTask: completeTask(input: $input) {
 		    completedTask: task {
 		      completedTaskId: id
 		      title
 		      isComplete
 		    }
-		    clientMutationId
+		    clientMutationId @skip(if: $skipClientMutationId)
 		  }
 		}
 	)gql"s;
@@ -166,6 +166,7 @@ response::Value serializeVariables(Variables&& variables)
 	response::Value result { response::Type::Map };
 
 	result.emplace_back(R"js(input)js"s, ModifiedVariable<Variables::CompleteTaskInput>::serialize(std::move(variables.input)));
+	result.emplace_back(R"js(skipClientMutationId)js"s, ModifiedVariable<response::BooleanType>::serialize(std::move(variables.skipClientMutationId)));
 
 	return result;
 }

--- a/samples/client/mutate/MutateClient.h
+++ b/samples/client/mutate/MutateClient.h
@@ -29,14 +29,14 @@ static_assert(graphql::internal::MinorVersion == 7, "regenerate with clientgen: 
 /// # Copyright (c) Microsoft Corporation. All rights reserved.
 /// # Licensed under the MIT License.
 /// 
-/// mutation CompleteTaskMutation($input: CompleteTaskInput! = {id: "ZmFrZVRhc2tJZA==", isComplete: true, clientMutationId: "Hi There!"}) {
+/// mutation CompleteTaskMutation($input: CompleteTaskInput! = {id: "ZmFrZVRhc2tJZA==", isComplete: true, clientMutationId: "Hi There!"}, $skipClientMutationId: Boolean!) {
 ///   completedTask: completeTask(input: $input) {
 ///     completedTask: task {
 ///       completedTaskId: id
 ///       title
 ///       isComplete
 ///     }
-///     clientMutationId
+///     clientMutationId @skip(if: $skipClientMutationId)
 ///   }
 /// }
 /// </code>
@@ -67,6 +67,7 @@ struct Variables
 	};
 
 	CompleteTaskInput input {};
+	response::BooleanType skipClientMutationId {};
 };
 
 response::Value serializeVariables(Variables&& variables);

--- a/samples/client/mutate/mutate.today.graphql
+++ b/samples/client/mutate/mutate.today.graphql
@@ -1,13 +1,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-mutation CompleteTaskMutation($input: CompleteTaskInput! = {id: "ZmFrZVRhc2tJZA==", isComplete: true, clientMutationId: "Hi There!"}) {
+mutation CompleteTaskMutation($input: CompleteTaskInput! = {id: "ZmFrZVRhc2tJZA==", isComplete: true, clientMutationId: "Hi There!"}, $skipClientMutationId: Boolean!) {
   completedTask: completeTask(input: $input) {
     completedTask: task {
       completedTaskId: id
       title
       isComplete
     }
-    clientMutationId
+    clientMutationId @skip(if: $skipClientMutationId)
   }
 }

--- a/samples/client/query/QueryClient.cpp
+++ b/samples/client/query/QueryClient.cpp
@@ -7,8 +7,8 @@
 
 #include <algorithm>
 #include <array>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 #include <string_view>
 
 using namespace std::literals;

--- a/samples/client/subscribe/SubscribeClient.cpp
+++ b/samples/client/subscribe/SubscribeClient.cpp
@@ -7,8 +7,8 @@
 
 #include <algorithm>
 #include <array>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 #include <string_view>
 
 using namespace std::literals;

--- a/src/ClientGenerator.cpp
+++ b/src/ClientGenerator.cpp
@@ -223,7 +223,8 @@ static_assert(graphql::internal::MinorVersion == )cpp"
 	{
 		pendingSeparator.reset();
 
-		headerFile << R"cpp(enum class )cpp" << _schemaLoader.getCppType(enumType->name()) << R"cpp(
+		headerFile << R"cpp(enum class )cpp" << _schemaLoader.getCppType(enumType->name())
+				   << R"cpp(
 {
 )cpp";
 		for (const auto& enumValue : enumType->enumValues())
@@ -451,8 +452,8 @@ bool Generator::outputSource() const noexcept
 
 #include <algorithm>
 #include <array>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 #include <string_view>
 
 using namespace std::literals;
@@ -625,8 +626,14 @@ response::Value serializeVariables(Variables&& variables)
 		for (const auto& variable : variables)
 		{
 			sourceFile << R"cpp(	result.emplace_back(R"js()cpp" << variable.name
-					   << R"cpp()js"s, ModifiedVariable<Variables::)cpp"
-					   << _schemaLoader.getCppType(variable.type->name()) << R"cpp(>::serialize)cpp"
+					   << R"cpp()js"s, ModifiedVariable<)cpp";
+
+			if (_schemaLoader.getSchemaType(variable.type->name()) != SchemaType::Scalar)
+			{
+				sourceFile << R"cpp(Variables::)cpp";
+			}
+
+			sourceFile << _schemaLoader.getCppType(variable.type->name()) << R"cpp(>::serialize)cpp"
 					   << getTypeModifierList(variable.modifiers)
 					   << R"cpp((std::move(variables.)cpp" << variable.cppName << R"cpp()));
 )cpp";

--- a/src/ClientGenerator.cpp
+++ b/src/ClientGenerator.cpp
@@ -628,7 +628,10 @@ response::Value serializeVariables(Variables&& variables)
 			sourceFile << R"cpp(	result.emplace_back(R"js()cpp" << variable.name
 					   << R"cpp()js"s, ModifiedVariable<)cpp";
 
-			if (_schemaLoader.getSchemaType(variable.type->name()) != SchemaType::Scalar)
+			const auto& builtinTypes = _schemaLoader.getBuiltinTypes();
+
+			if (builtinTypes.find(variable.type->name()) == builtinTypes.cend()
+				&& _schemaLoader.getSchemaType(variable.type->name()) != SchemaType::Scalar)
 			{
 				sourceFile << R"cpp(Variables::)cpp";
 			}


### PR DESCRIPTION
Fix #199 