### PR TITLE
Options to remove base64 ID encoding at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,8 @@ option(GRAPHQL_BUILD_CLIENTGEN "Build the clientgen tool." ON)
 
 option(GRAPHQL_UPDATE_VERSION "Regenerate graphqlservice/internal/Version.h and all of the version info rc files for Windows." ON)
 
+option(GRAPHQL_NO_BASE64 "Disable Base64 encoding for ID types" OFF)
+
 add_subdirectory(cmake)
 add_subdirectory(src)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,6 +140,10 @@ target_include_directories(graphqlresponse PUBLIC
   $<INSTALL_INTERFACE:${GRAPHQL_INSTALL_INCLUDE_DIR}>)
 target_link_libraries(graphqlresponse PUBLIC graphqlcoro)
 
+if(GRAPHQL_NO_BASE64)
+target_compile_definitions(graphqlresponse PUBLIC GRAPHQL_NO_BASE64)
+endif()
+
 if(GRAPHQL_UPDATE_VERSION)
   update_version_rc(graphqlresponse)
 endif()

--- a/src/Validation.cpp
+++ b/src/Validation.cpp
@@ -1218,9 +1218,10 @@ bool ValidateExecutableVisitor::validateInputValue(
 				{
 					try
 					{
+#ifndef GRAPHQL_NO_BASE64
 						auto decoded = internal::Base64::fromBase64(
 							std::get<std::string_view>(argument.value->data));
-
+#endif
 						return true;
 					}
 					catch (const std::logic_error&)


### PR DESCRIPTION
This one is a bit of a bigger one - we've been looking at other GQL implementations in other languages, and noticed that they don't encode Base64 for the ID type. 

While I agree that Base64 IDs are actually better given their implicit binary nature - we need to get consistency between the other implementations we are building up. 

Given the scope of changes and breakage for existing client usage - I've added an option as a compile time flag for the behaviour change. 

Obviously - the library user would need to ensure that they are not encoding anything that is illegal here - but given its an opt-in - I would expect its more a "user-beware" sort of option