### PR TITLE
Make Request/Operations methods thread-safe and test custom awaitables

### DIFF
--- a/doc/awaitable.md
+++ b/doc/awaitable.md
@@ -8,7 +8,7 @@ specifically a type-erased `graphql::service::await_async` class in
 [GraphQLService.h](../include/graphqlservice/GraphQLService.h):
 ```cpp
 // Type-erased awaitable.
-class await_async : public coro::suspend_always
+class await_async final
 {
 private:
 	struct Concept
@@ -31,7 +31,7 @@ public:
 
 	// Default to immediate synchronous execution.
 	await_async()
-		: _pimpl { std::static_pointer_cast<Concept>(
+		: _pimpl { std::static_pointer_cast<const Concept>(
 			std::make_shared<Model<coro::suspend_never>>(std::make_shared<coro::suspend_never>())) }
 	{
 	}
@@ -39,9 +39,9 @@ public:
 	// Implicitly convert a std::launch parameter used with std::async to an awaitable.
 	await_async(std::launch launch)
 		: _pimpl { ((launch & std::launch::async) == std::launch::async)
-				? std::static_pointer_cast<Concept>(std::make_shared<Model<await_worker_thread>>(
+				? std::static_pointer_cast<const Concept>(std::make_shared<Model<await_worker_thread>>(
 					std::make_shared<await_worker_thread>()))
-				: std::static_pointer_cast<Concept>(std::make_shared<Model<coro::suspend_never>>(
+				: std::static_pointer_cast<const Concept>(std::make_shared<Model<coro::suspend_never>>(
 					std::make_shared<coro::suspend_never>())) }
 	{
 	}

--- a/doc/json.md
+++ b/doc/json.md
@@ -46,7 +46,7 @@ to some other output mechanism, without building a single string buffer for the 
 document in memory. For example, you might use this to write directly to a buffered IPC pipe
 or network connection:
 ```cpp
-class Writer
+class Writer final
 {
 private:
 	struct Concept
@@ -71,7 +71,7 @@ private:
 public:
 	template <class T>
 	Writer(std::unique_ptr<T> writer)
-		: _concept { std::static_pointer_cast<Concept>(
+		: _concept { std::static_pointer_cast<const Concept>(
 			std::make_shared<Model<T>>(std::move(writer))) }
 	{
 	}

--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -269,7 +269,7 @@ GRAPHQLRESPONSE_EXPORT IdType Value::release<IdType>();
 
 using AwaitableValue = internal::Awaitable<Value>;
 
-class Writer
+class Writer final
 {
 private:
 	struct Concept
@@ -357,7 +357,7 @@ private:
 public:
 	template <class T>
 	Writer(std::unique_ptr<T> writer)
-		: _concept { std::static_pointer_cast<Concept>(
+		: _concept { std::static_pointer_cast<const Concept>(
 			std::make_shared<Model<T>>(std::move(writer))) }
 	{
 	}

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -1332,7 +1332,9 @@ private:
 		std::string_view field, RequestDeliverFilter&& filter) const noexcept;
 
 	const TypeMap _operations;
-	std::unique_ptr<ValidateExecutableVisitor> _validation;
+	mutable std::mutex _validationMutex {};
+	const std::unique_ptr<ValidateExecutableVisitor> _validation;
+	mutable std::mutex _subscriptionMutex {};
 	internal::sorted_map<SubscriptionKey, std::shared_ptr<SubscriptionData>> _subscriptions;
 	internal::sorted_map<SubscriptionName, internal::sorted_set<SubscriptionKey>> _listeners;
 	SubscriptionKey _nextKey = 0;

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -826,7 +826,7 @@ struct ModifiedResult
 			typename std::conditional_t<std::is_base_of_v<Object, U>, std::shared_ptr<U>, U>;
 
 		using future_type = typename std::conditional_t<std::is_base_of_v<Object, U>,
-			AwaitableObject<std::shared_ptr<Object>>, AwaitableScalar<type>>;
+			AwaitableObject<std::shared_ptr<const Object>>, AwaitableScalar<type>>;
 	};
 
 	// Convert a single value of the specified type to JSON.
@@ -849,7 +849,7 @@ struct ModifiedResult
 		co_await params.launch;
 
 		auto awaitedResult = co_await ModifiedResult<Object>::convert(
-			std::static_pointer_cast<Object>(co_await result),
+			std::static_pointer_cast<const Object>(co_await result),
 			std::move(params));
 
 		co_return std::move(awaitedResult);
@@ -1155,7 +1155,7 @@ GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<response::Value>::convert
 	AwaitableScalar<response::Value> result, ResolverParams params);
 template <>
 GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<Object>::convert(
-	AwaitableObject<std::shared_ptr<Object>> result, ResolverParams params);
+	AwaitableObject<std::shared_ptr<const Object>> result, ResolverParams params);
 
 // Export all of the scalar value validation methods
 template <>
@@ -1260,10 +1260,10 @@ struct RequestDeliverParams
 	await_async launch {};
 
 	// Optional override for the default Subscription operation object.
-	std::shared_ptr<Object> subscriptionObject {};
+	std::shared_ptr<const Object> subscriptionObject {};
 };
 
-using TypeMap = internal::string_view_map<std::shared_ptr<Object>>;
+using TypeMap = internal::string_view_map<std::shared_ptr<const Object>>;
 
 // State which is captured and kept alive until all pending futures have been resolved for an
 // operation. Note: SelectionSet is the other parameter that gets passed to the top level Object,
@@ -1328,14 +1328,14 @@ public:
 private:
 	SubscriptionKey addSubscription(RequestSubscribeParams&& params);
 	void removeSubscription(SubscriptionKey key);
-	std::vector<std::shared_ptr<SubscriptionData>> collectRegistrations(
+	std::vector<std::shared_ptr<const SubscriptionData>> collectRegistrations(
 		std::string_view field, RequestDeliverFilter&& filter) const noexcept;
 
 	const TypeMap _operations;
 	mutable std::mutex _validationMutex {};
 	const std::unique_ptr<ValidateExecutableVisitor> _validation;
 	mutable std::mutex _subscriptionMutex {};
-	internal::sorted_map<SubscriptionKey, std::shared_ptr<SubscriptionData>> _subscriptions;
+	internal::sorted_map<SubscriptionKey, std::shared_ptr<const SubscriptionData>> _subscriptions;
 	internal::sorted_map<SubscriptionName, internal::sorted_set<SubscriptionKey>> _listeners;
 	SubscriptionKey _nextKey = 0;
 };

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -177,7 +177,7 @@ private:
 };
 
 // Type-erased awaitable.
-class await_async
+class await_async final
 {
 private:
 	struct Concept

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -177,7 +177,7 @@ private:
 };
 
 // Type-erased awaitable.
-class await_async : public coro::suspend_always
+class await_async
 {
 private:
 	struct Concept
@@ -216,7 +216,7 @@ private:
 		std::shared_ptr<T> _pimpl;
 	};
 
-	const std::shared_ptr<Concept> _pimpl;
+	const std::shared_ptr<const Concept> _pimpl;
 
 public:
 	// Type-erased explicit constructor for a custom awaitable.
@@ -227,36 +227,14 @@ public:
 	}
 
 	// Default to immediate synchronous execution.
-	await_async()
-		: _pimpl { std::static_pointer_cast<Concept>(
-			std::make_shared<Model<coro::suspend_never>>(std::make_shared<coro::suspend_never>())) }
-	{
-	}
+	GRAPHQLSERVICE_EXPORT await_async();
 
 	// Implicitly convert a std::launch parameter used with std::async to an awaitable.
-	await_async(std::launch launch)
-		: _pimpl { ((launch & std::launch::async) == std::launch::async)
-				? std::static_pointer_cast<Concept>(std::make_shared<Model<await_worker_thread>>(
-					std::make_shared<await_worker_thread>()))
-				: std::static_pointer_cast<Concept>(std::make_shared<Model<coro::suspend_never>>(
-					std::make_shared<coro::suspend_never>())) }
-	{
-	}
+	GRAPHQLSERVICE_EXPORT await_async(std::launch launch);
 
-	bool await_ready() const
-	{
-		return _pimpl->await_ready();
-	}
-
-	void await_suspend(coro::coroutine_handle<> h) const
-	{
-		_pimpl->await_suspend(std::move(h));
-	}
-
-	void await_resume() const
-	{
-		_pimpl->await_resume();
-	}
+	GRAPHQLSERVICE_EXPORT bool await_ready() const;
+	GRAPHQLSERVICE_EXPORT void await_suspend(coro::coroutine_handle<> h) const;
+	GRAPHQLSERVICE_EXPORT void await_resume() const;
 };
 
 // Directive order matters, and some of them are repeatable. So rather than passing them in a

--- a/include/graphqlservice/introspection/DirectiveObject.h
+++ b/include/graphqlservice/introspection/DirectiveObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::introspection::object {
 
-class Directive
+class Directive final
 	: public service::Object
 {
 private:
@@ -73,7 +73,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;

--- a/include/graphqlservice/introspection/EnumValueObject.h
+++ b/include/graphqlservice/introspection/EnumValueObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::introspection::object {
 
-class EnumValue
+class EnumValue final
 	: public service::Object
 {
 private:
@@ -66,7 +66,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;

--- a/include/graphqlservice/introspection/FieldObject.h
+++ b/include/graphqlservice/introspection/FieldObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::introspection::object {
 
-class Field
+class Field final
 	: public service::Object
 {
 private:
@@ -80,7 +80,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;

--- a/include/graphqlservice/introspection/InputValueObject.h
+++ b/include/graphqlservice/introspection/InputValueObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::introspection::object {
 
-class InputValue
+class InputValue final
 	: public service::Object
 {
 private:
@@ -66,7 +66,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;

--- a/include/graphqlservice/introspection/SchemaObject.h
+++ b/include/graphqlservice/introspection/SchemaObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::introspection::object {
 
-class Schema
+class Schema final
 	: public service::Object
 {
 private:
@@ -80,7 +80,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;

--- a/include/graphqlservice/introspection/TypeObject.h
+++ b/include/graphqlservice/introspection/TypeObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::introspection::object {
 
-class Type
+class Type final
 	: public service::Object
 {
 private:
@@ -108,7 +108,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;

--- a/samples/learn/schema/CharacterObject.cpp
+++ b/samples/learn/schema/CharacterObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::learn {
 namespace object {
 
-Character::Character(std::unique_ptr<Concept>&& pimpl) noexcept
+Character::Character(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/learn/schema/CharacterObject.h
+++ b/samples/learn/schema/CharacterObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::learn::object {
 
-class Character
+class Character final
 	: public service::Object
 {
 private:
@@ -60,17 +60,17 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Character(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Character(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Character(std::shared_ptr<T> pimpl) noexcept
-		: Character { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Character { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Character>(), "Character is not implemented");
 	}

--- a/samples/learn/schema/DroidObject.cpp
+++ b/samples/learn/schema/DroidObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::learn {
 namespace object {
 
-Droid::Droid(std::unique_ptr<Concept>&& pimpl) noexcept
+Droid::Droid(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/learn/schema/DroidObject.h
+++ b/samples/learn/schema/DroidObject.h
@@ -94,7 +94,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::DroidHas
 
-class Droid
+class Droid final
 	: public service::Object
 {
 private:
@@ -214,7 +214,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Droid(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Droid(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Character;
@@ -231,12 +231,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Droid(std::shared_ptr<T> pimpl) noexcept
-		: Droid { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Droid { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/learn/schema/HumanObject.cpp
+++ b/samples/learn/schema/HumanObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::learn {
 namespace object {
 
-Human::Human(std::unique_ptr<Concept>&& pimpl) noexcept
+Human::Human(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/learn/schema/HumanObject.h
+++ b/samples/learn/schema/HumanObject.h
@@ -94,7 +94,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::HumanHas
 
-class Human
+class Human final
 	: public service::Object
 {
 private:
@@ -214,7 +214,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Human(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Human(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Character;
@@ -231,12 +231,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Human(std::shared_ptr<T> pimpl) noexcept
-		: Human { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Human { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/learn/schema/MutationObject.cpp
+++ b/samples/learn/schema/MutationObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::learn {
 namespace object {
 
-Mutation::Mutation(std::unique_ptr<Concept>&& pimpl) noexcept
+Mutation::Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/learn/schema/MutationObject.h
+++ b/samples/learn/schema/MutationObject.h
@@ -39,7 +39,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutationHas
 
-class Mutation
+class Mutation final
 	: public service::Object
 {
 private:
@@ -99,7 +99,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Mutation(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -107,12 +107,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Mutation(std::shared_ptr<T> pimpl) noexcept
-		: Mutation { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Mutation { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/learn/schema/QueryObject.cpp
+++ b/samples/learn/schema/QueryObject.cpp
@@ -24,7 +24,7 @@ using namespace std::literals;
 namespace graphql::learn {
 namespace object {
 
-Query::Query(std::unique_ptr<Concept>&& pimpl) noexcept
+Query::Query(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _schema { GetSchema() }
 	, _pimpl { std::move(pimpl) }

--- a/samples/learn/schema/QueryObject.h
+++ b/samples/learn/schema/QueryObject.h
@@ -63,7 +63,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::QueryHas
 
-class Query
+class Query final
 	: public service::Object
 {
 private:
@@ -157,7 +157,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Query(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Query(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -165,12 +165,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Query(std::shared_ptr<T> pimpl) noexcept
-		: Query { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Query { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/learn/schema/ReviewObject.cpp
+++ b/samples/learn/schema/ReviewObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::learn {
 namespace object {
 
-Review::Review(std::unique_ptr<Concept>&& pimpl) noexcept
+Review::Review(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/learn/schema/ReviewObject.h
+++ b/samples/learn/schema/ReviewObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::ReviewHas
 
-class Review
+class Review final
 	: public service::Object
 {
 private:
@@ -126,7 +126,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Review(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Review(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -134,12 +134,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Review(std::shared_ptr<T> pimpl) noexcept
-		: Review { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Review { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/learn/schema/StarWarsSchema.h
+++ b/samples/learn/schema/StarWarsSchema.h
@@ -46,7 +46,7 @@ class Mutation;
 
 } // namespace object
 
-class Operations
+class Operations final
 	: public service::Request
 {
 public:

--- a/samples/today/nointrospection/AppointmentConnectionObject.cpp
+++ b/samples/today/nointrospection/AppointmentConnectionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-AppointmentConnection::AppointmentConnection(std::unique_ptr<Concept>&& pimpl) noexcept
+AppointmentConnection::AppointmentConnection(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/AppointmentConnectionObject.h
+++ b/samples/today/nointrospection/AppointmentConnectionObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentConnectionHas
 
-class AppointmentConnection
+class AppointmentConnection final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	AppointmentConnection(std::unique_ptr<Concept>&& pimpl) noexcept;
+	AppointmentConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	AppointmentConnection(std::shared_ptr<T> pimpl) noexcept
-		: AppointmentConnection { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: AppointmentConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/AppointmentEdgeObject.cpp
+++ b/samples/today/nointrospection/AppointmentEdgeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-AppointmentEdge::AppointmentEdge(std::unique_ptr<Concept>&& pimpl) noexcept
+AppointmentEdge::AppointmentEdge(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/AppointmentEdgeObject.h
+++ b/samples/today/nointrospection/AppointmentEdgeObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentEdgeHas
 
-class AppointmentEdge
+class AppointmentEdge final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	AppointmentEdge(std::unique_ptr<Concept>&& pimpl) noexcept;
+	AppointmentEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	AppointmentEdge(std::shared_ptr<T> pimpl) noexcept
-		: AppointmentEdge { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: AppointmentEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/AppointmentObject.cpp
+++ b/samples/today/nointrospection/AppointmentObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Appointment::Appointment(std::unique_ptr<Concept>&& pimpl) noexcept
+Appointment::Appointment(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/AppointmentObject.h
+++ b/samples/today/nointrospection/AppointmentObject.h
@@ -94,7 +94,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentHas
 
-class Appointment
+class Appointment final
 	: public service::Object
 {
 private:
@@ -229,7 +229,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Appointment(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Appointment(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Node;
@@ -249,12 +249,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Appointment(std::shared_ptr<T> pimpl) noexcept
-		: Appointment { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Appointment { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/CompleteTaskPayloadObject.cpp
+++ b/samples/today/nointrospection/CompleteTaskPayloadObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-CompleteTaskPayload::CompleteTaskPayload(std::unique_ptr<Concept>&& pimpl) noexcept
+CompleteTaskPayload::CompleteTaskPayload(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/CompleteTaskPayloadObject.h
+++ b/samples/today/nointrospection/CompleteTaskPayloadObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::CompleteTaskPayloadHas
 
-class CompleteTaskPayload
+class CompleteTaskPayload final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	CompleteTaskPayload(std::unique_ptr<Concept>&& pimpl) noexcept;
+	CompleteTaskPayload(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	CompleteTaskPayload(std::shared_ptr<T> pimpl) noexcept
-		: CompleteTaskPayload { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: CompleteTaskPayload { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/ExpensiveObject.cpp
+++ b/samples/today/nointrospection/ExpensiveObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Expensive::Expensive(std::unique_ptr<Concept>&& pimpl) noexcept
+Expensive::Expensive(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/ExpensiveObject.h
+++ b/samples/today/nointrospection/ExpensiveObject.h
@@ -39,7 +39,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::ExpensiveHas
 
-class Expensive
+class Expensive final
 	: public service::Object
 {
 private:
@@ -102,7 +102,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Expensive(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Expensive(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -110,12 +110,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Expensive(std::shared_ptr<T> pimpl) noexcept
-		: Expensive { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Expensive { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/FolderConnectionObject.cpp
+++ b/samples/today/nointrospection/FolderConnectionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-FolderConnection::FolderConnection(std::unique_ptr<Concept>&& pimpl) noexcept
+FolderConnection::FolderConnection(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/FolderConnectionObject.h
+++ b/samples/today/nointrospection/FolderConnectionObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderConnectionHas
 
-class FolderConnection
+class FolderConnection final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	FolderConnection(std::unique_ptr<Concept>&& pimpl) noexcept;
+	FolderConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	FolderConnection(std::shared_ptr<T> pimpl) noexcept
-		: FolderConnection { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: FolderConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/FolderEdgeObject.cpp
+++ b/samples/today/nointrospection/FolderEdgeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-FolderEdge::FolderEdge(std::unique_ptr<Concept>&& pimpl) noexcept
+FolderEdge::FolderEdge(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/FolderEdgeObject.h
+++ b/samples/today/nointrospection/FolderEdgeObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderEdgeHas
 
-class FolderEdge
+class FolderEdge final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	FolderEdge(std::unique_ptr<Concept>&& pimpl) noexcept;
+	FolderEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	FolderEdge(std::shared_ptr<T> pimpl) noexcept
-		: FolderEdge { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: FolderEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/FolderObject.cpp
+++ b/samples/today/nointrospection/FolderObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Folder::Folder(std::unique_ptr<Concept>&& pimpl) noexcept
+Folder::Folder(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/FolderObject.h
+++ b/samples/today/nointrospection/FolderObject.h
@@ -70,7 +70,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderHas
 
-class Folder
+class Folder final
 	: public service::Object
 {
 private:
@@ -169,7 +169,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Folder(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Folder(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Node;
@@ -189,12 +189,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Folder(std::shared_ptr<T> pimpl) noexcept
-		: Folder { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Folder { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/MutationObject.cpp
+++ b/samples/today/nointrospection/MutationObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Mutation::Mutation(std::unique_ptr<Concept>&& pimpl) noexcept
+Mutation::Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/MutationObject.h
+++ b/samples/today/nointrospection/MutationObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutationHas
 
-class Mutation
+class Mutation final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Mutation(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Mutation(std::shared_ptr<T> pimpl) noexcept
-		: Mutation { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Mutation { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/NestedTypeObject.cpp
+++ b/samples/today/nointrospection/NestedTypeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-NestedType::NestedType(std::unique_ptr<Concept>&& pimpl) noexcept
+NestedType::NestedType(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/NestedTypeObject.h
+++ b/samples/today/nointrospection/NestedTypeObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::NestedTypeHas
 
-class NestedType
+class NestedType final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	NestedType(std::unique_ptr<Concept>&& pimpl) noexcept;
+	NestedType(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	NestedType(std::shared_ptr<T> pimpl) noexcept
-		: NestedType { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: NestedType { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/NodeObject.cpp
+++ b/samples/today/nointrospection/NodeObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Node::Node(std::unique_ptr<Concept>&& pimpl) noexcept
+Node::Node(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/NodeObject.h
+++ b/samples/today/nointrospection/NodeObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::today::object {
 
-class Node
+class Node final
 	: public service::Object
 {
 private:
@@ -60,17 +60,17 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Node(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Node(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Node(std::shared_ptr<T> pimpl) noexcept
-		: Node { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Node { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Node>(), "Node is not implemented");
 	}

--- a/samples/today/nointrospection/PageInfoObject.cpp
+++ b/samples/today/nointrospection/PageInfoObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-PageInfo::PageInfo(std::unique_ptr<Concept>&& pimpl) noexcept
+PageInfo::PageInfo(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/PageInfoObject.h
+++ b/samples/today/nointrospection/PageInfoObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::PageInfoHas
 
-class PageInfo
+class PageInfo final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	PageInfo(std::unique_ptr<Concept>&& pimpl) noexcept;
+	PageInfo(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	PageInfo(std::shared_ptr<T> pimpl) noexcept
-		: PageInfo { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: PageInfo { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/QueryObject.cpp
+++ b/samples/today/nointrospection/QueryObject.cpp
@@ -30,7 +30,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Query::Query(std::unique_ptr<Concept>&& pimpl) noexcept
+Query::Query(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/QueryObject.h
+++ b/samples/today/nointrospection/QueryObject.h
@@ -171,7 +171,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::QueryHas
 
-class Query
+class Query final
 	: public service::Object
 {
 private:
@@ -432,7 +432,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Query(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Query(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -440,12 +440,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Query(std::shared_ptr<T> pimpl) noexcept
-		: Query { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Query { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/SubscriptionObject.cpp
+++ b/samples/today/nointrospection/SubscriptionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Subscription::Subscription(std::unique_ptr<Concept>&& pimpl) noexcept
+Subscription::Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/SubscriptionObject.h
+++ b/samples/today/nointrospection/SubscriptionObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::SubscriptionHas
 
-class Subscription
+class Subscription final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Subscription(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Subscription(std::shared_ptr<T> pimpl) noexcept
-		: Subscription { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Subscription { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/TaskConnectionObject.cpp
+++ b/samples/today/nointrospection/TaskConnectionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-TaskConnection::TaskConnection(std::unique_ptr<Concept>&& pimpl) noexcept
+TaskConnection::TaskConnection(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/TaskConnectionObject.h
+++ b/samples/today/nointrospection/TaskConnectionObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskConnectionHas
 
-class TaskConnection
+class TaskConnection final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	TaskConnection(std::unique_ptr<Concept>&& pimpl) noexcept;
+	TaskConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	TaskConnection(std::shared_ptr<T> pimpl) noexcept
-		: TaskConnection { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: TaskConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/TaskEdgeObject.cpp
+++ b/samples/today/nointrospection/TaskEdgeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-TaskEdge::TaskEdge(std::unique_ptr<Concept>&& pimpl) noexcept
+TaskEdge::TaskEdge(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/TaskEdgeObject.h
+++ b/samples/today/nointrospection/TaskEdgeObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskEdgeHas
 
-class TaskEdge
+class TaskEdge final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	TaskEdge(std::unique_ptr<Concept>&& pimpl) noexcept;
+	TaskEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	TaskEdge(std::shared_ptr<T> pimpl) noexcept
-		: TaskEdge { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: TaskEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/TaskObject.cpp
+++ b/samples/today/nointrospection/TaskObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Task::Task(std::unique_ptr<Concept>&& pimpl) noexcept
+Task::Task(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/TaskObject.h
+++ b/samples/today/nointrospection/TaskObject.h
@@ -70,7 +70,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskHas
 
-class Task
+class Task final
 	: public service::Object
 {
 private:
@@ -169,7 +169,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Task(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Task(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Node;
@@ -189,12 +189,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Task(std::shared_ptr<T> pimpl) noexcept
-		: Task { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Task { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/nointrospection/TodaySchema.h
+++ b/samples/today/nointrospection/TodaySchema.h
@@ -85,7 +85,7 @@ class Expensive;
 
 } // namespace object
 
-class Operations
+class Operations final
 	: public service::Request
 {
 public:

--- a/samples/today/nointrospection/UnionTypeObject.cpp
+++ b/samples/today/nointrospection/UnionTypeObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-UnionType::UnionType(std::unique_ptr<Concept>&& pimpl) noexcept
+UnionType::UnionType(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/UnionTypeObject.h
+++ b/samples/today/nointrospection/UnionTypeObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::today::object {
 
-class UnionType
+class UnionType final
 	: public service::Object
 {
 private:
@@ -60,17 +60,17 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	UnionType(std::unique_ptr<Concept>&& pimpl) noexcept;
+	UnionType(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	UnionType(std::shared_ptr<T> pimpl) noexcept
-		: UnionType { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: UnionType { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<UnionType>(), "UnionType is not implemented");
 	}

--- a/samples/today/schema/AppointmentConnectionObject.cpp
+++ b/samples/today/schema/AppointmentConnectionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-AppointmentConnection::AppointmentConnection(std::unique_ptr<Concept>&& pimpl) noexcept
+AppointmentConnection::AppointmentConnection(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/AppointmentConnectionObject.h
+++ b/samples/today/schema/AppointmentConnectionObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentConnectionHas
 
-class AppointmentConnection
+class AppointmentConnection final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	AppointmentConnection(std::unique_ptr<Concept>&& pimpl) noexcept;
+	AppointmentConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	AppointmentConnection(std::shared_ptr<T> pimpl) noexcept
-		: AppointmentConnection { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: AppointmentConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/AppointmentEdgeObject.cpp
+++ b/samples/today/schema/AppointmentEdgeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-AppointmentEdge::AppointmentEdge(std::unique_ptr<Concept>&& pimpl) noexcept
+AppointmentEdge::AppointmentEdge(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/AppointmentEdgeObject.h
+++ b/samples/today/schema/AppointmentEdgeObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentEdgeHas
 
-class AppointmentEdge
+class AppointmentEdge final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	AppointmentEdge(std::unique_ptr<Concept>&& pimpl) noexcept;
+	AppointmentEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	AppointmentEdge(std::shared_ptr<T> pimpl) noexcept
-		: AppointmentEdge { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: AppointmentEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/AppointmentObject.cpp
+++ b/samples/today/schema/AppointmentObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Appointment::Appointment(std::unique_ptr<Concept>&& pimpl) noexcept
+Appointment::Appointment(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/AppointmentObject.h
+++ b/samples/today/schema/AppointmentObject.h
@@ -94,7 +94,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentHas
 
-class Appointment
+class Appointment final
 	: public service::Object
 {
 private:
@@ -229,7 +229,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Appointment(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Appointment(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Node;
@@ -249,12 +249,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Appointment(std::shared_ptr<T> pimpl) noexcept
-		: Appointment { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Appointment { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/CompleteTaskPayloadObject.cpp
+++ b/samples/today/schema/CompleteTaskPayloadObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-CompleteTaskPayload::CompleteTaskPayload(std::unique_ptr<Concept>&& pimpl) noexcept
+CompleteTaskPayload::CompleteTaskPayload(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/CompleteTaskPayloadObject.h
+++ b/samples/today/schema/CompleteTaskPayloadObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::CompleteTaskPayloadHas
 
-class CompleteTaskPayload
+class CompleteTaskPayload final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	CompleteTaskPayload(std::unique_ptr<Concept>&& pimpl) noexcept;
+	CompleteTaskPayload(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	CompleteTaskPayload(std::shared_ptr<T> pimpl) noexcept
-		: CompleteTaskPayload { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: CompleteTaskPayload { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/ExpensiveObject.cpp
+++ b/samples/today/schema/ExpensiveObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Expensive::Expensive(std::unique_ptr<Concept>&& pimpl) noexcept
+Expensive::Expensive(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/ExpensiveObject.h
+++ b/samples/today/schema/ExpensiveObject.h
@@ -39,7 +39,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::ExpensiveHas
 
-class Expensive
+class Expensive final
 	: public service::Object
 {
 private:
@@ -102,7 +102,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Expensive(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Expensive(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -110,12 +110,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Expensive(std::shared_ptr<T> pimpl) noexcept
-		: Expensive { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Expensive { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/FolderConnectionObject.cpp
+++ b/samples/today/schema/FolderConnectionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-FolderConnection::FolderConnection(std::unique_ptr<Concept>&& pimpl) noexcept
+FolderConnection::FolderConnection(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/FolderConnectionObject.h
+++ b/samples/today/schema/FolderConnectionObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderConnectionHas
 
-class FolderConnection
+class FolderConnection final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	FolderConnection(std::unique_ptr<Concept>&& pimpl) noexcept;
+	FolderConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	FolderConnection(std::shared_ptr<T> pimpl) noexcept
-		: FolderConnection { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: FolderConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/FolderEdgeObject.cpp
+++ b/samples/today/schema/FolderEdgeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-FolderEdge::FolderEdge(std::unique_ptr<Concept>&& pimpl) noexcept
+FolderEdge::FolderEdge(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/FolderEdgeObject.h
+++ b/samples/today/schema/FolderEdgeObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderEdgeHas
 
-class FolderEdge
+class FolderEdge final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	FolderEdge(std::unique_ptr<Concept>&& pimpl) noexcept;
+	FolderEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	FolderEdge(std::shared_ptr<T> pimpl) noexcept
-		: FolderEdge { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: FolderEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/FolderObject.cpp
+++ b/samples/today/schema/FolderObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Folder::Folder(std::unique_ptr<Concept>&& pimpl) noexcept
+Folder::Folder(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/FolderObject.h
+++ b/samples/today/schema/FolderObject.h
@@ -70,7 +70,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderHas
 
-class Folder
+class Folder final
 	: public service::Object
 {
 private:
@@ -169,7 +169,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Folder(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Folder(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Node;
@@ -189,12 +189,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Folder(std::shared_ptr<T> pimpl) noexcept
-		: Folder { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Folder { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/MutationObject.cpp
+++ b/samples/today/schema/MutationObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Mutation::Mutation(std::unique_ptr<Concept>&& pimpl) noexcept
+Mutation::Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/MutationObject.h
+++ b/samples/today/schema/MutationObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutationHas
 
-class Mutation
+class Mutation final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Mutation(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Mutation(std::shared_ptr<T> pimpl) noexcept
-		: Mutation { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Mutation { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/NestedTypeObject.cpp
+++ b/samples/today/schema/NestedTypeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-NestedType::NestedType(std::unique_ptr<Concept>&& pimpl) noexcept
+NestedType::NestedType(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/NestedTypeObject.h
+++ b/samples/today/schema/NestedTypeObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::NestedTypeHas
 
-class NestedType
+class NestedType final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	NestedType(std::unique_ptr<Concept>&& pimpl) noexcept;
+	NestedType(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	NestedType(std::shared_ptr<T> pimpl) noexcept
-		: NestedType { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: NestedType { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/NodeObject.cpp
+++ b/samples/today/schema/NodeObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Node::Node(std::unique_ptr<Concept>&& pimpl) noexcept
+Node::Node(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/NodeObject.h
+++ b/samples/today/schema/NodeObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::today::object {
 
-class Node
+class Node final
 	: public service::Object
 {
 private:
@@ -60,17 +60,17 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Node(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Node(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Node(std::shared_ptr<T> pimpl) noexcept
-		: Node { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Node { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Node>(), "Node is not implemented");
 	}

--- a/samples/today/schema/PageInfoObject.cpp
+++ b/samples/today/schema/PageInfoObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-PageInfo::PageInfo(std::unique_ptr<Concept>&& pimpl) noexcept
+PageInfo::PageInfo(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/PageInfoObject.h
+++ b/samples/today/schema/PageInfoObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::PageInfoHas
 
-class PageInfo
+class PageInfo final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	PageInfo(std::unique_ptr<Concept>&& pimpl) noexcept;
+	PageInfo(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	PageInfo(std::shared_ptr<T> pimpl) noexcept
-		: PageInfo { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: PageInfo { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/QueryObject.cpp
+++ b/samples/today/schema/QueryObject.cpp
@@ -31,7 +31,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Query::Query(std::unique_ptr<Concept>&& pimpl) noexcept
+Query::Query(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _schema { GetSchema() }
 	, _pimpl { std::move(pimpl) }

--- a/samples/today/schema/QueryObject.h
+++ b/samples/today/schema/QueryObject.h
@@ -171,7 +171,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::QueryHas
 
-class Query
+class Query final
 	: public service::Object
 {
 private:
@@ -436,7 +436,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Query(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Query(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -444,12 +444,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Query(std::shared_ptr<T> pimpl) noexcept
-		: Query { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Query { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/SubscriptionObject.cpp
+++ b/samples/today/schema/SubscriptionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Subscription::Subscription(std::unique_ptr<Concept>&& pimpl) noexcept
+Subscription::Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/SubscriptionObject.h
+++ b/samples/today/schema/SubscriptionObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::SubscriptionHas
 
-class Subscription
+class Subscription final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Subscription(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Subscription(std::shared_ptr<T> pimpl) noexcept
-		: Subscription { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Subscription { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/TaskConnectionObject.cpp
+++ b/samples/today/schema/TaskConnectionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-TaskConnection::TaskConnection(std::unique_ptr<Concept>&& pimpl) noexcept
+TaskConnection::TaskConnection(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/TaskConnectionObject.h
+++ b/samples/today/schema/TaskConnectionObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskConnectionHas
 
-class TaskConnection
+class TaskConnection final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	TaskConnection(std::unique_ptr<Concept>&& pimpl) noexcept;
+	TaskConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	TaskConnection(std::shared_ptr<T> pimpl) noexcept
-		: TaskConnection { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: TaskConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/TaskEdgeObject.cpp
+++ b/samples/today/schema/TaskEdgeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-TaskEdge::TaskEdge(std::unique_ptr<Concept>&& pimpl) noexcept
+TaskEdge::TaskEdge(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/TaskEdgeObject.h
+++ b/samples/today/schema/TaskEdgeObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskEdgeHas
 
-class TaskEdge
+class TaskEdge final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	TaskEdge(std::unique_ptr<Concept>&& pimpl) noexcept;
+	TaskEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	TaskEdge(std::shared_ptr<T> pimpl) noexcept
-		: TaskEdge { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: TaskEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/TaskObject.cpp
+++ b/samples/today/schema/TaskObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Task::Task(std::unique_ptr<Concept>&& pimpl) noexcept
+Task::Task(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/TaskObject.h
+++ b/samples/today/schema/TaskObject.h
@@ -70,7 +70,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskHas
 
-class Task
+class Task final
 	: public service::Object
 {
 private:
@@ -169,7 +169,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Task(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Task(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Node;
@@ -189,12 +189,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Task(std::shared_ptr<T> pimpl) noexcept
-		: Task { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Task { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/today/schema/TodaySchema.h
+++ b/samples/today/schema/TodaySchema.h
@@ -85,7 +85,7 @@ class Expensive;
 
 } // namespace object
 
-class Operations
+class Operations final
 	: public service::Request
 {
 public:

--- a/samples/today/schema/UnionTypeObject.cpp
+++ b/samples/today/schema/UnionTypeObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-UnionType::UnionType(std::unique_ptr<Concept>&& pimpl) noexcept
+UnionType::UnionType(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/UnionTypeObject.h
+++ b/samples/today/schema/UnionTypeObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::today::object {
 
-class UnionType
+class UnionType final
 	: public service::Object
 {
 private:
@@ -60,17 +60,17 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	UnionType(std::unique_ptr<Concept>&& pimpl) noexcept;
+	UnionType(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	UnionType(std::shared_ptr<T> pimpl) noexcept
-		: UnionType { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: UnionType { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<UnionType>(), "UnionType is not implemented");
 	}

--- a/samples/validation/schema/AlienObject.cpp
+++ b/samples/validation/schema/AlienObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Alien::Alien(std::unique_ptr<Concept>&& pimpl) noexcept
+Alien::Alien(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/AlienObject.h
+++ b/samples/validation/schema/AlienObject.h
@@ -58,7 +58,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AlienHas
 
-class Alien
+class Alien final
 	: public service::Object
 {
 private:
@@ -139,7 +139,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Alien(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Alien(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Sentient;
@@ -159,12 +159,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Alien(std::shared_ptr<T> pimpl) noexcept
-		: Alien { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Alien { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/validation/schema/ArgumentsObject.cpp
+++ b/samples/validation/schema/ArgumentsObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Arguments::Arguments(std::unique_ptr<Concept>&& pimpl) noexcept
+Arguments::Arguments(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/ArgumentsObject.h
+++ b/samples/validation/schema/ArgumentsObject.h
@@ -123,7 +123,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::ArgumentsHas
 
-class Arguments
+class Arguments final
 	: public service::Object
 {
 private:
@@ -312,7 +312,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Arguments(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Arguments(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -320,12 +320,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Arguments(std::shared_ptr<T> pimpl) noexcept
-		: Arguments { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Arguments { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/validation/schema/CatObject.cpp
+++ b/samples/validation/schema/CatObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Cat::Cat(std::unique_ptr<Concept>&& pimpl) noexcept
+Cat::Cat(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/CatObject.h
+++ b/samples/validation/schema/CatObject.h
@@ -82,7 +82,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::CatHas
 
-class Cat
+class Cat final
 	: public service::Object
 {
 private:
@@ -199,7 +199,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Cat(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Cat(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Pet;
@@ -219,12 +219,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Cat(std::shared_ptr<T> pimpl) noexcept
-		: Cat { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Cat { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/validation/schema/CatOrDogObject.cpp
+++ b/samples/validation/schema/CatOrDogObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-CatOrDog::CatOrDog(std::unique_ptr<Concept>&& pimpl) noexcept
+CatOrDog::CatOrDog(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/CatOrDogObject.h
+++ b/samples/validation/schema/CatOrDogObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::validation::object {
 
-class CatOrDog
+class CatOrDog final
 	: public service::Object
 {
 private:
@@ -60,17 +60,17 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	CatOrDog(std::unique_ptr<Concept>&& pimpl) noexcept;
+	CatOrDog(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	CatOrDog(std::shared_ptr<T> pimpl) noexcept
-		: CatOrDog { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: CatOrDog { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<CatOrDog>(), "CatOrDog is not implemented");
 	}

--- a/samples/validation/schema/DogObject.cpp
+++ b/samples/validation/schema/DogObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Dog::Dog(std::unique_ptr<Concept>&& pimpl) noexcept
+Dog::Dog(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/DogObject.h
+++ b/samples/validation/schema/DogObject.h
@@ -106,7 +106,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::DogHas
 
-class Dog
+class Dog final
 	: public service::Object
 {
 private:
@@ -259,7 +259,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Dog(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Dog(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Pet;
@@ -280,12 +280,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Dog(std::shared_ptr<T> pimpl) noexcept
-		: Dog { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Dog { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/validation/schema/DogOrHumanObject.cpp
+++ b/samples/validation/schema/DogOrHumanObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-DogOrHuman::DogOrHuman(std::unique_ptr<Concept>&& pimpl) noexcept
+DogOrHuman::DogOrHuman(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/DogOrHumanObject.h
+++ b/samples/validation/schema/DogOrHumanObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::validation::object {
 
-class DogOrHuman
+class DogOrHuman final
 	: public service::Object
 {
 private:
@@ -60,17 +60,17 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	DogOrHuman(std::unique_ptr<Concept>&& pimpl) noexcept;
+	DogOrHuman(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	DogOrHuman(std::shared_ptr<T> pimpl) noexcept
-		: DogOrHuman { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: DogOrHuman { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<DogOrHuman>(), "DogOrHuman is not implemented");
 	}

--- a/samples/validation/schema/HumanObject.cpp
+++ b/samples/validation/schema/HumanObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Human::Human(std::unique_ptr<Concept>&& pimpl) noexcept
+Human::Human(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/HumanObject.h
+++ b/samples/validation/schema/HumanObject.h
@@ -58,7 +58,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::HumanHas
 
-class Human
+class Human final
 	: public service::Object
 {
 private:
@@ -139,7 +139,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Human(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Human(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Sentient;
@@ -160,12 +160,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Human(std::shared_ptr<T> pimpl) noexcept
-		: Human { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Human { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/validation/schema/HumanOrAlienObject.cpp
+++ b/samples/validation/schema/HumanOrAlienObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-HumanOrAlien::HumanOrAlien(std::unique_ptr<Concept>&& pimpl) noexcept
+HumanOrAlien::HumanOrAlien(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/HumanOrAlienObject.h
+++ b/samples/validation/schema/HumanOrAlienObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::validation::object {
 
-class HumanOrAlien
+class HumanOrAlien final
 	: public service::Object
 {
 private:
@@ -60,17 +60,17 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	HumanOrAlien(std::unique_ptr<Concept>&& pimpl) noexcept;
+	HumanOrAlien(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	HumanOrAlien(std::shared_ptr<T> pimpl) noexcept
-		: HumanOrAlien { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: HumanOrAlien { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<HumanOrAlien>(), "HumanOrAlien is not implemented");
 	}

--- a/samples/validation/schema/MessageObject.cpp
+++ b/samples/validation/schema/MessageObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Message::Message(std::unique_ptr<Concept>&& pimpl) noexcept
+Message::Message(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/MessageObject.h
+++ b/samples/validation/schema/MessageObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MessageHas
 
-class Message
+class Message final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Message(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Message(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Message(std::shared_ptr<T> pimpl) noexcept
-		: Message { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Message { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/validation/schema/MutateDogResultObject.cpp
+++ b/samples/validation/schema/MutateDogResultObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-MutateDogResult::MutateDogResult(std::unique_ptr<Concept>&& pimpl) noexcept
+MutateDogResult::MutateDogResult(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/MutateDogResultObject.h
+++ b/samples/validation/schema/MutateDogResultObject.h
@@ -39,7 +39,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutateDogResultHas
 
-class MutateDogResult
+class MutateDogResult final
 	: public service::Object
 {
 private:
@@ -102,7 +102,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	MutateDogResult(std::unique_ptr<Concept>&& pimpl) noexcept;
+	MutateDogResult(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -110,12 +110,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	MutateDogResult(std::shared_ptr<T> pimpl) noexcept
-		: MutateDogResult { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: MutateDogResult { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/validation/schema/MutationObject.cpp
+++ b/samples/validation/schema/MutationObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Mutation::Mutation(std::unique_ptr<Concept>&& pimpl) noexcept
+Mutation::Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/MutationObject.h
+++ b/samples/validation/schema/MutationObject.h
@@ -39,7 +39,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutationHas
 
-class Mutation
+class Mutation final
 	: public service::Object
 {
 private:
@@ -102,7 +102,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Mutation(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -110,12 +110,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Mutation(std::shared_ptr<T> pimpl) noexcept
-		: Mutation { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Mutation { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/validation/schema/NodeObject.cpp
+++ b/samples/validation/schema/NodeObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Node::Node(std::unique_ptr<Concept>&& pimpl) noexcept
+Node::Node(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/NodeObject.h
+++ b/samples/validation/schema/NodeObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::validation::object {
 
-class Node
+class Node final
 	: public service::Object
 {
 private:
@@ -60,17 +60,17 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Node(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Node(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Node(std::shared_ptr<T> pimpl) noexcept
-		: Node { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Node { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Node>(), "Node is not implemented");
 	}

--- a/samples/validation/schema/PetObject.cpp
+++ b/samples/validation/schema/PetObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Pet::Pet(std::unique_ptr<Concept>&& pimpl) noexcept
+Pet::Pet(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/PetObject.h
+++ b/samples/validation/schema/PetObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::validation::object {
 
-class Pet
+class Pet final
 	: public service::Object
 {
 private:
@@ -60,17 +60,17 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Pet(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Pet(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Pet(std::shared_ptr<T> pimpl) noexcept
-		: Pet { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Pet { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Pet>(), "Pet is not implemented");
 	}

--- a/samples/validation/schema/QueryObject.cpp
+++ b/samples/validation/schema/QueryObject.cpp
@@ -26,7 +26,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Query::Query(std::unique_ptr<Concept>&& pimpl) noexcept
+Query::Query(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/QueryObject.h
+++ b/samples/validation/schema/QueryObject.h
@@ -123,7 +123,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::QueryHas
 
-class Query
+class Query final
 	: public service::Object
 {
 private:
@@ -312,7 +312,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Query(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Query(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -320,12 +320,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Query(std::shared_ptr<T> pimpl) noexcept
-		: Query { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Query { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/validation/schema/ResourceObject.cpp
+++ b/samples/validation/schema/ResourceObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Resource::Resource(std::unique_ptr<Concept>&& pimpl) noexcept
+Resource::Resource(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/ResourceObject.h
+++ b/samples/validation/schema/ResourceObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::validation::object {
 
-class Resource
+class Resource final
 	: public service::Object
 {
 private:
@@ -60,17 +60,17 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Resource(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Resource(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Resource(std::shared_ptr<T> pimpl) noexcept
-		: Resource { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Resource { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Resource>(), "Resource is not implemented");
 	}

--- a/samples/validation/schema/SentientObject.cpp
+++ b/samples/validation/schema/SentientObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Sentient::Sentient(std::unique_ptr<Concept>&& pimpl) noexcept
+Sentient::Sentient(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/SentientObject.h
+++ b/samples/validation/schema/SentientObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::validation::object {
 
-class Sentient
+class Sentient final
 	: public service::Object
 {
 private:
@@ -60,17 +60,17 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Sentient(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Sentient(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Sentient(std::shared_ptr<T> pimpl) noexcept
-		: Sentient { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Sentient { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Sentient>(), "Sentient is not implemented");
 	}

--- a/samples/validation/schema/SubscriptionObject.cpp
+++ b/samples/validation/schema/SubscriptionObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Subscription::Subscription(std::unique_ptr<Concept>&& pimpl) noexcept
+Subscription::Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/SubscriptionObject.h
+++ b/samples/validation/schema/SubscriptionObject.h
@@ -51,7 +51,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::SubscriptionHas
 
-class Subscription
+class Subscription final
 	: public service::Object
 {
 private:
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Subscription(std::unique_ptr<Concept>&& pimpl) noexcept;
+	Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -140,12 +140,12 @@ private:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
 	Subscription(std::shared_ptr<T> pimpl) noexcept
-		: Subscription { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		: Subscription { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };

--- a/samples/validation/schema/ValidationSchema.h
+++ b/samples/validation/schema/ValidationSchema.h
@@ -63,7 +63,7 @@ class Arguments;
 
 } // namespace object
 
-class Operations
+class Operations final
 	: public service::Request
 {
 public:

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -232,7 +232,7 @@ void await_worker_queue::resumePending()
 
 // Default to immediate synchronous execution.
 await_async::await_async()
-	: _pimpl { std::static_pointer_cast<Concept>(
+	: _pimpl { std::static_pointer_cast<const Concept>(
 		std::make_shared<Model<coro::suspend_never>>(std::make_shared<coro::suspend_never>())) }
 {
 }
@@ -240,9 +240,9 @@ await_async::await_async()
 // Implicitly convert a std::launch parameter used with std::async to an awaitable.
 await_async::await_async(std::launch launch)
 	: _pimpl { ((launch & std::launch::async) == std::launch::async)
-			? std::static_pointer_cast<Concept>(std::make_shared<Model<await_worker_thread>>(
+			? std::static_pointer_cast<const Concept>(std::make_shared<Model<await_worker_thread>>(
 				std::make_shared<await_worker_thread>()))
-			: std::static_pointer_cast<Concept>(std::make_shared<Model<coro::suspend_never>>(
+			: std::static_pointer_cast<const Concept>(std::make_shared<Model<coro::suspend_never>>(
 				std::make_shared<coro::suspend_never>())) }
 {
 }

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -272,7 +272,7 @@ static_assert(graphql::internal::MinorVersion == )cpp"
 	{
 		bool firstOperation = true;
 
-		headerFile << R"cpp(class Operations
+		headerFile << R"cpp(class Operations final
 	: public service::Request
 {
 public:
@@ -480,7 +480,7 @@ GRAPHQLSERVICE_EXPORT )cpp" << _loader.getSchemaNamespace()
 void Generator::outputInterfaceDeclaration(std::ostream& headerFile, std::string_view cppType) const
 {
 	headerFile
-		<< R"cpp(class )cpp" << cppType << R"cpp(
+		<< R"cpp(class )cpp" << cppType << R"cpp( final
 	: public service::Object
 {
 private:
@@ -529,12 +529,12 @@ private:
 	};
 
 	)cpp"
-		<< cppType << R"cpp((std::unique_ptr<Concept>&& pimpl) noexcept;
+		<< cppType << R"cpp((std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
@@ -542,7 +542,7 @@ public:
 		<< cppType << R"cpp((std::shared_ptr<T> pimpl) noexcept
 		: )cpp"
 		<< cppType
-		<< R"cpp( { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+		<< R"cpp( { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<)cpp"
 		<< cppType << R"cpp(>(), ")cpp" << cppType << R"cpp( is not implemented");
@@ -680,7 +680,7 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 void Generator::outputObjectDeclaration(
 	std::ostream& headerFile, const ObjectType& objectType, bool isQueryType) const
 {
-	headerFile << R"cpp(class )cpp" << objectType.cppType << R"cpp(
+	headerFile << R"cpp(class )cpp" << objectType.cppType << R"cpp( final
 	: public service::Object
 {
 private:
@@ -895,7 +895,7 @@ private:
 
 	if (_loader.isIntrospection())
 	{
-		headerFile << R"cpp(	const std::unique_ptr<Concept> _pimpl;
+		headerFile << R"cpp(	const std::unique_ptr<const Concept> _pimpl;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;
@@ -913,7 +913,7 @@ public:
 	else
 	{
 		headerFile << R"cpp(	)cpp" << objectType.cppType
-				   << R"cpp((std::unique_ptr<Concept>&& pimpl) noexcept;
+				   << R"cpp((std::unique_ptr<const Concept>&& pimpl) noexcept;
 
 )cpp";
 
@@ -939,7 +939,8 @@ public:
 
 			for (auto unionName : objectType.unions)
 			{
-				headerFile << R"cpp(	friend )cpp" << _loader.getSafeCppName(unionName) << R"cpp(;
+				headerFile << R"cpp(	friend )cpp" << _loader.getSafeCppName(unionName)
+						   << R"cpp(;
 )cpp";
 			}
 
@@ -966,7 +967,7 @@ public:
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 public:
 	template <class T>
@@ -974,7 +975,7 @@ public:
 			<< R"cpp((std::shared_ptr<T> pimpl) noexcept
 		: )cpp"
 			<< objectType.cppType
-			<< R"cpp( { std::unique_ptr<Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
+			<< R"cpp( { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}
 };
@@ -1720,7 +1721,8 @@ Operations::Operations()cpp";
 	)cpp";
 			}
 			sourceFile << R"cpp(}, )cpp"
-					   << (directive.isRepeatable ? R"cpp(true)cpp" : R"cpp(false)cpp") << R"cpp());
+					   << (directive.isRepeatable ? R"cpp(true)cpp" : R"cpp(false)cpp")
+					   << R"cpp());
 )cpp";
 		}
 	}
@@ -1786,7 +1788,7 @@ void Generator::outputInterfaceImplementation(
 	// with arguments that declare the set of types it implements and bind the fields to the
 	// resolver methods.
 	sourceFile << cppType << R"cpp(::)cpp" << cppType
-			   << R"cpp((std::unique_ptr<Concept>&& pimpl) noexcept
+			   << R"cpp((std::unique_ptr<const Concept>&& pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {
@@ -1865,7 +1867,7 @@ void Generator::outputObjectImplementation(
 		// with arguments that declare the set of types it implements and bind the fields to the
 		// resolver methods.
 		sourceFile << objectType.cppType << R"cpp(::)cpp" << objectType.cppType
-				   << R"cpp((std::unique_ptr<Concept>&& pimpl))cpp";
+				   << R"cpp((std::unique_ptr<const Concept>&& pimpl))cpp";
 	}
 
 	sourceFile << R"cpp( noexcept

--- a/src/introspection/DirectiveObject.h
+++ b/src/introspection/DirectiveObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::introspection::object {
 
-class Directive
+class Directive final
 	: public service::Object
 {
 private:
@@ -73,7 +73,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;

--- a/src/introspection/EnumValueObject.h
+++ b/src/introspection/EnumValueObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::introspection::object {
 
-class EnumValue
+class EnumValue final
 	: public service::Object
 {
 private:
@@ -66,7 +66,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;

--- a/src/introspection/FieldObject.h
+++ b/src/introspection/FieldObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::introspection::object {
 
-class Field
+class Field final
 	: public service::Object
 {
 private:
@@ -80,7 +80,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;

--- a/src/introspection/InputValueObject.h
+++ b/src/introspection/InputValueObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::introspection::object {
 
-class InputValue
+class InputValue final
 	: public service::Object
 {
 private:
@@ -66,7 +66,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;

--- a/src/introspection/SchemaObject.h
+++ b/src/introspection/SchemaObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::introspection::object {
 
-class Schema
+class Schema final
 	: public service::Object
 {
 private:
@@ -80,7 +80,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;

--- a/src/introspection/TypeObject.h
+++ b/src/introspection/TypeObject.h
@@ -12,7 +12,7 @@
 
 namespace graphql::introspection::object {
 
-class Type
+class Type final
 	: public service::Object
 {
 private:
@@ -108,7 +108,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	const std::unique_ptr<Concept> _pimpl;
+	const std::unique_ptr<const Concept> _pimpl;
 
 	service::TypeNames getTypeNames() const noexcept;
 	service::ResolverMap getResolvers() const noexcept;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,14 @@ target_link_libraries(today_tests PRIVATE
 add_bigobj_flag(today_tests)
 gtest_add_tests(TARGET today_tests)
 
+add_executable(coroutine_tests CoroutineTests.cpp)
+target_link_libraries(coroutine_tests PRIVATE
+  todaygraphql
+  graphqljson
+  GTest::GTest
+  GTest::Main)
+gtest_add_tests(TARGET coroutine_tests)
+
 add_executable(client_tests ClientTests.cpp)
 target_link_libraries(client_tests PRIVATE
   todaygraphql

--- a/test/CoroutineTests.cpp
+++ b/test/CoroutineTests.cpp
@@ -1,0 +1,416 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include "TodayMock.h"
+
+#include "graphqlservice/JSONResponse.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+using namespace graphql;
+
+using namespace std::literals;
+
+class CoroutineCase : public ::testing::Test
+{
+public:
+	void SetUp() override
+	{
+		_mockService = today::mock_service();
+	}
+
+	void TearDown() override
+	{
+		_mockService.reset();
+	}
+
+protected:
+	std::unique_ptr<today::TodayMockService> _mockService;
+};
+
+TEST_F(CoroutineCase, QueryEverythingSync)
+{
+	auto query = R"(
+		query Everything {
+			appointments {
+				edges {
+					node {
+						id
+						subject
+						when
+						isNow
+						__typename
+					}
+				}
+			}
+			tasks {
+				edges {
+					node {
+						id
+						title
+						isComplete
+						__typename
+					}
+				}
+			}
+			unreadCounts {
+				edges {
+					node {
+						id
+						name
+						unreadCount
+						__typename
+					}
+				}
+			}
+		})"_graphql;
+	response::Value variables(response::Type::Map);
+	auto state = std::make_shared<today::RequestState>(1);
+	const auto worker = std::make_shared<coro::suspend_never>();
+	auto result = _mockService->service
+					  ->resolve({ query,
+						  "Everything"sv,
+						  std::move(variables),
+						  service::await_async { worker },
+						  state })
+					  .get();
+	EXPECT_EQ(size_t { 1 }, _mockService->getAppointmentsCount)
+		<< "today service lazy loads the appointments and caches the result";
+	EXPECT_EQ(size_t { 1 }, _mockService->getTasksCount)
+		<< "today service lazy loads the tasks and caches the result";
+	EXPECT_EQ(size_t { 1 }, _mockService->getUnreadCountsCount)
+		<< "today service lazy loads the unreadCounts and caches the result";
+	EXPECT_EQ(size_t { 1 }, state->appointmentsRequestId)
+		<< "today service passed the same RequestState";
+	EXPECT_EQ(size_t { 1 }, state->tasksRequestId) << "today service passed the same RequestState";
+	EXPECT_EQ(size_t { 1 }, state->unreadCountsRequestId)
+		<< "today service passed the same RequestState";
+	EXPECT_EQ(size_t { 1 }, state->loadAppointmentsCount) << "today service called the loader once";
+	EXPECT_EQ(size_t { 1 }, state->loadTasksCount) << "today service called the loader once";
+	EXPECT_EQ(size_t { 1 }, state->loadUnreadCountsCount) << "today service called the loader once";
+
+	try
+	{
+		ASSERT_TRUE(result.type() == response::Type::Map);
+		auto errorsItr = result.find("errors");
+		if (errorsItr != result.get<response::MapType>().cend())
+		{
+			FAIL() << response::toJSON(response::Value(errorsItr->second));
+		}
+		const auto data = service::ScalarArgument::require("data", result);
+
+		const auto appointments = service::ScalarArgument::require("appointments", data);
+		const auto appointmentEdges =
+			service::ScalarArgument::require<service::TypeModifier::List>("edges", appointments);
+		ASSERT_EQ(size_t { 1 }, appointmentEdges.size()) << "appointments should have 1 entry";
+		ASSERT_TRUE(appointmentEdges[0].type() == response::Type::Map)
+			<< "appointment should be an object";
+		const auto appointmentNode = service::ScalarArgument::require("node", appointmentEdges[0]);
+		EXPECT_EQ(today::getFakeAppointmentId(),
+			service::IdArgument::require("id", appointmentNode))
+			<< "id should match in base64 encoding";
+		EXPECT_EQ("Lunch?", service::StringArgument::require("subject", appointmentNode))
+			<< "subject should match";
+		EXPECT_EQ("tomorrow", service::StringArgument::require("when", appointmentNode))
+			<< "when should match";
+		EXPECT_FALSE(service::BooleanArgument::require("isNow", appointmentNode))
+			<< "isNow should match";
+		EXPECT_EQ("Appointment", service::StringArgument::require("__typename", appointmentNode))
+			<< "__typename should match";
+
+		const auto tasks = service::ScalarArgument::require("tasks", data);
+		const auto taskEdges =
+			service::ScalarArgument::require<service::TypeModifier::List>("edges", tasks);
+		ASSERT_EQ(size_t { 1 }, taskEdges.size()) << "tasks should have 1 entry";
+		ASSERT_TRUE(taskEdges[0].type() == response::Type::Map) << "task should be an object";
+		const auto taskNode = service::ScalarArgument::require("node", taskEdges[0]);
+		EXPECT_EQ(today::getFakeTaskId(), service::IdArgument::require("id", taskNode))
+			<< "id should match in base64 encoding";
+		EXPECT_EQ("Don't forget", service::StringArgument::require("title", taskNode))
+			<< "title should match";
+		EXPECT_TRUE(service::BooleanArgument::require("isComplete", taskNode))
+			<< "isComplete should match";
+		EXPECT_EQ("Task", service::StringArgument::require("__typename", taskNode))
+			<< "__typename should match";
+
+		const auto unreadCounts = service::ScalarArgument::require("unreadCounts", data);
+		const auto unreadCountEdges =
+			service::ScalarArgument::require<service::TypeModifier::List>("edges", unreadCounts);
+		ASSERT_EQ(size_t { 1 }, unreadCountEdges.size()) << "unreadCounts should have 1 entry";
+		ASSERT_TRUE(unreadCountEdges[0].type() == response::Type::Map)
+			<< "unreadCount should be an object";
+		const auto unreadCountNode = service::ScalarArgument::require("node", unreadCountEdges[0]);
+		EXPECT_EQ(today::getFakeFolderId(), service::IdArgument::require("id", unreadCountNode))
+			<< "id should match in base64 encoding";
+		EXPECT_EQ("\"Fake\" Inbox", service::StringArgument::require("name", unreadCountNode))
+			<< "name should match";
+		EXPECT_EQ(3, service::IntArgument::require("unreadCount", unreadCountNode))
+			<< "unreadCount should match";
+		EXPECT_EQ("Folder", service::StringArgument::require("__typename", unreadCountNode))
+			<< "__typename should match";
+	}
+	catch (service::schema_exception& ex)
+	{
+		FAIL() << response::toJSON(ex.getErrors());
+	}
+}
+
+TEST_F(CoroutineCase, QueryEverythingQueued)
+{
+	auto query = R"(
+		query Everything {
+			appointments {
+				edges {
+					node {
+						id
+						subject
+						when
+						isNow
+						__typename
+					}
+				}
+			}
+			tasks {
+				edges {
+					node {
+						id
+						title
+						isComplete
+						__typename
+					}
+				}
+			}
+			unreadCounts {
+				edges {
+					node {
+						id
+						name
+						unreadCount
+						__typename
+					}
+				}
+			}
+		})"_graphql;
+	response::Value variables(response::Type::Map);
+	auto state = std::make_shared<today::RequestState>(2);
+	const auto worker = std::make_shared<service::await_worker_queue>();
+	auto result = _mockService->service
+					  ->resolve({ query,
+						  "Everything"sv,
+						  std::move(variables),
+						  service::await_async { worker },
+						  state })
+					  .get();
+	EXPECT_EQ(size_t { 1 }, _mockService->getAppointmentsCount)
+		<< "today service lazy loads the appointments and caches the result";
+	EXPECT_EQ(size_t { 1 }, _mockService->getTasksCount)
+		<< "today service lazy loads the tasks and caches the result";
+	EXPECT_EQ(size_t { 1 }, _mockService->getUnreadCountsCount)
+		<< "today service lazy loads the unreadCounts and caches the result";
+	EXPECT_EQ(size_t { 2 }, state->appointmentsRequestId)
+		<< "today service passed the same RequestState";
+	EXPECT_EQ(size_t { 2 }, state->tasksRequestId) << "today service passed the same RequestState";
+	EXPECT_EQ(size_t { 2 }, state->unreadCountsRequestId)
+		<< "today service passed the same RequestState";
+	EXPECT_EQ(size_t { 1 }, state->loadAppointmentsCount) << "today service called the loader once";
+	EXPECT_EQ(size_t { 1 }, state->loadTasksCount) << "today service called the loader once";
+	EXPECT_EQ(size_t { 1 }, state->loadUnreadCountsCount) << "today service called the loader once";
+
+	try
+	{
+		ASSERT_TRUE(result.type() == response::Type::Map);
+		auto errorsItr = result.find("errors");
+		if (errorsItr != result.get<response::MapType>().cend())
+		{
+			FAIL() << response::toJSON(response::Value(errorsItr->second));
+		}
+		const auto data = service::ScalarArgument::require("data", result);
+
+		const auto appointments = service::ScalarArgument::require("appointments", data);
+		const auto appointmentEdges =
+			service::ScalarArgument::require<service::TypeModifier::List>("edges", appointments);
+		ASSERT_EQ(size_t { 1 }, appointmentEdges.size()) << "appointments should have 1 entry";
+		ASSERT_TRUE(appointmentEdges[0].type() == response::Type::Map)
+			<< "appointment should be an object";
+		const auto appointmentNode = service::ScalarArgument::require("node", appointmentEdges[0]);
+		EXPECT_EQ(today::getFakeAppointmentId(),
+			service::IdArgument::require("id", appointmentNode))
+			<< "id should match in base64 encoding";
+		EXPECT_EQ("Lunch?", service::StringArgument::require("subject", appointmentNode))
+			<< "subject should match";
+		EXPECT_EQ("tomorrow", service::StringArgument::require("when", appointmentNode))
+			<< "when should match";
+		EXPECT_FALSE(service::BooleanArgument::require("isNow", appointmentNode))
+			<< "isNow should match";
+		EXPECT_EQ("Appointment", service::StringArgument::require("__typename", appointmentNode))
+			<< "__typename should match";
+
+		const auto tasks = service::ScalarArgument::require("tasks", data);
+		const auto taskEdges =
+			service::ScalarArgument::require<service::TypeModifier::List>("edges", tasks);
+		ASSERT_EQ(size_t { 1 }, taskEdges.size()) << "tasks should have 1 entry";
+		ASSERT_TRUE(taskEdges[0].type() == response::Type::Map) << "task should be an object";
+		const auto taskNode = service::ScalarArgument::require("node", taskEdges[0]);
+		EXPECT_EQ(today::getFakeTaskId(), service::IdArgument::require("id", taskNode))
+			<< "id should match in base64 encoding";
+		EXPECT_EQ("Don't forget", service::StringArgument::require("title", taskNode))
+			<< "title should match";
+		EXPECT_TRUE(service::BooleanArgument::require("isComplete", taskNode))
+			<< "isComplete should match";
+		EXPECT_EQ("Task", service::StringArgument::require("__typename", taskNode))
+			<< "__typename should match";
+
+		const auto unreadCounts = service::ScalarArgument::require("unreadCounts", data);
+		const auto unreadCountEdges =
+			service::ScalarArgument::require<service::TypeModifier::List>("edges", unreadCounts);
+		ASSERT_EQ(size_t { 1 }, unreadCountEdges.size()) << "unreadCounts should have 1 entry";
+		ASSERT_TRUE(unreadCountEdges[0].type() == response::Type::Map)
+			<< "unreadCount should be an object";
+		const auto unreadCountNode = service::ScalarArgument::require("node", unreadCountEdges[0]);
+		EXPECT_EQ(today::getFakeFolderId(), service::IdArgument::require("id", unreadCountNode))
+			<< "id should match in base64 encoding";
+		EXPECT_EQ("\"Fake\" Inbox", service::StringArgument::require("name", unreadCountNode))
+			<< "name should match";
+		EXPECT_EQ(3, service::IntArgument::require("unreadCount", unreadCountNode))
+			<< "unreadCount should match";
+		EXPECT_EQ("Folder", service::StringArgument::require("__typename", unreadCountNode))
+			<< "__typename should match";
+	}
+	catch (service::schema_exception& ex)
+	{
+		FAIL() << response::toJSON(ex.getErrors());
+	}
+}
+
+TEST_F(CoroutineCase, QueryEverythingThreaded)
+{
+	auto query = R"(
+		query Everything {
+			appointments {
+				edges {
+					node {
+						id
+						subject
+						when
+						isNow
+						__typename
+					}
+				}
+			}
+			tasks {
+				edges {
+					node {
+						id
+						title
+						isComplete
+						__typename
+					}
+				}
+			}
+			unreadCounts {
+				edges {
+					node {
+						id
+						name
+						unreadCount
+						__typename
+					}
+				}
+			}
+		})"_graphql;
+	response::Value variables(response::Type::Map);
+	auto state = std::make_shared<today::RequestState>(3);
+	const auto worker = std::make_shared<service::await_worker_thread>();
+	auto result = _mockService->service
+					  ->resolve({ query,
+						  "Everything"sv,
+						  std::move(variables),
+						  service::await_async { worker },
+						  state })
+					  .get();
+	EXPECT_EQ(size_t { 1 }, _mockService->getAppointmentsCount)
+		<< "today service lazy loads the appointments and caches the result";
+	EXPECT_EQ(size_t { 1 }, _mockService->getTasksCount)
+		<< "today service lazy loads the tasks and caches the result";
+	EXPECT_EQ(size_t { 1 }, _mockService->getUnreadCountsCount)
+		<< "today service lazy loads the unreadCounts and caches the result";
+	EXPECT_EQ(size_t { 3 }, state->appointmentsRequestId)
+		<< "today service passed the same RequestState";
+	EXPECT_EQ(size_t { 3 }, state->tasksRequestId) << "today service passed the same RequestState";
+	EXPECT_EQ(size_t { 3 }, state->unreadCountsRequestId)
+		<< "today service passed the same RequestState";
+	EXPECT_EQ(size_t { 1 }, state->loadAppointmentsCount) << "today service called the loader once";
+	EXPECT_EQ(size_t { 1 }, state->loadTasksCount) << "today service called the loader once";
+	EXPECT_EQ(size_t { 1 }, state->loadUnreadCountsCount) << "today service called the loader once";
+
+	try
+	{
+		ASSERT_TRUE(result.type() == response::Type::Map);
+		auto errorsItr = result.find("errors");
+		if (errorsItr != result.get<response::MapType>().cend())
+		{
+			FAIL() << response::toJSON(response::Value(errorsItr->second));
+		}
+		const auto data = service::ScalarArgument::require("data", result);
+
+		const auto appointments = service::ScalarArgument::require("appointments", data);
+		const auto appointmentEdges =
+			service::ScalarArgument::require<service::TypeModifier::List>("edges", appointments);
+		ASSERT_EQ(size_t { 1 }, appointmentEdges.size()) << "appointments should have 1 entry";
+		ASSERT_TRUE(appointmentEdges[0].type() == response::Type::Map)
+			<< "appointment should be an object";
+		const auto appointmentNode = service::ScalarArgument::require("node", appointmentEdges[0]);
+		EXPECT_EQ(today::getFakeAppointmentId(),
+			service::IdArgument::require("id", appointmentNode))
+			<< "id should match in base64 encoding";
+		EXPECT_EQ("Lunch?", service::StringArgument::require("subject", appointmentNode))
+			<< "subject should match";
+		EXPECT_EQ("tomorrow", service::StringArgument::require("when", appointmentNode))
+			<< "when should match";
+		EXPECT_FALSE(service::BooleanArgument::require("isNow", appointmentNode))
+			<< "isNow should match";
+		EXPECT_EQ("Appointment", service::StringArgument::require("__typename", appointmentNode))
+			<< "__typename should match";
+
+		const auto tasks = service::ScalarArgument::require("tasks", data);
+		const auto taskEdges =
+			service::ScalarArgument::require<service::TypeModifier::List>("edges", tasks);
+		ASSERT_EQ(size_t { 1 }, taskEdges.size()) << "tasks should have 1 entry";
+		ASSERT_TRUE(taskEdges[0].type() == response::Type::Map) << "task should be an object";
+		const auto taskNode = service::ScalarArgument::require("node", taskEdges[0]);
+		EXPECT_EQ(today::getFakeTaskId(), service::IdArgument::require("id", taskNode))
+			<< "id should match in base64 encoding";
+		EXPECT_EQ("Don't forget", service::StringArgument::require("title", taskNode))
+			<< "title should match";
+		EXPECT_TRUE(service::BooleanArgument::require("isComplete", taskNode))
+			<< "isComplete should match";
+		EXPECT_EQ("Task", service::StringArgument::require("__typename", taskNode))
+			<< "__typename should match";
+
+		const auto unreadCounts = service::ScalarArgument::require("unreadCounts", data);
+		const auto unreadCountEdges =
+			service::ScalarArgument::require<service::TypeModifier::List>("edges", unreadCounts);
+		ASSERT_EQ(size_t { 1 }, unreadCountEdges.size()) << "unreadCounts should have 1 entry";
+		ASSERT_TRUE(unreadCountEdges[0].type() == response::Type::Map)
+			<< "unreadCount should be an object";
+		const auto unreadCountNode = service::ScalarArgument::require("node", unreadCountEdges[0]);
+		EXPECT_EQ(today::getFakeFolderId(), service::IdArgument::require("id", unreadCountNode))
+			<< "id should match in base64 encoding";
+		EXPECT_EQ("\"Fake\" Inbox", service::StringArgument::require("name", unreadCountNode))
+			<< "name should match";
+		EXPECT_EQ(3, service::IntArgument::require("unreadCount", unreadCountNode))
+			<< "unreadCount should match";
+		EXPECT_EQ("Folder", service::StringArgument::require("__typename", unreadCountNode))
+			<< "__typename should match";
+	}
+	catch (service::schema_exception& ex)
+	{
+		FAIL() << response::toJSON(ex.getErrors());
+	}
+}


### PR DESCRIPTION
- Fix #200 
- Implement `await_worker_queue` and test custom awaitables
- Add `const` in a lot of places where members are immutable
- Mark type-erased classes and structs as `final` to prevent inheritance