### PR TITLE
Adds a virtual default destructor for RequestState

### DIFF
--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -108,6 +108,7 @@ private:
 // correlate the asynchronous/recursive callbacks and accumulate state in it.
 struct RequestState : std::enable_shared_from_this<RequestState>
 {
+	virtual ~RequestState() = default;
 };
 
 namespace {


### PR DESCRIPTION
Adds a default destructor to allow the use of `std::dynamic_pointer_cast` on a RequestState derivation