### PR TITLE
Add constexpr support to internal::sorted_map and internal::sorted_set

### DIFF
--- a/include/ClientGenerator.h
+++ b/include/ClientGenerator.h
@@ -11,19 +11,19 @@
 
 namespace graphql::generator::client {
 
-struct GeneratorPaths
+struct [[nodiscard]] GeneratorPaths
 {
 	const std::string headerPath;
 	const std::string sourcePath;
 };
 
-struct GeneratorOptions
+struct [[nodiscard]] GeneratorOptions
 {
 	const GeneratorPaths paths;
 	const bool verbose = false;
 };
 
-class Generator
+class [[nodiscard]] Generator
 {
 public:
 	// Initialize the generator with the introspection client or a custom GraphQL client.
@@ -31,30 +31,31 @@ public:
 		SchemaOptions&& schemaOptions, RequestOptions&& requestOptions, GeneratorOptions&& options);
 
 	// Run the generator and return a list of filenames that were output.
-	std::vector<std::string> Build() const noexcept;
+	[[nodiscard]] std::vector<std::string> Build() const noexcept;
 
 private:
-	std::string getHeaderDir() const noexcept;
-	std::string getSourceDir() const noexcept;
-	std::string getHeaderPath() const noexcept;
-	std::string getSourcePath() const noexcept;
-	const std::string& getClientNamespace() const noexcept;
-	const std::string& getRequestNamespace() const noexcept;
-	const std::string& getFullNamespace() const noexcept;
-	std::string getResponseFieldCppType(
+	[[nodiscard]] std::string getHeaderDir() const noexcept;
+	[[nodiscard]] std::string getSourceDir() const noexcept;
+	[[nodiscard]] std::string getHeaderPath() const noexcept;
+	[[nodiscard]] std::string getSourcePath() const noexcept;
+	[[nodiscard]] const std::string& getClientNamespace() const noexcept;
+	[[nodiscard]] const std::string& getRequestNamespace() const noexcept;
+	[[nodiscard]] const std::string& getFullNamespace() const noexcept;
+	[[nodiscard]] std::string getResponseFieldCppType(
 		const ResponseField& responseField, std::string_view currentScope = {}) const noexcept;
 
-	bool outputHeader() const noexcept;
+	[[nodiscard]] bool outputHeader() const noexcept;
 	void outputRequestComment(std::ostream& headerFile) const noexcept;
 	void outputGetRequestDeclaration(std::ostream& headerFile) const noexcept;
-	bool outputResponseFieldType(std::ostream& headerFile, const ResponseField& responseField,
-		size_t indent = 0) const noexcept;
+	[[nodiscard]] bool outputResponseFieldType(std::ostream& headerFile,
+		const ResponseField& responseField, size_t indent = 0) const noexcept;
 
-	bool outputSource() const noexcept;
+	[[nodiscard]] bool outputSource() const noexcept;
 	void outputGetRequestImplementation(std::ostream& sourceFile) const noexcept;
 	bool outputModifiedResponseImplementation(std::ostream& sourceFile,
 		const std::string& outerScope, const ResponseField& responseField) const noexcept;
-	static std::string getTypeModifierList(const TypeModifierStack& modifiers) noexcept;
+	[[nodiscard]] static std::string getTypeModifierList(
+		const TypeModifierStack& modifiers) noexcept;
 
 	const SchemaLoader _schemaLoader;
 	const RequestLoader _requestLoader;

--- a/include/GeneratorLoader.h
+++ b/include/GeneratorLoader.h
@@ -11,8 +11,7 @@
 namespace graphql::generator {
 
 // Types that we understand and use to generate the skeleton of a service.
-enum class SchemaType
-{
+enum class [[nodiscard]] SchemaType {
 	Scalar,
 	Enum,
 	Input,
@@ -31,10 +30,10 @@ using TypeModifierStack = std::vector<service::TypeModifier>;
 
 // Recursively visit a Type node until we reach a NamedType and we've
 // taken stock of all of the modifier wrappers.
-class TypeVisitor
+class [[nodiscard]] TypeVisitor
 {
 public:
-	std::pair<std::string_view, TypeModifierStack> getType();
+	[[nodiscard]] std::pair<std::string_view, TypeModifierStack> getType();
 
 	void visit(const peg::ast_node& typeName);
 
@@ -50,10 +49,10 @@ private:
 
 // Recursively visit a Value node representing the default value on an input field
 // and build a JSON representation of the hardcoded value.
-class DefaultValueVisitor
+class [[nodiscard]] DefaultValueVisitor
 {
 public:
-	response::Value getValue();
+	[[nodiscard]] response::Value getValue();
 
 	void visit(const peg::ast_node& value);
 

--- a/include/GeneratorUtil.h
+++ b/include/GeneratorUtil.h
@@ -13,7 +13,7 @@
 namespace graphql::generator {
 
 // RAII object to help with emitting matching include guard begin and end statements
-class IncludeGuardScope
+class [[nodiscard]] IncludeGuardScope
 {
 public:
 	explicit IncludeGuardScope(std::ostream& outputFile, std::string_view headerFileName) noexcept;
@@ -25,7 +25,7 @@ private:
 };
 
 // RAII object to help with emitting matching namespace begin and end statements
-class NamespaceScope
+class [[nodiscard]] NamespaceScope
 {
 public:
 	explicit NamespaceScope(
@@ -44,7 +44,7 @@ private:
 
 // Keep track of whether we want to add a blank separator line once some additional content is about
 // to be output.
-class PendingBlankLine
+class [[nodiscard]] PendingBlankLine
 {
 public:
 	explicit PendingBlankLine(std::ostream& outputFile) noexcept;

--- a/include/RequestLoader.h
+++ b/include/RequestLoader.h
@@ -25,14 +25,14 @@ struct ResponseField;
 
 using ResponseFieldList = std::vector<ResponseField>;
 
-struct ResponseType
+struct [[nodiscard]] ResponseType
 {
 	RequestSchemaType type;
 	std::string_view cppType;
 	ResponseFieldList fields;
 };
 
-struct ResponseField
+struct [[nodiscard]] ResponseField
 {
 	RequestSchemaType type;
 	TypeModifierStack modifiers;
@@ -42,7 +42,7 @@ struct ResponseField
 	ResponseFieldList children;
 };
 
-struct RequestInputType
+struct [[nodiscard]] RequestInputType
 {
 	RequestSchemaType type;
 	std::unordered_set<std::string_view> dependencies {};
@@ -51,7 +51,7 @@ struct RequestInputType
 
 using RequestInputTypeList = std::vector<RequestInputType>;
 
-struct RequestVariable
+struct [[nodiscard]] RequestVariable
 {
 	RequestInputType inputType;
 	TypeModifierStack modifiers;
@@ -64,7 +64,7 @@ struct RequestVariable
 
 using RequestVariableList = std::vector<RequestVariable>;
 
-struct RequestOptions
+struct [[nodiscard]] RequestOptions
 {
 	const std::string requestFilename;
 	const std::string operationName;
@@ -73,40 +73,41 @@ struct RequestOptions
 
 class SchemaLoader;
 
-class RequestLoader
+class [[nodiscard]] RequestLoader
 {
 public:
 	explicit RequestLoader(RequestOptions&& requestOptions, const SchemaLoader& schemaLoader);
 
-	std::string_view getRequestFilename() const noexcept;
-	std::string_view getOperationDisplayName() const noexcept;
-	std::string getOperationNamespace() const noexcept;
-	std::string_view getOperationType() const noexcept;
-	std::string_view getRequestText() const noexcept;
+	[[nodiscard]] std::string_view getRequestFilename() const noexcept;
+	[[nodiscard]] std::string_view getOperationDisplayName() const noexcept;
+	[[nodiscard]] std::string getOperationNamespace() const noexcept;
+	[[nodiscard]] std::string_view getOperationType() const noexcept;
+	[[nodiscard]] std::string_view getRequestText() const noexcept;
 
-	const ResponseType& getResponseType() const noexcept;
-	const RequestVariableList& getVariables() const noexcept;
+	[[nodiscard]] const ResponseType& getResponseType() const noexcept;
+	[[nodiscard]] const RequestVariableList& getVariables() const noexcept;
 
-	const RequestInputTypeList& getReferencedInputTypes() const noexcept;
-	const RequestSchemaTypeList& getReferencedEnums() const noexcept;
+	[[nodiscard]] const RequestInputTypeList& getReferencedInputTypes() const noexcept;
+	[[nodiscard]] const RequestSchemaTypeList& getReferencedEnums() const noexcept;
 
-	std::string getInputCppType(const RequestSchemaType& wrappedInputType) const noexcept;
-	std::string getInputCppType(const RequestSchemaType& inputType,
-		const TypeModifierStack& modifiers) const noexcept;
-	static std::string getOutputCppType(
+	[[nodiscard]] std::string getInputCppType(
+		const RequestSchemaType& wrappedInputType) const noexcept;
+	[[nodiscard]] std::string getInputCppType(
+		const RequestSchemaType& inputType, const TypeModifierStack& modifiers) const noexcept;
+	[[nodiscard]] static std::string getOutputCppType(
 		std::string_view outputCppType, const TypeModifierStack& modifiers) noexcept;
 
-	static std::pair<RequestSchemaType, TypeModifierStack> unwrapSchemaType(
+	[[nodiscard]] static std::pair<RequestSchemaType, TypeModifierStack> unwrapSchemaType(
 		RequestSchemaType&& type) noexcept;
 
 private:
 	void buildSchema();
 	void addTypesToSchema();
-	RequestSchemaType getSchemaType(
+	[[nodiscard]] RequestSchemaType getSchemaType(
 		std::string_view type, const TypeModifierStack& modifiers) const noexcept;
 	void validateRequest() const;
 
-	static std::string_view trimWhitespace(std::string_view content) noexcept;
+	[[nodiscard]] static std::string_view trimWhitespace(std::string_view content) noexcept;
 
 	void findOperation();
 	void collectFragments() noexcept;
@@ -119,7 +120,7 @@ private:
 	using FragmentDefinitionMap = std::map<std::string_view, const peg::ast_node*>;
 
 	// SelectionVisitor visits the AST and fills in the ResponseType for the request.
-	class SelectionVisitor
+	class [[nodiscard]] SelectionVisitor
 	{
 	public:
 		explicit SelectionVisitor(const SchemaLoader& schemaLoader,
@@ -128,7 +129,7 @@ private:
 
 		void visit(const peg::ast_node& selection);
 
-		ResponseFieldList getFields();
+		[[nodiscard]] ResponseFieldList getFields();
 
 	private:
 		void visitField(const peg::ast_node& field);

--- a/include/SchemaGenerator.h
+++ b/include/SchemaGenerator.h
@@ -10,13 +10,13 @@
 
 namespace graphql::generator::schema {
 
-struct GeneratorPaths
+struct [[nodiscard]] GeneratorPaths
 {
 	const std::string headerPath;
 	const std::string sourcePath;
 };
 
-struct GeneratorOptions
+struct [[nodiscard]] GeneratorOptions
 {
 	const GeneratorPaths paths;
 	const bool verbose = false;
@@ -24,32 +24,32 @@ struct GeneratorOptions
 	const bool noIntrospection = false;
 };
 
-class Generator
+class [[nodiscard]] Generator
 {
 public:
 	// Initialize the generator with the introspection schema or a custom GraphQL schema.
 	explicit Generator(SchemaOptions&& schemaOptions, GeneratorOptions&& options);
 
 	// Run the generator and return a list of filenames that were output.
-	std::vector<std::string> Build() const noexcept;
+	[[nodiscard]] std::vector<std::string> Build() const noexcept;
 
 private:
-	std::string getHeaderDir() const noexcept;
-	std::string getSourceDir() const noexcept;
-	std::string getHeaderPath() const noexcept;
-	std::string getSourcePath() const noexcept;
+	[[nodiscard]] std::string getHeaderDir() const noexcept;
+	[[nodiscard]] std::string getSourceDir() const noexcept;
+	[[nodiscard]] std::string getHeaderPath() const noexcept;
+	[[nodiscard]] std::string getSourcePath() const noexcept;
 
-	bool outputHeader() const noexcept;
+	[[nodiscard]] bool outputHeader() const noexcept;
 	void outputInterfaceDeclaration(std::ostream& headerFile, std::string_view cppType) const;
 	void outputObjectImplements(std::ostream& headerFile, const ObjectType& objectType) const;
 	void outputObjectStubs(std::ostream& headerFile, const ObjectType& objectType) const;
 	void outputObjectDeclaration(
 		std::ostream& headerFile, const ObjectType& objectType, bool isQueryType) const;
-	std::string getFieldDeclaration(const InputField& inputField) const noexcept;
-	std::string getFieldDeclaration(const OutputField& outputField) const noexcept;
-	std::string getResolverDeclaration(const OutputField& outputField) const noexcept;
+	[[nodiscard]] std::string getFieldDeclaration(const InputField& inputField) const noexcept;
+	[[nodiscard]] std::string getFieldDeclaration(const OutputField& outputField) const noexcept;
+	[[nodiscard]] std::string getResolverDeclaration(const OutputField& outputField) const noexcept;
 
-	bool outputSource() const noexcept;
+	[[nodiscard]] bool outputSource() const noexcept;
 	void outputInterfaceImplementation(std::ostream& sourceFile, std::string_view cppType) const;
 	void outputInterfaceIntrospection(
 		std::ostream& sourceFile, const InterfaceType& interfaceType) const;
@@ -61,17 +61,18 @@ private:
 		const std::vector<std::string_view>& interfaces) const;
 	void outputIntrospectionFields(
 		std::ostream& sourceFile, std::string_view cppType, const OutputFieldList& fields) const;
-	std::string getArgumentDefaultValue(
+	[[nodiscard]] std::string getArgumentDefaultValue(
 		size_t level, const response::Value& defaultValue) const noexcept;
-	std::string getArgumentDeclaration(const InputField& argument, const char* prefixToken,
-		const char* argumentsToken, const char* defaultToken) const noexcept;
-	std::string getArgumentAccessType(const InputField& argument) const noexcept;
-	std::string getResultAccessType(const OutputField& result) const noexcept;
-	std::string getTypeModifiers(const TypeModifierStack& modifiers) const noexcept;
-	std::string getIntrospectionType(
+	[[nodiscard]] std::string getArgumentDeclaration(const InputField& argument,
+		const char* prefixToken, const char* argumentsToken,
+		const char* defaultToken) const noexcept;
+	[[nodiscard]] std::string getArgumentAccessType(const InputField& argument) const noexcept;
+	[[nodiscard]] std::string getResultAccessType(const OutputField& result) const noexcept;
+	[[nodiscard]] std::string getTypeModifiers(const TypeModifierStack& modifiers) const noexcept;
+	[[nodiscard]] std::string getIntrospectionType(
 		std::string_view type, const TypeModifierStack& modifiers) const noexcept;
 
-	std::vector<std::string> outputSeparateFiles() const noexcept;
+	[[nodiscard]] std::vector<std::string> outputSeparateFiles() const noexcept;
 
 	static const std::string s_currentDirectory;
 

--- a/include/SchemaLoader.h
+++ b/include/SchemaLoader.h
@@ -20,8 +20,7 @@
 namespace graphql::generator {
 
 // These are the set of built-in types in GraphQL.
-enum class BuiltinType
-{
+enum class [[nodiscard]] BuiltinType {
 	Int,
 	Float,
 	String,
@@ -44,7 +43,7 @@ using TypeNameMap = std::unordered_map<std::string_view, size_t>;
 // Scalar types are opaque to the generator, it's up to the service implementation
 // to handle parsing, validating, and serializing them. We just need to track which
 // scalar type names have been declared so we recognize the references.
-struct ScalarType
+struct [[nodiscard]] ScalarType
 {
 	std::string_view type;
 	std::string_view description;
@@ -54,7 +53,7 @@ struct ScalarType
 using ScalarTypeList = std::vector<ScalarType>;
 
 // Enum types map a type name to a collection of valid string values.
-struct EnumValueType
+struct [[nodiscard]] EnumValueType
 {
 	std::string_view value;
 	std::string_view cppValue;
@@ -63,7 +62,7 @@ struct EnumValueType
 	std::optional<tao::graphqlpeg::position> position;
 };
 
-struct EnumType
+struct [[nodiscard]] EnumType
 {
 	std::string_view type;
 	std::string_view cppType;
@@ -76,15 +75,14 @@ using EnumTypeList = std::vector<EnumType>;
 // Input types are complex types that have a set of named fields. Each field may be
 // a scalar type (including lists or non-null wrappers) or another nested input type,
 // but it cannot include output object types.
-enum class InputFieldType
-{
+enum class [[nodiscard]] InputFieldType {
 	Builtin,
 	Scalar,
 	Enum,
 	Input,
 };
 
-struct InputField
+struct [[nodiscard]] InputField
 {
 	std::string_view type;
 	std::string_view name;
@@ -99,7 +97,7 @@ struct InputField
 
 using InputFieldList = std::vector<InputField>;
 
-struct InputType
+struct [[nodiscard]] InputType
 {
 	std::string_view type;
 	std::string_view cppType;
@@ -112,7 +110,7 @@ struct InputType
 using InputTypeList = std::vector<InputType>;
 
 // Directives are defined with arguments and a list of valid locations.
-struct Directive
+struct [[nodiscard]] Directive
 {
 	std::string_view name;
 	bool isRepeatable = false;
@@ -124,7 +122,7 @@ struct Directive
 using DirectiveList = std::vector<Directive>;
 
 // Union types map a type name to a set of potential concrete type names.
-struct UnionType
+struct [[nodiscard]] UnionType
 {
 	std::string_view type;
 	std::string_view cppType;
@@ -138,8 +136,7 @@ using UnionTypeList = std::vector<UnionType>;
 // field may be a scalar type (including lists or non-null wrappers) or another nested
 // output type, but it cannot include input object types. Each field can also take
 // optional arguments which are all input types.
-enum class OutputFieldType
-{
+enum class [[nodiscard]] OutputFieldType {
 	Builtin,
 	Scalar,
 	Enum,
@@ -151,7 +148,7 @@ enum class OutputFieldType
 constexpr std::string_view strGet = "get";
 constexpr std::string_view strApply = "apply";
 
-struct OutputField
+struct [[nodiscard]] OutputField
 {
 	std::string_view type;
 	std::string_view name;
@@ -172,7 +169,7 @@ using OutputFieldList = std::vector<OutputField>;
 // are inherited by concrete object output types which support all of the fields in
 // the interface, and the concrete object matches the interface for fragment type
 // conditions. The fields can include any output type.
-struct InterfaceType
+struct [[nodiscard]] InterfaceType
 {
 	std::string_view type;
 	std::string_view cppType;
@@ -185,7 +182,7 @@ using InterfaceTypeList = std::vector<InterfaceType>;
 
 // Object types are concrete complex output types that have a set of fields. They
 // may inherit multiple interfaces.
-struct ObjectType
+struct [[nodiscard]] ObjectType
 {
 	std::string_view type;
 	std::string_view cppType;
@@ -198,7 +195,7 @@ struct ObjectType
 using ObjectTypeList = std::vector<ObjectType>;
 
 // The schema maps operation types to named types.
-struct OperationType
+struct [[nodiscard]] OperationType
 {
 	std::string_view type;
 	std::string_view cppType;
@@ -207,7 +204,7 @@ struct OperationType
 
 using OperationTypeList = std::vector<OperationType>;
 
-struct SchemaOptions
+struct [[nodiscard]] SchemaOptions
 {
 	const std::string schemaFilename;
 	const std::string filenamePrefix;
@@ -215,59 +212,60 @@ struct SchemaOptions
 	const bool isIntrospection = false;
 };
 
-class SchemaLoader
+class [[nodiscard]] SchemaLoader
 {
 public:
 	// Initialize the loader with the introspection schema or a custom GraphQL schema.
 	explicit SchemaLoader(SchemaOptions&& schemaOptions);
 
-	bool isIntrospection() const noexcept;
-	std::string_view getSchemaDescription() const noexcept;
-	std::string_view getFilenamePrefix() const noexcept;
-	std::string_view getSchemaNamespace() const noexcept;
+	[[nodiscard]] bool isIntrospection() const noexcept;
+	[[nodiscard]] std::string_view getSchemaDescription() const noexcept;
+	[[nodiscard]] std::string_view getFilenamePrefix() const noexcept;
+	[[nodiscard]] std::string_view getSchemaNamespace() const noexcept;
 
-	static std::string_view getIntrospectionNamespace() noexcept;
-	static const BuiltinTypeMap& getBuiltinTypes() noexcept;
-	static const CppTypeMap& getBuiltinCppTypes() noexcept;
-	static std::string_view getScalarCppType() noexcept;
+	[[nodiscard]] static std::string_view getIntrospectionNamespace() noexcept;
+	[[nodiscard]] static const BuiltinTypeMap& getBuiltinTypes() noexcept;
+	[[nodiscard]] static const CppTypeMap& getBuiltinCppTypes() noexcept;
+	[[nodiscard]] static std::string_view getScalarCppType() noexcept;
 
-	SchemaType getSchemaType(std::string_view type) const;
-	const tao::graphqlpeg::position& getTypePosition(std::string_view type) const;
+	[[nodiscard]] SchemaType getSchemaType(std::string_view type) const;
+	[[nodiscard]] const tao::graphqlpeg::position& getTypePosition(std::string_view type) const;
 
-	size_t getScalarIndex(std::string_view type) const;
-	const ScalarTypeList& getScalarTypes() const noexcept;
+	[[nodiscard]] size_t getScalarIndex(std::string_view type) const;
+	[[nodiscard]] const ScalarTypeList& getScalarTypes() const noexcept;
 
-	size_t getEnumIndex(std::string_view type) const;
-	const EnumTypeList& getEnumTypes() const noexcept;
+	[[nodiscard]] size_t getEnumIndex(std::string_view type) const;
+	[[nodiscard]] const EnumTypeList& getEnumTypes() const noexcept;
 
-	size_t getInputIndex(std::string_view type) const;
-	const InputTypeList& getInputTypes() const noexcept;
+	[[nodiscard]] size_t getInputIndex(std::string_view type) const;
+	[[nodiscard]] const InputTypeList& getInputTypes() const noexcept;
 
-	size_t getUnionIndex(std::string_view type) const;
-	const UnionTypeList& getUnionTypes() const noexcept;
+	[[nodiscard]] size_t getUnionIndex(std::string_view type) const;
+	[[nodiscard]] const UnionTypeList& getUnionTypes() const noexcept;
 
-	size_t getInterfaceIndex(std::string_view type) const;
-	const InterfaceTypeList& getInterfaceTypes() const noexcept;
+	[[nodiscard]] size_t getInterfaceIndex(std::string_view type) const;
+	[[nodiscard]] const InterfaceTypeList& getInterfaceTypes() const noexcept;
 
-	size_t getObjectIndex(std::string_view type) const;
-	const ObjectTypeList& getObjectTypes() const noexcept;
+	[[nodiscard]] size_t getObjectIndex(std::string_view type) const;
+	[[nodiscard]] const ObjectTypeList& getObjectTypes() const noexcept;
 
-	const DirectiveList& getDirectives() const noexcept;
-	const tao::graphqlpeg::position& getDirectivePosition(std::string_view type) const;
+	[[nodiscard]] const DirectiveList& getDirectives() const noexcept;
+	[[nodiscard]] const tao::graphqlpeg::position& getDirectivePosition(
+		std::string_view type) const;
 
-	const OperationTypeList& getOperationTypes() const noexcept;
+	[[nodiscard]] const OperationTypeList& getOperationTypes() const noexcept;
 
-	static std::string_view getSafeCppName(std::string_view type) noexcept;
+	[[nodiscard]] static std::string_view getSafeCppName(std::string_view type) noexcept;
 
-	std::string_view getCppType(std::string_view type) const noexcept;
-	std::string getInputCppType(const InputField& field) const noexcept;
-	std::string getOutputCppType(const OutputField& field) const noexcept;
+	[[nodiscard]] std::string_view getCppType(std::string_view type) const noexcept;
+	[[nodiscard]] std::string getInputCppType(const InputField& field) const noexcept;
+	[[nodiscard]] std::string getOutputCppType(const OutputField& field) const noexcept;
 
-	static std::string getOutputCppAccessor(const OutputField& field) noexcept;
-	static std::string getOutputCppResolver(const OutputField& field) noexcept;
+	[[nodiscard]] static std::string getOutputCppAccessor(const OutputField& field) noexcept;
+	[[nodiscard]] static std::string getOutputCppResolver(const OutputField& field) noexcept;
 
 private:
-	static bool isExtension(const peg::ast_node& definition) noexcept;
+	[[nodiscard]] static bool isExtension(const peg::ast_node& definition) noexcept;
 
 	void visitDefinition(const peg::ast_node& definition);
 
@@ -289,8 +287,8 @@ private:
 
 	static void blockReservedName(
 		std::string_view name, std::optional<tao::graphqlpeg::position> position = std::nullopt);
-	static OutputFieldList getOutputFields(const peg::ast_node::children_t& fields);
-	static InputFieldList getInputFields(const peg::ast_node::children_t& fields);
+	[[nodiscard]] static OutputFieldList getOutputFields(const peg::ast_node::children_t& fields);
+	[[nodiscard]] static InputFieldList getInputFields(const peg::ast_node::children_t& fields);
 
 	void validateSchema();
 	void fixupOutputFieldList(OutputFieldList& fields,
@@ -299,14 +297,15 @@ private:
 	void fixupInputFieldList(InputFieldList& fields);
 	void reorderInputTypeDependencies();
 	void validateImplementedInterfaces() const;
-	const InterfaceType& findInterfaceType(
+	[[nodiscard]] const InterfaceType& findInterfaceType(
 		std::string_view typeName, std::string_view interfaceName) const;
 	void validateInterfaceFields(std::string_view typeName, std::string_view interfaceName,
 		const OutputFieldList& typeFields) const;
 	void validateTransitiveInterfaces(
 		std::string_view typeName, const std::vector<std::string_view>& interfaces) const;
 
-	static std::string getJoinedCppName(std::string_view prefix, std::string_view fieldName) noexcept;
+	[[nodiscard]] static std::string getJoinedCppName(
+		std::string_view prefix, std::string_view fieldName) noexcept;
 
 	static const std::string_view s_introspectionNamespace;
 	static const BuiltinTypeMap s_builtinTypes;

--- a/include/Validation.h
+++ b/include/Validation.h
@@ -15,10 +15,10 @@ namespace graphql::service {
 using ValidateType = std::optional<std::reference_wrapper<const schema::BaseType>>;
 using SharedType = std::shared_ptr<const schema::BaseType>;
 
-SharedType getSharedType(const ValidateType& type) noexcept;
-ValidateType getValidateType(const SharedType& type) noexcept;
+[[nodiscard]] SharedType getSharedType(const ValidateType& type) noexcept;
+[[nodiscard]] ValidateType getValidateType(const SharedType& type) noexcept;
 
-struct ValidateArgument
+struct [[nodiscard]] ValidateArgument
 {
 	bool defaultValue = false;
 	bool nonNullDefaultValue = false;
@@ -27,7 +27,7 @@ struct ValidateArgument
 
 using ValidateTypeFieldArguments = internal::string_view_map<ValidateArgument>;
 
-struct ValidateTypeField
+struct [[nodiscard]] ValidateTypeField
 {
 	ValidateType returnType;
 	ValidateTypeFieldArguments arguments;
@@ -35,47 +35,47 @@ struct ValidateTypeField
 
 using ValidateDirectiveArguments = internal::string_view_map<ValidateArgument>;
 
-struct ValidateDirective
+struct [[nodiscard]] ValidateDirective
 {
 	bool isRepeatable = false;
 	internal::sorted_set<introspection::DirectiveLocation> locations;
 	ValidateDirectiveArguments arguments;
 };
 
-struct ValidateArgumentVariable
+struct [[nodiscard]] ValidateArgumentVariable
 {
-	bool operator==(const ValidateArgumentVariable& other) const;
+	[[nodiscard]] bool operator==(const ValidateArgumentVariable& other) const;
 
 	std::string_view name;
 };
 
-struct ValidateArgumentEnumValue
+struct [[nodiscard]] ValidateArgumentEnumValue
 {
-	bool operator==(const ValidateArgumentEnumValue& other) const;
+	[[nodiscard]] bool operator==(const ValidateArgumentEnumValue& other) const;
 
 	std::string_view value;
 };
 
 struct ValidateArgumentValue;
 
-struct ValidateArgumentValuePtr
+struct [[nodiscard]] ValidateArgumentValuePtr
 {
-	bool operator==(const ValidateArgumentValuePtr& other) const;
+	[[nodiscard]] bool operator==(const ValidateArgumentValuePtr& other) const;
 
 	std::unique_ptr<ValidateArgumentValue> value;
 	schema_location position;
 };
 
-struct ValidateArgumentList
+struct [[nodiscard]] ValidateArgumentList
 {
-	bool operator==(const ValidateArgumentList& other) const;
+	[[nodiscard]] bool operator==(const ValidateArgumentList& other) const;
 
 	std::vector<ValidateArgumentValuePtr> values;
 };
 
-struct ValidateArgumentMap
+struct [[nodiscard]] ValidateArgumentMap
 {
-	bool operator==(const ValidateArgumentMap& other) const;
+	[[nodiscard]] bool operator==(const ValidateArgumentMap& other) const;
 
 	internal::string_view_map<ValidateArgumentValuePtr> values;
 };
@@ -83,7 +83,7 @@ struct ValidateArgumentMap
 using ValidateArgumentVariant = std::variant<ValidateArgumentVariable, int, double,
 	std::string_view, bool, ValidateArgumentEnumValue, ValidateArgumentList, ValidateArgumentMap>;
 
-struct ValidateArgumentValue
+struct [[nodiscard]] ValidateArgumentValue
 {
 	ValidateArgumentValue(ValidateArgumentVariable&& value);
 	ValidateArgumentValue(int value);
@@ -99,14 +99,14 @@ struct ValidateArgumentValue
 
 // ValidateArgumentValueVisitor visits the AST and builds a record of a field return type and map
 // of the arguments for comparison to see if 2 fields with the same result name can be merged.
-class ValidateArgumentValueVisitor
+class [[nodiscard]] ValidateArgumentValueVisitor
 {
 public:
 	ValidateArgumentValueVisitor(std::list<schema_error>& errors);
 
 	void visit(const peg::ast_node& value);
 
-	ValidateArgumentValuePtr getArgumentValue();
+	[[nodiscard]] ValidateArgumentValuePtr getArgumentValue();
 
 private:
 	void visitVariable(const peg::ast_node& variable);
@@ -125,12 +125,12 @@ private:
 
 using ValidateFieldArguments = internal::string_view_map<ValidateArgumentValuePtr>;
 
-struct ValidateField
+struct [[nodiscard]] ValidateField
 {
 	ValidateField(ValidateType&& returnType, ValidateType&& objectType, std::string_view fieldName,
 		ValidateFieldArguments&& arguments);
 
-	bool operator==(const ValidateField& other) const;
+	[[nodiscard]] bool operator==(const ValidateField& other) const;
 
 	ValidateType returnType;
 	ValidateType objectType;
@@ -142,7 +142,7 @@ using ValidateTypes = internal::string_view_map<ValidateType>;
 
 // ValidateVariableTypeVisitor visits the AST and builds a ValidateType structure representing
 // a variable type in an operation definition as if it came from an Introspection query.
-class ValidateVariableTypeVisitor
+class [[nodiscard]] ValidateVariableTypeVisitor
 {
 public:
 	ValidateVariableTypeVisitor(
@@ -150,8 +150,8 @@ public:
 
 	void visit(const peg::ast_node& typeName);
 
-	bool isInputType() const;
-	ValidateType getType();
+	[[nodiscard]] bool isInputType() const;
+	[[nodiscard]] ValidateType getType();
 
 private:
 	void visitNamedType(const peg::ast_node& namedType);
@@ -167,17 +167,17 @@ private:
 
 // ValidateExecutableVisitor visits the AST and validates that it is executable against the service
 // schema.
-class ValidateExecutableVisitor
+class [[nodiscard]] ValidateExecutableVisitor
 {
 public:
 	GRAPHQLSERVICE_EXPORT ValidateExecutableVisitor(std::shared_ptr<schema::Schema> schema);
 
 	GRAPHQLSERVICE_EXPORT void visit(const peg::ast_node& root);
 
-	GRAPHQLSERVICE_EXPORT std::list<schema_error> getStructuredErrors();
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::list<schema_error> getStructuredErrors();
 
 private:
-	static ValidateTypeFieldArguments getArguments(
+	[[nodiscard]] static ValidateTypeFieldArguments getArguments(
 		const std::vector<std::shared_ptr<const schema::InputValue>>& args);
 
 	using FieldTypes = internal::string_view_map<ValidateTypeField>;
@@ -186,18 +186,22 @@ private:
 	using InputTypeFields = internal::string_view_map<InputFieldTypes>;
 	using EnumValues = internal::string_view_map<internal::string_view_set>;
 
-	constexpr bool isScalarType(introspection::TypeKind kind);
+	[[nodiscard]] constexpr bool isScalarType(introspection::TypeKind kind);
 
-	bool matchesScopedType(std::string_view name) const;
+	[[nodiscard]] bool matchesScopedType(std::string_view name) const;
 
-	TypeFields::const_iterator getScopedTypeFields();
-	InputTypeFields::const_iterator getInputTypeFields(std::string_view name);
-	static const ValidateType& getValidateFieldType(const FieldTypes::mapped_type& value);
-	static const ValidateType& getValidateFieldType(const InputFieldTypes::mapped_type& value);
+	[[nodiscard]] TypeFields::const_iterator getScopedTypeFields();
+	[[nodiscard]] InputTypeFields::const_iterator getInputTypeFields(std::string_view name);
+	[[nodiscard]] static const ValidateType& getValidateFieldType(
+		const FieldTypes::mapped_type& value);
+	[[nodiscard]] static const ValidateType& getValidateFieldType(
+		const InputFieldTypes::mapped_type& value);
 	template <class _FieldTypes>
-	static ValidateType getFieldType(const _FieldTypes& fields, std::string_view name);
+	[[nodiscard]] static ValidateType getFieldType(
+		const _FieldTypes& fields, std::string_view name);
 	template <class _FieldTypes>
-	static ValidateType getWrappedFieldType(const _FieldTypes& fields, std::string_view name);
+	[[nodiscard]] static ValidateType getWrappedFieldType(
+		const _FieldTypes& fields, std::string_view name);
 
 	void visitFragmentDefinition(const peg::ast_node& fragmentDefinition);
 	void visitOperationDefinition(const peg::ast_node& operationDefinition);
@@ -211,9 +215,9 @@ private:
 	void visitDirectives(
 		introspection::DirectiveLocation location, const peg::ast_node& directives);
 
-	bool validateInputValue(bool hasNonNullDefaultValue, const ValidateArgumentValuePtr& argument,
-		const ValidateType& type);
-	bool validateVariableType(bool isNonNull, const ValidateType& variableType,
+	[[nodiscard]] bool validateInputValue(bool hasNonNullDefaultValue,
+		const ValidateArgumentValuePtr& argument, const ValidateType& type);
+	[[nodiscard]] bool validateVariableType(bool isNonNull, const ValidateType& variableType,
 		const schema_location& position, const ValidateType& inputType);
 
 	const std::shared_ptr<schema::Schema> _schema;

--- a/include/graphqlservice/GraphQLParse.h
+++ b/include/graphqlservice/GraphQLParse.h
@@ -27,7 +27,7 @@ namespace peg {
 class ast_node;
 struct ast_input;
 
-struct ast
+struct [[nodiscard]] ast
 {
 	std::shared_ptr<ast_input> input;
 	std::shared_ptr<ast_node> root;
@@ -38,17 +38,19 @@ struct ast
 // another value for the depthLimit parameter in these parse functions.
 constexpr size_t c_defaultDepthLimit = 25;
 
-GRAPHQLPEG_EXPORT ast parseSchemaString(
+GRAPHQLPEG_EXPORT [[nodiscard]] ast parseSchemaString(
 	std::string_view input, size_t depthLimit = c_defaultDepthLimit);
-GRAPHQLPEG_EXPORT ast parseSchemaFile(
+GRAPHQLPEG_EXPORT [[nodiscard]] ast parseSchemaFile(
 	std::string_view filename, size_t depthLimit = c_defaultDepthLimit);
 
-GRAPHQLPEG_EXPORT ast parseString(std::string_view input, size_t depthLimit = c_defaultDepthLimit);
-GRAPHQLPEG_EXPORT ast parseFile(std::string_view filename, size_t depthLimit = c_defaultDepthLimit);
+GRAPHQLPEG_EXPORT [[nodiscard]] ast parseString(
+	std::string_view input, size_t depthLimit = c_defaultDepthLimit);
+GRAPHQLPEG_EXPORT [[nodiscard]] ast parseFile(
+	std::string_view filename, size_t depthLimit = c_defaultDepthLimit);
 
 } // namespace peg
 
-GRAPHQLPEG_EXPORT peg::ast operator"" _graphql(const char* text, size_t size);
+GRAPHQLPEG_EXPORT [[nodiscard]] peg::ast operator"" _graphql(const char* text, size_t size);
 
 } // namespace graphql
 

--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -33,8 +33,7 @@ namespace graphql::response {
 // GraphQL responses are not technically JSON-specific, although that is probably the most common
 // way of representing them. These are the primitive types that may be represented in GraphQL, as
 // of the [October 2021 spec](https://spec.graphql.org/October2021/#sec-Serialization-Format).
-enum class Type : std::uint8_t
-{
+enum class [[nodiscard]] Type : std::uint8_t {
 	Map,	   // JSON Object
 	List,	   // JSON Array
 	String,	   // JSON String
@@ -57,7 +56,7 @@ using IntType = int;
 using FloatType = double;
 using ScalarType = Value;
 
-struct IdType
+struct [[nodiscard]] IdType
 {
 	using ByteData = std::vector<std::uint8_t>;
 	using OpaqueString = std::string;
@@ -84,20 +83,20 @@ struct IdType
 	GRAPHQLRESPONSE_EXPORT IdType& operator=(OpaqueString&& opaque) noexcept;
 
 	template <typename ValueType>
-	const ValueType& get() const;
+	[[nodiscard]] const ValueType& get() const;
 
 	template <typename ValueType>
-	ValueType release();
+	[[nodiscard]] ValueType release();
 
 	// Comparison
-	GRAPHQLRESPONSE_EXPORT bool operator==(const IdType& rhs) const noexcept;
-	GRAPHQLRESPONSE_EXPORT bool operator==(const ByteData& rhs) const noexcept;
-	GRAPHQLRESPONSE_EXPORT bool operator==(const OpaqueString& rhs) const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool operator==(const IdType& rhs) const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool operator==(const ByteData& rhs) const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool operator==(const OpaqueString& rhs) const noexcept;
 
-	GRAPHQLRESPONSE_EXPORT bool operator<(const IdType& rhs) const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool operator<(const IdType& rhs) const noexcept;
 
 	// Check the Type
-	GRAPHQLRESPONSE_EXPORT bool isBase64() const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool isBase64() const noexcept;
 
 private:
 	std::variant<ByteData, OpaqueString> _data;
@@ -167,7 +166,7 @@ struct ValueTypeTraits<FloatType>
 };
 
 // Represent a discriminated union of GraphQL response value types.
-struct Value
+struct [[nodiscard]] Value
 {
 	GRAPHQLRESPONSE_EXPORT Value(Type type = Type::Null);
 	GRAPHQLRESPONSE_EXPORT ~Value();
@@ -188,37 +187,37 @@ struct Value
 	Value& operator=(const Value& rhs) = delete;
 
 	// Comparison
-	GRAPHQLRESPONSE_EXPORT bool operator==(const Value& rhs) const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool operator==(const Value& rhs) const noexcept;
 
 	// Check the Type
-	GRAPHQLRESPONSE_EXPORT Type type() const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] Type type() const noexcept;
 
 	// JSON doesn't distinguish between Type::String, Type::EnumValue, and Type::ID, so if this
 	// value comes from JSON and it's a string we need to track the fact that it can be interpreted
 	// as any of those types.
-	GRAPHQLRESPONSE_EXPORT Value&& from_json() noexcept;
-	GRAPHQLRESPONSE_EXPORT bool maybe_enum() const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] Value&& from_json() noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool maybe_enum() const noexcept;
 
 	// Input values don't distinguish between Type::String and Type::ID, so if this value comes from
 	// a string literal input value we need to track that fact that it can be interpreted as either
 	// of those types.
-	GRAPHQLRESPONSE_EXPORT Value&& from_input() noexcept;
-	GRAPHQLRESPONSE_EXPORT bool maybe_id() const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] Value&& from_input() noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool maybe_id() const noexcept;
 
 	// Valid for Type::Map or Type::List
 	GRAPHQLRESPONSE_EXPORT void reserve(size_t count);
-	GRAPHQLRESPONSE_EXPORT size_t size() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] size_t size() const;
 
 	// Valid for Type::Map
 	GRAPHQLRESPONSE_EXPORT bool emplace_back(std::string&& name, Value&& value);
-	GRAPHQLRESPONSE_EXPORT MapType::const_iterator find(std::string_view name) const;
-	GRAPHQLRESPONSE_EXPORT MapType::const_iterator begin() const;
-	GRAPHQLRESPONSE_EXPORT MapType::const_iterator end() const;
-	GRAPHQLRESPONSE_EXPORT const Value& operator[](std::string_view name) const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] MapType::const_iterator find(std::string_view name) const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] MapType::const_iterator begin() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] MapType::const_iterator end() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] const Value& operator[](std::string_view name) const;
 
 	// Valid for Type::List
 	GRAPHQLRESPONSE_EXPORT void emplace_back(Value&& value);
-	GRAPHQLRESPONSE_EXPORT const Value& operator[](size_t index) const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] const Value& operator[](size_t index) const;
 
 	// Specialized for all single-value Types.
 	template <typename ValueType>
@@ -228,28 +227,28 @@ struct Value
 
 	// Specialized for all Types.
 	template <typename ValueType>
-	typename std::enable_if_t<std::is_same_v<std::decay_t<ValueType>, ValueType>,
+	[[nodiscard]] typename std::enable_if_t<std::is_same_v<std::decay_t<ValueType>, ValueType>,
 		typename ValueTypeTraits<ValueType>::get_type>
 	get() const;
 
 	// Specialized for all Types which allocate extra memory.
 	template <typename ValueType>
-	typename ValueTypeTraits<ValueType>::release_type release();
+	[[nodiscard]] typename ValueTypeTraits<ValueType>::release_type release();
 
 private:
 	// Type::Map
-	struct MapData
+	struct [[nodiscard]] MapData
 	{
-		bool operator==(const MapData& rhs) const;
+		[[nodiscard]] bool operator==(const MapData& rhs) const;
 
 		MapType map;
 		std::vector<size_t> members;
 	};
 
 	// Type::String
-	struct StringData
+	struct [[nodiscard]] StringData
 	{
-		bool operator==(const StringData& rhs) const;
+		[[nodiscard]] bool operator==(const StringData& rhs) const;
 
 		StringType string;
 		bool from_json = false;
@@ -257,18 +256,18 @@ private:
 	};
 
 	// Type::Null
-	struct NullData
+	struct [[nodiscard]] NullData
 	{
-		bool operator==(const NullData& rhs) const;
+		[[nodiscard]] bool operator==(const NullData& rhs) const;
 	};
 
 	// Type::EnumValue
 	using EnumData = StringType;
 
 	// Type::Scalar
-	struct ScalarData
+	struct [[nodiscard]] ScalarData
 	{
-		bool operator==(const ScalarData& rhs) const;
+		[[nodiscard]] bool operator==(const ScalarData& rhs) const;
 
 		std::unique_ptr<ScalarType> scalar;
 	};
@@ -278,9 +277,9 @@ private:
 	using TypeData = std::variant<MapData, ListType, StringData, NullData, BooleanType, IntType,
 		FloatType, EnumData, IdType, ScalarData, SharedData>;
 
-	const TypeData& data() const noexcept;
+	[[nodiscard]] const TypeData& data() const noexcept;
 
-	static Type typeOf(const TypeData& data) noexcept;
+	[[nodiscard]] static Type typeOf(const TypeData& data) noexcept;
 
 	TypeData _data;
 };
@@ -329,7 +328,7 @@ GRAPHQLRESPONSE_EXPORT IdType Value::release<IdType>();
 
 using AwaitableValue = internal::Awaitable<Value>;
 
-class Writer final
+class [[nodiscard]] Writer final
 {
 private:
 	struct Concept

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -39,8 +39,8 @@
 #include <string>
 #include <string_view>
 #include <thread>
-#include <tuple>
 #include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -54,7 +54,7 @@ class Schema;
 namespace service {
 
 // Errors should have a message string, and optional locations and a path.
-struct schema_location
+struct [[nodiscard]] schema_location
 {
 	size_t line = 0;
 	size_t column = 1;
@@ -65,7 +65,7 @@ struct schema_location
 // from an accessor as part of error reporting.
 using path_segment = std::variant<std::string_view, size_t>;
 
-struct field_path
+struct [[nodiscard]] field_path
 {
 	std::optional<std::reference_wrapper<const field_path>> parent;
 	std::variant<std::string_view, size_t> segment;
@@ -73,19 +73,21 @@ struct field_path
 
 using error_path = std::vector<path_segment>;
 
-GRAPHQLSERVICE_EXPORT error_path buildErrorPath(const std::optional<field_path>& path);
+GRAPHQLSERVICE_EXPORT [[nodiscard]] error_path buildErrorPath(
+	const std::optional<field_path>& path);
 
-struct schema_error
+struct [[nodiscard]] schema_error
 {
 	std::string message;
 	schema_location location {};
 	error_path path {};
 };
 
-GRAPHQLSERVICE_EXPORT response::Value buildErrorValues(std::list<schema_error>&& structuredErrors);
+GRAPHQLSERVICE_EXPORT [[nodiscard]] response::Value buildErrorValues(
+	std::list<schema_error>&& structuredErrors);
 
 // This exception bubbles up 1 or more error messages to the JSON results.
-class schema_exception : public std::exception
+class [[nodiscard]] schema_exception : public std::exception
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit schema_exception(std::list<schema_error>&& structuredErrors);
@@ -93,13 +95,14 @@ public:
 
 	schema_exception() = delete;
 
-	GRAPHQLSERVICE_EXPORT const char* what() const noexcept override;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const char* what() const noexcept override;
 
-	GRAPHQLSERVICE_EXPORT std::list<schema_error> getStructuredErrors() noexcept;
-	GRAPHQLSERVICE_EXPORT response::Value getErrors();
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::list<schema_error> getStructuredErrors() noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] response::Value getErrors();
 
 private:
-	static std::list<schema_error> convertMessages(std::vector<std::string>&& messages) noexcept;
+	[[nodiscard]] static std::list<schema_error> convertMessages(
+		std::vector<std::string>&& messages) noexcept;
 
 	std::list<schema_error> _structuredErrors;
 };
@@ -108,7 +111,7 @@ private:
 // any per-request state that you want to maintain throughout the request (e.g. optimizing or
 // batching backend requests), you can inherit from RequestState and pass it to Request::resolve to
 // correlate the asynchronous/recursive callbacks and accumulate state in it.
-struct RequestState : std::enable_shared_from_this<RequestState>
+struct [[nodiscard]] RequestState : std::enable_shared_from_this<RequestState>
 {
 	virtual ~RequestState() = default;
 };
@@ -131,8 +134,7 @@ constexpr std::string_view strSubscription { "subscription"sv };
 } // namespace
 
 // Resolvers may be called in multiple different Operation contexts.
-enum class ResolverContext
-{
+enum class [[nodiscard]] ResolverContext {
 	// Resolving a Query operation.
 	Query,
 
@@ -153,19 +155,19 @@ enum class ResolverContext
 
 // Resume coroutine execution on a new worker thread any time co_await is called. This emulates the
 // behavior of std::async when passing std::launch::async.
-struct await_worker_thread : coro::suspend_always
+struct [[nodiscard]] await_worker_thread : coro::suspend_always
 {
 	GRAPHQLSERVICE_EXPORT void await_suspend(coro::coroutine_handle<> h) const;
 };
 
 // Queue coroutine execution on a single dedicated worker thread any time co_await is called from
 // the thread which created it.
-struct await_worker_queue : coro::suspend_always
+struct [[nodiscard]] await_worker_queue : coro::suspend_always
 {
 	GRAPHQLSERVICE_EXPORT await_worker_queue();
 	GRAPHQLSERVICE_EXPORT ~await_worker_queue();
 
-	GRAPHQLSERVICE_EXPORT bool await_ready() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] bool await_ready() const;
 	GRAPHQLSERVICE_EXPORT void await_suspend(coro::coroutine_handle<> h);
 
 private:
@@ -180,27 +182,27 @@ private:
 };
 
 // Type-erased awaitable.
-class await_async final
+class [[nodiscard]] await_async final
 {
 private:
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual bool await_ready() const = 0;
+		[[nodiscard]] virtual bool await_ready() const = 0;
 		virtual void await_suspend(coro::coroutine_handle<> h) const = 0;
 		virtual void await_resume() const = 0;
 	};
 
 	template <class T>
-	struct Model : Concept
+	struct [[nodiscard]] Model : Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl)
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		bool await_ready() const final
+		[[nodiscard]] bool await_ready() const final
 		{
 			return _pimpl->await_ready();
 		}
@@ -235,7 +237,7 @@ public:
 	// Implicitly convert a std::launch parameter used with std::async to an awaitable.
 	GRAPHQLSERVICE_EXPORT await_async(std::launch launch);
 
-	GRAPHQLSERVICE_EXPORT bool await_ready() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] bool await_ready() const;
 	GRAPHQLSERVICE_EXPORT void await_suspend(coro::coroutine_handle<> h) const;
 	GRAPHQLSERVICE_EXPORT void await_resume() const;
 };
@@ -251,7 +253,7 @@ using FragmentSpreadDirectiveStack = std::list<Directives>;
 
 // Pass a common bundle of parameters to all of the generated Object::getField accessors in a
 // SelectionSet
-struct SelectionSetParams
+struct [[nodiscard]] SelectionSetParams
 {
 	// Context for this selection set.
 	const ResolverContext resolverContext;
@@ -276,7 +278,7 @@ struct SelectionSetParams
 };
 
 // Pass a common bundle of parameters to all of the generated Object::getField accessors.
-struct FieldParams : SelectionSetParams
+struct [[nodiscard]] FieldParams : SelectionSetParams
 {
 	GRAPHQLSERVICE_EXPORT explicit FieldParams(
 		SelectionSetParams&& selectionSetParams, Directives directives);
@@ -294,7 +296,7 @@ struct FieldParams : SelectionSetParams
 // If the overhead of conversion to response::Value is too expensive, scalar type field accessors
 // can store and return a std::shared_ptr<const response::Value> directly.
 template <typename T>
-class AwaitableScalar
+class [[nodiscard]] AwaitableScalar
 {
 public:
 	template <typename U>
@@ -305,7 +307,7 @@ public:
 
 	struct promise_type
 	{
-		AwaitableScalar<T> get_return_object() noexcept
+		[[nodiscard]] AwaitableScalar<T> get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
@@ -339,7 +341,7 @@ public:
 		std::promise<T> _promise;
 	};
 
-	bool await_ready() const noexcept
+	[[nodiscard]] bool await_ready() const noexcept
 	{
 		return std::visit(
 			[](const auto& value) noexcept {
@@ -375,7 +377,7 @@ public:
 			.detach();
 	}
 
-	T await_resume()
+	[[nodiscard]] T await_resume()
 	{
 		return std::visit(
 			[](auto&& value) -> T {
@@ -398,7 +400,7 @@ public:
 			std::move(_value));
 	}
 
-	std::shared_ptr<const response::Value> get_value() noexcept
+	[[nodiscard]] std::shared_ptr<const response::Value> get_value() noexcept
 	{
 		return std::visit(
 			[](auto&& value) noexcept {
@@ -423,7 +425,7 @@ private:
 // runtime the implementer may choose to return by value or defer/parallelize expensive operations
 // by returning an async future or an awaitable coroutine.
 template <typename T>
-class AwaitableObject
+class [[nodiscard]] AwaitableObject
 {
 public:
 	template <typename U>
@@ -434,7 +436,7 @@ public:
 
 	struct promise_type
 	{
-		AwaitableObject<T> get_return_object() noexcept
+		[[nodiscard]] AwaitableObject<T> get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
@@ -468,7 +470,7 @@ public:
 		std::promise<T> _promise;
 	};
 
-	bool await_ready() const noexcept
+	[[nodiscard]] bool await_ready() const noexcept
 	{
 		return std::visit(
 			[](const auto& value) noexcept {
@@ -499,7 +501,7 @@ public:
 			.detach();
 	}
 
-	T await_resume()
+	[[nodiscard]] T await_resume()
 	{
 		return std::visit(
 			[](auto&& value) -> T {
@@ -524,14 +526,14 @@ private:
 // Fragments are referenced by name and have a single type condition (except for inline
 // fragments, where the type condition is common but optional). They contain a set of fields
 // (with optional aliases and sub-selections) and potentially references to other fragments.
-class Fragment
+class [[nodiscard]] Fragment
 {
 public:
 	explicit Fragment(const peg::ast_node& fragmentDefinition, const response::Value& variables);
 
-	std::string_view getType() const;
-	const peg::ast_node& getSelection() const;
-	const Directives& getDirectives() const;
+	[[nodiscard]] std::string_view getType() const;
+	[[nodiscard]] const peg::ast_node& getSelection() const;
+	[[nodiscard]] const Directives& getDirectives() const;
 
 private:
 	std::string_view _type;
@@ -547,14 +549,14 @@ using FragmentMap = internal::string_view_map<Fragment>;
 // Resolver functors take a set of arguments encoded as members on a JSON object
 // with an optional selection set for complex types and return a JSON value for
 // a single field.
-struct ResolverParams : SelectionSetParams
+struct [[nodiscard]] ResolverParams : SelectionSetParams
 {
 	GRAPHQLSERVICE_EXPORT explicit ResolverParams(const SelectionSetParams& selectionSetParams,
 		const peg::ast_node& field, std::string&& fieldName, response::Value arguments,
 		Directives fieldDirectives, const peg::ast_node* selection, const FragmentMap& fragments,
 		const response::Value& variables);
 
-	GRAPHQLSERVICE_EXPORT schema_location getLocation() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] schema_location getLocation() const;
 
 	// These values are different for each resolver.
 	const peg::ast_node& field;
@@ -571,7 +573,7 @@ struct ResolverParams : SelectionSetParams
 
 // Propagate data and errors together without bundling them into a response::Value struct until
 // we're ready to return from the top level Operation.
-struct ResolverResult
+struct [[nodiscard]] ResolverResult
 {
 	response::Value data;
 	std::list<schema_error> errors {};
@@ -584,8 +586,7 @@ using ResolverMap = internal::string_view_map<Resolver>;
 // GraphQL types are nullable by default, but they may be wrapped with non-null or list types.
 // Since nullability is a more special case in C++, we invert the default and apply that modifier
 // instead when the non-null wrapper is not present in that part of the wrapper chain.
-enum class TypeModifier
-{
+enum class [[nodiscard]] TypeModifier {
 	None,
 	Nullable,
 	List,
@@ -593,7 +594,7 @@ enum class TypeModifier
 
 // Specialized to return true for all INPUT_OBJECT types.
 template <typename Type>
-constexpr bool isInputType() noexcept
+[[nodiscard]] constexpr bool isInputType() noexcept
 {
 	return false;
 }
@@ -607,7 +608,7 @@ struct ModifiedArgument
 {
 	// Special-case an innermost nullable INPUT_OBJECT type.
 	template <TypeModifier... Other>
-	static constexpr bool onlyNoneModifiers() noexcept
+	[[nodiscard]] static constexpr bool onlyNoneModifiers() noexcept
 	{
 		return (... && (Other == TypeModifier::None));
 	}
@@ -631,10 +632,10 @@ struct ModifiedArgument
 	};
 
 	// Convert a single value to the specified type.
-	static Type convert(const response::Value& value);
+	[[nodiscard]] static Type convert(const response::Value& value);
 
 	// Call convert on this type without any modifiers.
-	static Type require(std::string_view name, const response::Value& arguments)
+	[[nodiscard]] static Type require(std::string_view name, const response::Value& arguments)
 	{
 		try
 		{
@@ -658,7 +659,7 @@ struct ModifiedArgument
 	}
 
 	// Wrap require in a try/catch block.
-	static std::pair<Type, bool> find(
+	[[nodiscard]] static std::pair<Type, bool> find(
 		const std::string& name, const response::Value& arguments) noexcept
 	{
 		try
@@ -673,7 +674,7 @@ struct ModifiedArgument
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	static typename std::enable_if_t<TypeModifier::None == Modifier, Type> require(
+	[[nodiscard]] static typename std::enable_if_t<TypeModifier::None == Modifier, Type> require(
 		std::string_view name, const response::Value& arguments)
 	{
 		static_assert(sizeof...(Other) == 0, "None modifier should always be last");
@@ -684,7 +685,7 @@ struct ModifiedArgument
 
 	// Peel off nullable modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	static typename std::enable_if_t<TypeModifier::Nullable == Modifier,
+	[[nodiscard]] static typename std::enable_if_t<TypeModifier::Nullable == Modifier,
 		typename ArgumentTraits<Type, Modifier, Other...>::type>
 	require(std::string_view name, const response::Value& arguments)
 	{
@@ -710,7 +711,7 @@ struct ModifiedArgument
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	static typename std::enable_if_t<TypeModifier::List == Modifier,
+	[[nodiscard]] static typename std::enable_if_t<TypeModifier::List == Modifier,
 		typename ArgumentTraits<Type, Modifier, Other...>::type>
 	require(std::string_view name, const response::Value& arguments)
 	{
@@ -734,8 +735,8 @@ struct ModifiedArgument
 
 	// Wrap require with modifiers in a try/catch block.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	static std::pair<typename ArgumentTraits<Type, Modifier, Other...>::type, bool> find(
-		std::string_view name, const response::Value& arguments) noexcept
+	[[nodiscard]] static std::pair<typename ArgumentTraits<Type, Modifier, Other...>::type, bool>
+	find(std::string_view name, const response::Value& arguments) noexcept
 	{
 		try
 		{
@@ -785,17 +786,17 @@ using TypeNames = internal::string_view_set;
 // and @skip directives, and calls through to the resolver functor for each selected field with
 // its arguments. This may be a recursive process for fields which return another complex type,
 // in which case it requires its own selection set.
-class Object : public std::enable_shared_from_this<Object>
+class [[nodiscard]] Object : public std::enable_shared_from_this<Object>
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit Object(TypeNames&& typeNames, ResolverMap&& resolvers) noexcept;
 	GRAPHQLSERVICE_EXPORT virtual ~Object() = default;
 
-	GRAPHQLSERVICE_EXPORT AwaitableResolver resolve(const SelectionSetParams& selectionSetParams,
-		const peg::ast_node& selection, const FragmentMap& fragments,
-		const response::Value& variables) const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] AwaitableResolver resolve(
+		const SelectionSetParams& selectionSetParams, const peg::ast_node& selection,
+		const FragmentMap& fragments, const response::Value& variables) const;
 
-	GRAPHQLSERVICE_EXPORT bool matchesType(std::string_view typeName) const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] bool matchesType(std::string_view typeName) const;
 
 protected:
 	// These callbacks are optional, you may override either, both, or neither of them. The
@@ -847,12 +848,12 @@ struct ModifiedResult
 	};
 
 	// Convert a single value of the specified type to JSON.
-	static AwaitableResolver convert(
+	[[nodiscard]] static AwaitableResolver convert(
 		typename ResultTraits<Type>::future_type result, ResolverParams params);
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	static typename std::enable_if_t<TypeModifier::None == Modifier
+	[[nodiscard]] static typename std::enable_if_t<TypeModifier::None == Modifier
 			&& !std::is_same_v<Object, Type> && std::is_base_of_v<Object, Type>,
 		AwaitableResolver>
 	convert(AwaitableObject<typename ResultTraits<Type>::type> result, ResolverParams params)
@@ -874,7 +875,7 @@ struct ModifiedResult
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	static typename std::enable_if_t<TypeModifier::None == Modifier
+	[[nodiscard]] static typename std::enable_if_t<TypeModifier::None == Modifier
 			&& (std::is_same_v<Object, Type> || !std::is_base_of_v<Object, Type>),
 		AwaitableResolver>
 	convert(typename ResultTraits<Type>::future_type result, ResolverParams params)
@@ -887,7 +888,7 @@ struct ModifiedResult
 
 	// Peel off final nullable modifiers for std::shared_ptr of Object and subclasses of Object.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	static typename std::enable_if_t<TypeModifier::Nullable == Modifier
+	[[nodiscard]] static typename std::enable_if_t<TypeModifier::Nullable == Modifier
 			&& std::is_same_v<std::shared_ptr<Type>, typename ResultTraits<Type, Other...>::type>,
 		AwaitableResolver>
 	convert(
@@ -910,7 +911,7 @@ struct ModifiedResult
 
 	// Peel off nullable modifiers for anything else, which should all be std::optional.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	static typename std::enable_if_t<TypeModifier::Nullable == Modifier
+	[[nodiscard]] static typename std::enable_if_t<TypeModifier::Nullable == Modifier
 			&& !std::is_same_v<std::shared_ptr<Type>, typename ResultTraits<Type, Other...>::type>,
 		AwaitableResolver>
 	convert(
@@ -949,8 +950,10 @@ struct ModifiedResult
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	static typename std::enable_if_t<TypeModifier::List == Modifier, AwaitableResolver> convert(
-		typename ResultTraits<Type, Modifier, Other...>::future_type result, ResolverParams params)
+	[[nodiscard]] static
+		typename std::enable_if_t<TypeModifier::List == Modifier, AwaitableResolver>
+		convert(typename ResultTraits<Type, Modifier, Other...>::future_type result,
+			ResolverParams params)
 	{
 		if constexpr (!std::is_base_of_v<Object, Type>)
 		{
@@ -1093,7 +1096,7 @@ private:
 	using ResolverCallback =
 		std::function<response::Value(typename ResultTraits<Type>::type, const ResolverParams&)>;
 
-	static AwaitableResolver resolve(typename ResultTraits<Type>::future_type result,
+	[[nodiscard]] static AwaitableResolver resolve(typename ResultTraits<Type>::future_type result,
 		ResolverParams params, ResolverCallback&& resolver)
 	{
 		static_assert(!std::is_base_of_v<Object, Type>,
@@ -1204,7 +1207,7 @@ using AwaitableSubscribe = internal::Awaitable<SubscriptionKey>;
 using AwaitableUnsubscribe = internal::Awaitable<void>;
 using AwaitableDeliver = internal::Awaitable<void>;
 
-struct RequestResolveParams
+struct [[nodiscard]] RequestResolveParams
 {
 	// Required query information.
 	peg::ast& query;
@@ -1218,7 +1221,7 @@ struct RequestResolveParams
 	std::shared_ptr<RequestState> state {};
 };
 
-struct RequestSubscribeParams
+struct [[nodiscard]] RequestSubscribeParams
 {
 	// Callback which receives the event data.
 	SubscriptionCallback callback;
@@ -1235,7 +1238,7 @@ struct RequestSubscribeParams
 	std::shared_ptr<RequestState> state {};
 };
 
-struct RequestUnsubscribeParams
+struct [[nodiscard]] RequestUnsubscribeParams
 {
 	// Key returned by a previous call to subscribe.
 	SubscriptionKey key;
@@ -1248,7 +1251,7 @@ using SubscriptionArguments = std::map<std::string_view, response::Value>;
 using SubscriptionArgumentFilterCallback = std::function<bool(response::MapType::const_reference)>;
 using SubscriptionDirectiveFilterCallback = std::function<bool(Directives::const_reference)>;
 
-struct SubscriptionFilter
+struct [[nodiscard]] SubscriptionFilter
 {
 	// Optional field argument filter, which can either be a set of required arguments, or a
 	// callback which returns true if the arguments match custom criteria.
@@ -1264,7 +1267,7 @@ struct SubscriptionFilter
 // and directives in the Subscription query.
 using RequestDeliverFilter = std::optional<std::variant<SubscriptionKey, SubscriptionFilter>>;
 
-struct RequestDeliverParams
+struct [[nodiscard]] RequestDeliverParams
 {
 	// Deliver to subscriptions on this field.
 	std::string_view field;
@@ -1288,7 +1291,7 @@ using TypeMap = internal::string_view_map<std::shared_ptr<const Object>>;
 // it's up to the caller to guarantee the lifetime of the AST exceeds the futures we return.
 // Subscription operations need to hold onto the queries in SubscriptionData, so the lifetime is
 // already tied to the registration and any pending futures passed to callbacks.
-struct OperationData : std::enable_shared_from_this<OperationData>
+struct [[nodiscard]] OperationData : std::enable_shared_from_this<OperationData>
 {
 	explicit OperationData(std::shared_ptr<RequestState> state, response::Value variables,
 		Directives directives, FragmentMap fragments);
@@ -1300,7 +1303,7 @@ struct OperationData : std::enable_shared_from_this<OperationData>
 };
 
 // Registration information for subscription, cached in the Request::subscribe call.
-struct SubscriptionData : std::enable_shared_from_this<SubscriptionData>
+struct [[nodiscard]] SubscriptionData : std::enable_shared_from_this<SubscriptionData>
 {
 	explicit SubscriptionData(std::shared_ptr<OperationData> data, SubscriptionName&& field,
 		response::Value arguments, Directives fieldDirectives, peg::ast&& query,
@@ -1324,7 +1327,7 @@ class ValidateExecutableVisitor;
 // Request scans the fragment definitions and finds the right operation definition to interpret
 // depending on the operation name (which might be empty for a single-operation document). It
 // also needs the values of the request variables.
-class Request : public std::enable_shared_from_this<Request>
+class [[nodiscard]] Request : public std::enable_shared_from_this<Request>
 {
 protected:
 	GRAPHQLSERVICE_EXPORT explicit Request(
@@ -1332,20 +1335,22 @@ protected:
 	GRAPHQLSERVICE_EXPORT virtual ~Request();
 
 public:
-	GRAPHQLSERVICE_EXPORT std::list<schema_error> validate(peg::ast& query) const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::list<schema_error> validate(peg::ast& query) const;
 
-	GRAPHQLSERVICE_EXPORT std::pair<std::string_view, const peg::ast_node*> findOperationDefinition(
-		peg::ast& query, std::string_view operationName) const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::pair<std::string_view, const peg::ast_node*>
+	findOperationDefinition(peg::ast& query, std::string_view operationName) const;
 
-	GRAPHQLSERVICE_EXPORT response::AwaitableValue resolve(RequestResolveParams params) const;
-	GRAPHQLSERVICE_EXPORT AwaitableSubscribe subscribe(RequestSubscribeParams params);
-	GRAPHQLSERVICE_EXPORT AwaitableUnsubscribe unsubscribe(RequestUnsubscribeParams params);
-	GRAPHQLSERVICE_EXPORT AwaitableDeliver deliver(RequestDeliverParams params) const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] response::AwaitableValue resolve(
+		RequestResolveParams params) const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] AwaitableSubscribe subscribe(RequestSubscribeParams params);
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] AwaitableUnsubscribe unsubscribe(
+		RequestUnsubscribeParams params);
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] AwaitableDeliver deliver(RequestDeliverParams params) const;
 
 private:
-	SubscriptionKey addSubscription(RequestSubscribeParams&& params);
+	[[nodiscard]] SubscriptionKey addSubscription(RequestSubscribeParams&& params);
 	void removeSubscription(SubscriptionKey key);
-	std::vector<std::shared_ptr<const SubscriptionData>> collectRegistrations(
+	[[nodiscard]] std::vector<std::shared_ptr<const SubscriptionData>> collectRegistrations(
 		std::string_view field, RequestDeliverFilter&& filter) const noexcept;
 
 	const TypeMap _operations;

--- a/include/graphqlservice/JSONResponse.h
+++ b/include/graphqlservice/JSONResponse.h
@@ -22,9 +22,9 @@
 
 namespace graphql::response {
 
-JSONRESPONSE_EXPORT std::string toJSON(Value&& response);
+JSONRESPONSE_EXPORT [[nodiscard]] std::string toJSON(Value&& response);
 
-JSONRESPONSE_EXPORT Value parseJSON(const std::string& json);
+JSONRESPONSE_EXPORT [[nodiscard]] Value parseJSON(const std::string& json);
 
 } // namespace graphql::response
 

--- a/include/graphqlservice/internal/Awaitable.h
+++ b/include/graphqlservice/internal/Awaitable.h
@@ -22,10 +22,10 @@
 namespace graphql::internal {
 
 template <typename T>
-class Awaitable;
+class [[nodiscard]] Awaitable;
 
 template <>
-class Awaitable<void>
+class [[nodiscard]] Awaitable<void>
 {
 public:
 	Awaitable(std::future<void> value)
@@ -89,7 +89,7 @@ private:
 };
 
 template <typename T>
-class Awaitable
+class [[nodiscard]] Awaitable
 {
 public:
 	Awaitable(std::future<T> value)

--- a/include/graphqlservice/internal/Base64.h
+++ b/include/graphqlservice/internal/Base64.h
@@ -30,7 +30,7 @@ class Base64
 {
 public:
 	// Map a single Base64-encoded character to its 6-bit integer value.
-	static constexpr std::uint8_t fromBase64(char ch) noexcept
+	[[nodiscard]] static constexpr std::uint8_t fromBase64(char ch) noexcept
 	{
 		return (ch >= 'A' && ch <= 'Z'
 				? ch - 'A'
@@ -41,10 +41,11 @@ public:
 	}
 
 	// Convert a Base64-encoded string to a vector of bytes.
-	GRAPHQLRESPONSE_EXPORT static std::vector<std::uint8_t> fromBase64(std::string_view encoded);
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] static std::vector<std::uint8_t> fromBase64(
+		std::string_view encoded);
 
 	// Map a single 6-bit integer value to its Base64-encoded character.
-	static constexpr char toBase64(std::uint8_t i) noexcept
+	[[nodiscard]] static constexpr char toBase64(std::uint8_t i) noexcept
 	{
 		return (i < 26
 				? static_cast<char>(i + static_cast<std::uint8_t>('A'))
@@ -54,10 +55,10 @@ public:
 	}
 
 	// Convert a set of bytes to Base64.
-	GRAPHQLRESPONSE_EXPORT static std::string toBase64(const std::vector<std::uint8_t>& bytes);
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] static std::string toBase64(
+		const std::vector<std::uint8_t>& bytes);
 
-	enum class Comparison
-	{
+	enum class [[nodiscard]] Comparison {
 		LessThan = -1,
 		EqualTo = 0,
 		GreaterThan = 1,
@@ -66,20 +67,21 @@ public:
 	};
 
 	// Compare a set of bytes to a possible Base64 string without performing any heap allocations.
-	GRAPHQLRESPONSE_EXPORT static Comparison compareBase64(
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] static Comparison compareBase64(
 		const std::vector<std::uint8_t>& bytes, std::string_view maybeEncoded) noexcept;
 
 	// Validate whether or not a string is valid Base64 without performing any heap allocations.
-	GRAPHQLRESPONSE_EXPORT static bool validateBase64(std::string_view maybeEncoded) noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard]] static bool validateBase64(
+		std::string_view maybeEncoded) noexcept;
 
 private:
 	static constexpr char padding = '=';
 
 	// Throw a std::logic_error if the character is out of range.
-	static std::uint8_t verifyFromBase64(char ch);
+	[[nodiscard]] static std::uint8_t verifyFromBase64(char ch);
 
 	// Throw a std::logic_error if the integer is out of range.
-	static char verifyToBase64(std::uint8_t i);
+	[[nodiscard]] static char verifyToBase64(std::uint8_t i);
 };
 
 } // namespace graphql::internal

--- a/include/graphqlservice/internal/Introspection.h
+++ b/include/graphqlservice/internal/Introspection.h
@@ -19,111 +19,115 @@ class Field;
 class InputValue;
 class EnumValue;
 
-class Schema
+class [[nodiscard]] Schema
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit Schema(const std::shared_ptr<schema::Schema>& schema);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::optional<std::string> getDescription() const;
-	GRAPHQLSERVICE_EXPORT std::vector<std::shared_ptr<object::Type>> getTypes() const;
-	GRAPHQLSERVICE_EXPORT std::shared_ptr<object::Type> getQueryType() const;
-	GRAPHQLSERVICE_EXPORT std::shared_ptr<object::Type> getMutationType() const;
-	GRAPHQLSERVICE_EXPORT std::shared_ptr<object::Type> getSubscriptionType() const;
-	GRAPHQLSERVICE_EXPORT std::vector<std::shared_ptr<object::Directive>> getDirectives()
-		const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDescription() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::vector<std::shared_ptr<object::Type>> getTypes() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<object::Type> getQueryType() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<object::Type> getMutationType() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<object::Type> getSubscriptionType() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::vector<std::shared_ptr<object::Directive>>
+	getDirectives() const;
 
 private:
 	const std::shared_ptr<schema::Schema> _schema;
 };
 
-class Type
+class [[nodiscard]] Type
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit Type(const std::shared_ptr<const schema::BaseType>& type);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT TypeKind getKind() const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::string> getName() const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::string> getDescription() const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::vector<std::shared_ptr<object::Field>>>
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] TypeKind getKind() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getName() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDescription() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::vector<std::shared_ptr<object::Field>>>
 	getFields(std::optional<bool>&& includeDeprecatedArg) const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::vector<std::shared_ptr<object::Type>>>
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::vector<std::shared_ptr<object::Type>>>
 	getInterfaces() const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::vector<std::shared_ptr<object::Type>>>
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::vector<std::shared_ptr<object::Type>>>
 	getPossibleTypes() const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::vector<std::shared_ptr<object::EnumValue>>>
-	getEnumValues(std::optional<bool>&& includeDeprecatedArg) const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::vector<std::shared_ptr<object::InputValue>>>
-	getInputFields() const;
-	GRAPHQLSERVICE_EXPORT std::shared_ptr<object::Type> getOfType() const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::string> getSpecifiedByURL() const;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard]] std::optional<std::vector<std::shared_ptr<object::EnumValue>>> getEnumValues(
+		std::optional<bool>&& includeDeprecatedArg) const;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard]] std::optional<std::vector<std::shared_ptr<object::InputValue>>> getInputFields()
+		const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<object::Type> getOfType() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getSpecifiedByURL() const;
 
 private:
 	const std::shared_ptr<const schema::BaseType> _type;
 };
 
-class Field
+class [[nodiscard]] Field
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit Field(const std::shared_ptr<const schema::Field>& field);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string getName() const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::string> getDescription() const;
-	GRAPHQLSERVICE_EXPORT std::vector<std::shared_ptr<object::InputValue>> getArgs() const;
-	GRAPHQLSERVICE_EXPORT std::shared_ptr<object::Type> getType() const;
-	GRAPHQLSERVICE_EXPORT bool getIsDeprecated() const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::string> getDeprecationReason() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string getName() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDescription() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::vector<std::shared_ptr<object::InputValue>> getArgs()
+		const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<object::Type> getType() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] bool getIsDeprecated() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDeprecationReason() const;
 
 private:
 	const std::shared_ptr<const schema::Field> _field;
 };
 
-class InputValue
+class [[nodiscard]] InputValue
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit InputValue(
 		const std::shared_ptr<const schema::InputValue>& inputValue);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string getName() const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::string> getDescription() const;
-	GRAPHQLSERVICE_EXPORT std::shared_ptr<object::Type> getType() const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::string> getDefaultValue() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string getName() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDescription() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<object::Type> getType() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDefaultValue() const;
 
 private:
 	const std::shared_ptr<const schema::InputValue> _inputValue;
 };
 
-class EnumValue
+class [[nodiscard]] EnumValue
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit EnumValue(
 		const std::shared_ptr<const schema::EnumValue>& enumValue);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string getName() const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::string> getDescription() const;
-	GRAPHQLSERVICE_EXPORT bool getIsDeprecated() const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::string> getDeprecationReason() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string getName() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDescription() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] bool getIsDeprecated() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDeprecationReason() const;
 
 private:
 	const std::shared_ptr<const schema::EnumValue> _enumValue;
 };
 
-class Directive
+class [[nodiscard]] Directive
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit Directive(
 		const std::shared_ptr<const schema::Directive>& directive);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string getName() const;
-	GRAPHQLSERVICE_EXPORT std::optional<std::string> getDescription() const;
-	GRAPHQLSERVICE_EXPORT std::vector<DirectiveLocation> getLocations() const;
-	GRAPHQLSERVICE_EXPORT std::vector<std::shared_ptr<object::InputValue>> getArgs() const;
-	GRAPHQLSERVICE_EXPORT bool getIsRepeatable() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string getName() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDescription() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::vector<DirectiveLocation> getLocations() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::vector<std::shared_ptr<object::InputValue>> getArgs()
+		const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] bool getIsRepeatable() const;
 
 private:
 	const std::shared_ptr<const schema::Directive> _directive;

--- a/include/graphqlservice/internal/Schema.h
+++ b/include/graphqlservice/internal/Schema.h
@@ -34,7 +34,7 @@ class Field;
 class InputValue;
 class EnumValue;
 
-class Schema : public std::enable_shared_from_this<Schema>
+class [[nodiscard]] Schema : public std::enable_shared_from_this<Schema>
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit Schema(
@@ -44,24 +44,26 @@ public:
 	GRAPHQLSERVICE_EXPORT void AddMutationType(std::shared_ptr<ObjectType> mutation);
 	GRAPHQLSERVICE_EXPORT void AddSubscriptionType(std::shared_ptr<ObjectType> subscription);
 	GRAPHQLSERVICE_EXPORT void AddType(std::string_view name, std::shared_ptr<BaseType> type);
-	GRAPHQLSERVICE_EXPORT const std::shared_ptr<const BaseType>& LookupType(
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::shared_ptr<const BaseType>& LookupType(
 		std::string_view name) const;
-	GRAPHQLSERVICE_EXPORT std::shared_ptr<const BaseType> WrapType(
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<const BaseType> WrapType(
 		introspection::TypeKind kind, std::shared_ptr<const BaseType> ofType);
 	GRAPHQLSERVICE_EXPORT void AddDirective(std::shared_ptr<Directive> directive);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT bool supportsIntrospection() const noexcept;
-	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::vector<
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] bool supportsIntrospection() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view description() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<
 		std::pair<std::string_view, std::shared_ptr<const BaseType>>>&
 	types() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::shared_ptr<const ObjectType>& queryType() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::shared_ptr<const ObjectType>& mutationType() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::shared_ptr<const ObjectType>& subscriptionType()
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::shared_ptr<const ObjectType>& queryType()
 		const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const Directive>>& directives()
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::shared_ptr<const ObjectType>& mutationType()
 		const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::shared_ptr<const ObjectType>& subscriptionType()
+		const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const Directive>>&
+	directives() const noexcept;
 
 private:
 	const bool _noIntrospection = false;
@@ -81,27 +83,31 @@ private:
 		_listWrappers;
 };
 
-class BaseType : public std::enable_shared_from_this<BaseType>
+class [[nodiscard]] BaseType : public std::enable_shared_from_this<BaseType>
 {
 public:
 	GRAPHQLSERVICE_EXPORT virtual ~BaseType() = default;
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT introspection::TypeKind kind() const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual std::string_view name() const noexcept;
-	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<const Field>>& fields()
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] introspection::TypeKind kind() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] virtual std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view description() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] virtual const std::vector<std::shared_ptr<const Field>>&
+	fields() const noexcept;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard]] virtual const std::vector<std::shared_ptr<const InterfaceType>>& interfaces()
 		const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<const InterfaceType>>&
-	interfaces() const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::weak_ptr<const BaseType>>& possibleTypes()
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] virtual const std::vector<std::weak_ptr<const BaseType>>&
+	possibleTypes() const noexcept;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard]] virtual const std::vector<std::shared_ptr<const EnumValue>>& enumValues()
 		const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<const EnumValue>>& enumValues()
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard]] virtual const std::vector<std::shared_ptr<const InputValue>>& inputFields()
 		const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual const std::vector<std::shared_ptr<const InputValue>>&
-	inputFields() const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual const std::weak_ptr<const BaseType>& ofType() const noexcept;
-	GRAPHQLSERVICE_EXPORT virtual std::string_view specifiedByURL() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] virtual const std::weak_ptr<const BaseType>& ofType()
+		const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] virtual std::string_view specifiedByURL() const noexcept;
 
 protected:
 	BaseType(introspection::TypeKind kind, std::string_view description);
@@ -111,7 +117,7 @@ private:
 	const std::string_view _description;
 };
 
-class ScalarType : public BaseType
+class [[nodiscard]] ScalarType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -121,19 +127,19 @@ private:
 public:
 	explicit ScalarType(init&& params);
 
-	GRAPHQLSERVICE_EXPORT static std::shared_ptr<ScalarType> Make(
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<ScalarType> Make(
 		std::string_view name, std::string_view description, std::string_view specifiedByURL);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT std::string_view specifiedByURL() const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view specifiedByURL() const noexcept final;
 
 private:
 	const std::string_view _name;
 	const std::string_view _specifiedByURL;
 };
 
-class ObjectType : public BaseType
+class [[nodiscard]] ObjectType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -143,7 +149,7 @@ private:
 public:
 	explicit ObjectType(init&& params);
 
-	GRAPHQLSERVICE_EXPORT static std::shared_ptr<ObjectType> Make(
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<ObjectType> Make(
 		std::string_view name, std::string_view description);
 
 	GRAPHQLSERVICE_EXPORT void AddInterfaces(
@@ -151,11 +157,11 @@ public:
 	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<const Field>>&& fields);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const Field>>& fields()
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const Field>>& fields()
 		const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const InterfaceType>>& interfaces()
-		const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const InterfaceType>>&
+	interfaces() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -164,7 +170,7 @@ private:
 	std::vector<std::shared_ptr<const Field>> _fields;
 };
 
-class InterfaceType : public BaseType
+class [[nodiscard]] InterfaceType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -174,7 +180,7 @@ private:
 public:
 	explicit InterfaceType(init&& params);
 
-	GRAPHQLSERVICE_EXPORT static std::shared_ptr<InterfaceType> Make(
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<InterfaceType> Make(
 		std::string_view name, std::string_view description);
 
 	GRAPHQLSERVICE_EXPORT void AddPossibleType(std::weak_ptr<BaseType> possibleType);
@@ -183,13 +189,13 @@ public:
 	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<const Field>>&& fields);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const Field>>& fields()
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const Field>>& fields()
 		const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::weak_ptr<const BaseType>>& possibleTypes()
-		const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const InterfaceType>>& interfaces()
-		const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::weak_ptr<const BaseType>>&
+	possibleTypes() const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const InterfaceType>>&
+	interfaces() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -199,7 +205,7 @@ private:
 	std::vector<std::weak_ptr<const BaseType>> _possibleTypes;
 };
 
-class UnionType : public BaseType
+class [[nodiscard]] UnionType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -209,16 +215,16 @@ private:
 public:
 	explicit UnionType(init&& params);
 
-	GRAPHQLSERVICE_EXPORT static std::shared_ptr<UnionType> Make(
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<UnionType> Make(
 		std::string_view name, std::string_view description);
 
 	GRAPHQLSERVICE_EXPORT void AddPossibleTypes(
 		std::vector<std::weak_ptr<const BaseType>>&& possibleTypes);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::weak_ptr<const BaseType>>& possibleTypes()
-		const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::weak_ptr<const BaseType>>&
+	possibleTypes() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -226,14 +232,14 @@ private:
 	std::vector<std::weak_ptr<const BaseType>> _possibleTypes;
 };
 
-struct EnumValueType
+struct [[nodiscard]] EnumValueType
 {
 	std::string_view value;
 	std::string_view description;
 	std::optional<std::string_view> deprecationReason;
 };
 
-class EnumType : public BaseType
+class [[nodiscard]] EnumType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -243,15 +249,15 @@ private:
 public:
 	explicit EnumType(init&& params);
 
-	GRAPHQLSERVICE_EXPORT static std::shared_ptr<EnumType> Make(
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<EnumType> Make(
 		std::string_view name, std::string_view description);
 
 	GRAPHQLSERVICE_EXPORT void AddEnumValues(std::vector<EnumValueType>&& enumValues);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const EnumValue>>& enumValues()
-		const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const EnumValue>>&
+	enumValues() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -259,7 +265,7 @@ private:
 	std::vector<std::shared_ptr<const EnumValue>> _enumValues;
 };
 
-class InputObjectType : public BaseType
+class [[nodiscard]] InputObjectType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -269,16 +275,16 @@ private:
 public:
 	explicit InputObjectType(init&& params);
 
-	GRAPHQLSERVICE_EXPORT static std::shared_ptr<InputObjectType> Make(
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<InputObjectType> Make(
 		std::string_view name, std::string_view description);
 
 	GRAPHQLSERVICE_EXPORT void AddInputValues(
 		std::vector<std::shared_ptr<const InputValue>>&& inputValues);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const InputValue>>& inputFields()
-		const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const InputValue>>&
+	inputFields() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -286,7 +292,7 @@ private:
 	std::vector<std::shared_ptr<const InputValue>> _inputValues;
 };
 
-class WrapperType : public BaseType
+class [[nodiscard]] WrapperType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -296,17 +302,18 @@ private:
 public:
 	explicit WrapperType(init&& params);
 
-	GRAPHQLSERVICE_EXPORT static std::shared_ptr<WrapperType> Make(
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<WrapperType> Make(
 		introspection::TypeKind kind, std::weak_ptr<const BaseType> ofType);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT const std::weak_ptr<const BaseType>& ofType() const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::weak_ptr<const BaseType>& ofType()
+		const noexcept final;
 
 private:
 	const std::weak_ptr<const BaseType> _ofType;
 };
 
-class Field : public std::enable_shared_from_this<Field>
+class [[nodiscard]] Field : public std::enable_shared_from_this<Field>
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -316,18 +323,19 @@ private:
 public:
 	explicit Field(init&& params);
 
-	GRAPHQLSERVICE_EXPORT static std::shared_ptr<Field> Make(std::string_view name,
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<Field> Make(std::string_view name,
 		std::string_view description, std::optional<std::string_view> deprecationReason,
 		std::weak_ptr<const BaseType> type,
 		std::vector<std::shared_ptr<const InputValue>>&& args = {});
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept;
-	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const InputValue>>& args()
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view description() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const InputValue>>& args()
 		const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::weak_ptr<const BaseType>& type() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::optional<std::string_view>& deprecationReason() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::weak_ptr<const BaseType>& type() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::optional<std::string_view>& deprecationReason()
+		const noexcept;
 
 private:
 	const std::string_view _name;
@@ -337,7 +345,7 @@ private:
 	const std::vector<std::shared_ptr<const InputValue>> _args;
 };
 
-class InputValue : public std::enable_shared_from_this<InputValue>
+class [[nodiscard]] InputValue : public std::enable_shared_from_this<InputValue>
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -347,15 +355,15 @@ private:
 public:
 	explicit InputValue(init&& params);
 
-	GRAPHQLSERVICE_EXPORT static std::shared_ptr<InputValue> Make(std::string_view name,
-		std::string_view description, std::weak_ptr<const BaseType> type,
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<InputValue> Make(
+		std::string_view name, std::string_view description, std::weak_ptr<const BaseType> type,
 		std::string_view defaultValue);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept;
-	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::weak_ptr<const BaseType>& type() const noexcept;
-	GRAPHQLSERVICE_EXPORT std::string_view defaultValue() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view description() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::weak_ptr<const BaseType>& type() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view defaultValue() const noexcept;
 
 private:
 	const std::string_view _name;
@@ -364,7 +372,7 @@ private:
 	const std::string_view _defaultValue;
 };
 
-class EnumValue : public std::enable_shared_from_this<EnumValue>
+class [[nodiscard]] EnumValue : public std::enable_shared_from_this<EnumValue>
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -374,13 +382,15 @@ private:
 public:
 	explicit EnumValue(init&& params);
 
-	GRAPHQLSERVICE_EXPORT static std::shared_ptr<EnumValue> Make(std::string_view name,
-		std::string_view description, std::optional<std::string_view> deprecationReason);
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<EnumValue> Make(
+		std::string_view name, std::string_view description,
+		std::optional<std::string_view> deprecationReason);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept;
-	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::optional<std::string_view>& deprecationReason() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view description() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::optional<std::string_view>& deprecationReason()
+		const noexcept;
 
 private:
 	const std::string_view _name;
@@ -388,7 +398,7 @@ private:
 	const std::optional<std::string_view> _deprecationReason;
 };
 
-class Directive : public std::enable_shared_from_this<Directive>
+class [[nodiscard]] Directive : public std::enable_shared_from_this<Directive>
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -398,18 +408,19 @@ private:
 public:
 	explicit Directive(init&& params);
 
-	GRAPHQLSERVICE_EXPORT static std::shared_ptr<Directive> Make(std::string_view name,
-		std::string_view description, std::vector<introspection::DirectiveLocation>&& locations,
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<Directive> Make(
+		std::string_view name, std::string_view description,
+		std::vector<introspection::DirectiveLocation>&& locations,
 		std::vector<std::shared_ptr<const InputValue>>&& args, bool isRepeatable);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT std::string_view name() const noexcept;
-	GRAPHQLSERVICE_EXPORT std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::vector<introspection::DirectiveLocation>& locations()
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view description() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<introspection::DirectiveLocation>&
+	locations() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const InputValue>>& args()
 		const noexcept;
-	GRAPHQLSERVICE_EXPORT const std::vector<std::shared_ptr<const InputValue>>& args()
-		const noexcept;
-	GRAPHQLSERVICE_EXPORT bool isRepeatable() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard]] bool isRepeatable() const noexcept;
 
 private:
 	const std::string_view _name;

--- a/include/graphqlservice/internal/Schema.h
+++ b/include/graphqlservice/internal/Schema.h
@@ -13,8 +13,8 @@
 namespace graphql {
 namespace introspection {
 
-enum class TypeKind;
-enum class DirectiveLocation;
+enum class [[nodiscard]] TypeKind;
+enum class [[nodiscard]] DirectiveLocation;
 
 } // namespace introspection
 

--- a/include/graphqlservice/internal/SortedMap.h
+++ b/include/graphqlservice/internal/SortedMap.h
@@ -26,7 +26,7 @@ public:
 
 	sorted_map() = default;
 
-	sorted_map(std::initializer_list<std::pair<K, V>> init)
+	constexpr sorted_map(std::initializer_list<std::pair<K, V>> init)
 		: _data { init }
 	{
 		std::sort(_data.begin(), _data.end(), [](const auto& lhs, const auto& rhs) noexcept {
@@ -34,7 +34,7 @@ public:
 		});
 	}
 
-	bool operator==(const sorted_map& rhs) const noexcept
+	constexpr bool operator==(const sorted_map& rhs) const noexcept
 	{
 		return _data == rhs._data;
 	}
@@ -44,7 +44,7 @@ public:
 		_data.reserve(size);
 	}
 
-	size_t capacity() const noexcept
+	constexpr size_t capacity() const noexcept
 	{
 		return _data.capacity();
 	}
@@ -54,37 +54,37 @@ public:
 		_data.clear();
 	}
 
-	bool empty() const noexcept
+	constexpr bool empty() const noexcept
 	{
 		return _data.empty();
 	}
 
-	size_t size() const noexcept
+	constexpr size_t size() const noexcept
 	{
 		return _data.size();
 	}
 
-	const_iterator begin() const noexcept
+	constexpr const_iterator begin() const noexcept
 	{
 		return _data.begin();
 	}
 
-	const_iterator end() const noexcept
+	constexpr const_iterator end() const noexcept
 	{
 		return _data.end();
 	}
 
-	const_reverse_iterator rbegin() const noexcept
+	constexpr const_reverse_iterator rbegin() const noexcept
 	{
 		return _data.rbegin();
 	}
 
-	const_reverse_iterator rend() const noexcept
+	constexpr const_reverse_iterator rend() const noexcept
 	{
 		return _data.rend();
 	}
 
-	const_iterator find(const K& key) const noexcept
+	constexpr const_iterator find(const K& key) const noexcept
 	{
 		const auto [itr, itrEnd] = std::equal_range(begin(),
 			end(),
@@ -97,7 +97,7 @@ public:
 	}
 
 	template <typename KeyArg>
-	const_iterator find(KeyArg&& keyArg) const noexcept
+	constexpr const_iterator find(KeyArg&& keyArg) const noexcept
 	{
 		const K key { std::forward<KeyArg>(keyArg) };
 
@@ -195,12 +195,12 @@ public:
 private:
 	struct sorted_map_key
 	{
-		sorted_map_key(const std::pair<K, V>& entry)
+		constexpr sorted_map_key(const std::pair<K, V>& entry)
 			: key { entry.first }
 		{
 		}
 
-		sorted_map_key(const K& key)
+		constexpr sorted_map_key(const K& key)
 			: key { key }
 		{
 		}
@@ -221,15 +221,13 @@ public:
 
 	sorted_set() = default;
 
-	sorted_set(std::initializer_list<K> init)
+	constexpr sorted_set(std::initializer_list<K> init)
 		: _data { init }
 	{
-		std::sort(_data.begin(), _data.end(), [](const K& lhs, const K& rhs) noexcept {
-			return Compare {}(lhs, rhs);
-		});
+		std::sort(_data.begin(), _data.end(), Compare {});
 	}
 
-	bool operator==(const sorted_set& rhs) const noexcept
+	constexpr bool operator==(const sorted_set& rhs) const noexcept
 	{
 		return _data == rhs._data;
 	}
@@ -239,7 +237,7 @@ public:
 		_data.reserve(size);
 	}
 
-	size_t capacity() const noexcept
+	constexpr size_t capacity() const noexcept
 	{
 		return _data.capacity();
 	}
@@ -249,37 +247,37 @@ public:
 		_data.clear();
 	}
 
-	bool empty() const noexcept
+	constexpr bool empty() const noexcept
 	{
 		return _data.empty();
 	}
 
-	size_t size() const noexcept
+	constexpr size_t size() const noexcept
 	{
 		return _data.size();
 	}
 
-	const_iterator begin() const noexcept
+	constexpr const_iterator begin() const noexcept
 	{
 		return _data.begin();
 	}
 
-	const_iterator end() const noexcept
+	constexpr const_iterator end() const noexcept
 	{
 		return _data.end();
 	}
 
-	const_reverse_iterator rbegin() const noexcept
+	constexpr const_reverse_iterator rbegin() const noexcept
 	{
 		return _data.rbegin();
 	}
 
-	const_reverse_iterator rend() const noexcept
+	constexpr const_reverse_iterator rend() const noexcept
 	{
 		return _data.rend();
 	}
 
-	const_iterator find(const K& key) const noexcept
+	constexpr const_iterator find(const K& key) const noexcept
 	{
 		const auto [itr, itrEnd] =
 			std::equal_range(begin(), end(), key, [](const K& lhs, const K& rhs) noexcept {
@@ -290,7 +288,7 @@ public:
 	}
 
 	template <typename Arg>
-	const_iterator find(Arg&& arg) const noexcept
+	constexpr const_iterator find(Arg&& arg) const noexcept
 	{
 		const K key { std::forward<Arg>(arg) };
 

--- a/include/graphqlservice/internal/SortedMap.h
+++ b/include/graphqlservice/internal/SortedMap.h
@@ -16,7 +16,7 @@
 namespace graphql::internal {
 
 template <class K, class V>
-struct sorted_map_key
+struct [[nodiscard]] sorted_map_key
 {
 	constexpr sorted_map_key(const std::pair<K, V>& entry) noexcept
 		: key { entry.first }
@@ -35,7 +35,7 @@ struct sorted_map_key
 
 template <class Compare, class Iterator, class K,
 	class V = decltype(std::declval<Iterator>()->second)>
-constexpr std::pair<Iterator, Iterator> sorted_map_equal_range(
+[[nodiscard]] constexpr std::pair<Iterator, Iterator> sorted_map_equal_range(
 	Iterator itrBegin, Iterator itrEnd, const K& key) noexcept
 {
 	return std::equal_range(itrBegin,
@@ -47,7 +47,7 @@ constexpr std::pair<Iterator, Iterator> sorted_map_equal_range(
 }
 
 template <class Compare, class Container, class K>
-constexpr auto sorted_map_lookup(const Container& container, const K& key) noexcept
+[[nodiscard]] constexpr auto sorted_map_lookup(const Container& container, const K& key) noexcept
 {
 	const auto [itr, itrEnd] =
 		sorted_map_equal_range<Compare>(container.begin(), container.end(), key);
@@ -56,7 +56,7 @@ constexpr auto sorted_map_lookup(const Container& container, const K& key) noexc
 }
 
 template <class K, class V, class Compare = std::less<K>>
-class sorted_map
+class [[nodiscard]] sorted_map
 {
 public:
 	using vector_type = std::vector<std::pair<K, V>>;
@@ -65,7 +65,6 @@ public:
 	using mapped_type = V;
 
 	constexpr sorted_map() noexcept = default;
-
 	constexpr sorted_map(const sorted_map& other) = default;
 	sorted_map(sorted_map&& other) noexcept = default;
 
@@ -82,7 +81,7 @@ public:
 	sorted_map& operator=(const sorted_map& rhs) = default;
 	sorted_map& operator=(sorted_map&& rhs) noexcept = default;
 
-	constexpr bool operator==(const sorted_map& rhs) const noexcept
+	[[nodiscard]] constexpr bool operator==(const sorted_map& rhs) const noexcept
 	{
 		return _data == rhs._data;
 	}
@@ -92,7 +91,7 @@ public:
 		_data.reserve(size);
 	}
 
-	constexpr size_t capacity() const noexcept
+	[[nodiscard]] constexpr size_t capacity() const noexcept
 	{
 		return _data.capacity();
 	}
@@ -102,37 +101,37 @@ public:
 		_data.clear();
 	}
 
-	constexpr bool empty() const noexcept
+	[[nodiscard]] constexpr bool empty() const noexcept
 	{
 		return _data.empty();
 	}
 
-	constexpr size_t size() const noexcept
+	[[nodiscard]] constexpr size_t size() const noexcept
 	{
 		return _data.size();
 	}
 
-	constexpr const_iterator begin() const noexcept
+	[[nodiscard]] constexpr const_iterator begin() const noexcept
 	{
 		return _data.begin();
 	}
 
-	constexpr const_iterator end() const noexcept
+	[[nodiscard]] constexpr const_iterator end() const noexcept
 	{
 		return _data.end();
 	}
 
-	constexpr const_reverse_iterator rbegin() const noexcept
+	[[nodiscard]] constexpr const_reverse_iterator rbegin() const noexcept
 	{
 		return _data.rbegin();
 	}
 
-	constexpr const_reverse_iterator rend() const noexcept
+	[[nodiscard]] constexpr const_reverse_iterator rend() const noexcept
 	{
 		return _data.rend();
 	}
 
-	constexpr const_iterator find(const K& key) const noexcept
+	[[nodiscard]] constexpr const_iterator find(const K& key) const noexcept
 	{
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
 
@@ -140,7 +139,7 @@ public:
 	}
 
 	template <typename KeyArg>
-	constexpr const_iterator find(KeyArg&& keyArg) const noexcept
+	[[nodiscard]] constexpr const_iterator find(KeyArg&& keyArg) const noexcept
 	{
 		const K key { std::forward<KeyArg>(keyArg) };
 
@@ -188,7 +187,7 @@ public:
 	}
 
 	template <typename KeyArg>
-	V& operator[](KeyArg&& keyArg) noexcept
+	[[nodiscard]] V& operator[](KeyArg&& keyArg) noexcept
 	{
 		K key { std::forward<KeyArg>(keyArg) };
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
@@ -202,7 +201,7 @@ public:
 	}
 
 	template <typename KeyArg>
-	V& at(KeyArg&& keyArg)
+	[[nodiscard]] V& at(KeyArg&& keyArg)
 	{
 		const K key { std::forward<KeyArg>(keyArg) };
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
@@ -220,7 +219,7 @@ private:
 };
 
 template <class K, class Compare = std::less<K>>
-class sorted_set
+class [[nodiscard]] sorted_set
 {
 public:
 	using vector_type = std::vector<K>;
@@ -242,7 +241,7 @@ public:
 	sorted_set& operator=(const sorted_set& rhs) = default;
 	sorted_set& operator=(sorted_set&& rhs) noexcept = default;
 
-	constexpr bool operator==(const sorted_set& rhs) const noexcept
+	[[nodiscard]] constexpr bool operator==(const sorted_set& rhs) const noexcept
 	{
 		return _data == rhs._data;
 	}
@@ -252,7 +251,7 @@ public:
 		_data.reserve(size);
 	}
 
-	constexpr size_t capacity() const noexcept
+	[[nodiscard]] constexpr size_t capacity() const noexcept
 	{
 		return _data.capacity();
 	}
@@ -262,37 +261,37 @@ public:
 		_data.clear();
 	}
 
-	constexpr bool empty() const noexcept
+	[[nodiscard]] constexpr bool empty() const noexcept
 	{
 		return _data.empty();
 	}
 
-	constexpr size_t size() const noexcept
+	[[nodiscard]] constexpr size_t size() const noexcept
 	{
 		return _data.size();
 	}
 
-	constexpr const_iterator begin() const noexcept
+	[[nodiscard]] constexpr const_iterator begin() const noexcept
 	{
 		return _data.begin();
 	}
 
-	constexpr const_iterator end() const noexcept
+	[[nodiscard]] constexpr const_iterator end() const noexcept
 	{
 		return _data.end();
 	}
 
-	constexpr const_reverse_iterator rbegin() const noexcept
+	[[nodiscard]] constexpr const_reverse_iterator rbegin() const noexcept
 	{
 		return _data.rbegin();
 	}
 
-	constexpr const_reverse_iterator rend() const noexcept
+	[[nodiscard]] constexpr const_reverse_iterator rend() const noexcept
 	{
 		return _data.rend();
 	}
 
-	constexpr const_iterator find(const K& key) const noexcept
+	[[nodiscard]] constexpr const_iterator find(const K& key) const noexcept
 	{
 		const auto [itr, itrEnd] =
 			std::equal_range(begin(), end(), key, [](const K& lhs, const K& rhs) noexcept {
@@ -303,7 +302,7 @@ public:
 	}
 
 	template <typename Arg>
-	constexpr const_iterator find(Arg&& arg) const noexcept
+	[[nodiscard]] constexpr const_iterator find(Arg&& arg) const noexcept
 	{
 		const K key { std::forward<Arg>(arg) };
 
@@ -362,9 +361,9 @@ private:
 	vector_type _data;
 };
 
-struct shorter_or_less
+struct [[nodiscard]] shorter_or_less
 {
-	constexpr bool operator()(
+	[[nodiscard]] constexpr bool operator()(
 		const std::string_view& lhs, const std::string_view& rhs) const noexcept
 	{
 		return lhs.size() == rhs.size() ? lhs < rhs : lhs.size() < rhs.size();

--- a/include/graphqlservice/internal/SortedMap.h
+++ b/include/graphqlservice/internal/SortedMap.h
@@ -24,9 +24,20 @@ public:
 	using const_reverse_iterator = typename vector_type::const_reverse_iterator;
 	using mapped_type = V;
 
-	constexpr sorted_map() = default;
-	constexpr sorted_map(const sorted_map& other) = default;
-	sorted_map(sorted_map&& other) noexcept = default;
+	constexpr sorted_map() noexcept
+		: _data {}
+	{
+	}
+
+	constexpr sorted_map(const sorted_map& other)
+		: _data { other._data }
+	{
+	}
+
+	sorted_map(sorted_map&& other) noexcept
+		: _data { std::move(other._data) }
+	{
+	}
 
 	constexpr sorted_map(std::initializer_list<std::pair<K, V>> init)
 		: _data { init }
@@ -36,10 +47,21 @@ public:
 		});
 	}
 
-	constexpr ~sorted_map() = default;
+	constexpr ~sorted_map() noexcept
+	{
+	}
 
-	sorted_map& operator=(const sorted_map& rhs) = default;
-	sorted_map& operator=(sorted_map&& rhs) noexcept = default;
+	sorted_map& operator=(const sorted_map& rhs)
+	{
+		_data = rhs._data;
+		return *this;
+	}
+
+	sorted_map& operator=(sorted_map&& rhs) noexcept
+	{
+		_data = std::move(rhs._data);
+		return *this;
+	}
 
 	constexpr bool operator==(const sorted_map& rhs) const noexcept
 	{
@@ -202,17 +224,19 @@ public:
 private:
 	struct sorted_map_key
 	{
-		constexpr sorted_map_key(const std::pair<K, V>& entry)
+		constexpr sorted_map_key(const std::pair<K, V>& entry) noexcept
 			: key { entry.first }
 		{
 		}
 
-		constexpr sorted_map_key(const K& key)
+		constexpr sorted_map_key(const K& key) noexcept
 			: key { key }
 		{
 		}
 
-		constexpr ~sorted_map_key() = default;
+		constexpr ~sorted_map_key() noexcept
+		{
+		}
 
 		const K& key;
 	};
@@ -228,9 +252,20 @@ public:
 	using const_iterator = typename vector_type::const_iterator;
 	using const_reverse_iterator = typename vector_type::const_reverse_iterator;
 
-	constexpr sorted_set() = default;
-	constexpr sorted_set(const sorted_set& other) = default;
-	sorted_set(sorted_set&& other) noexcept = default;
+	constexpr sorted_set() noexcept
+		: _data {}
+	{
+	}
+
+	constexpr sorted_set(const sorted_set& other)
+		: _data { other._data }
+	{
+	}
+
+	sorted_set(sorted_set&& other) noexcept
+		: _data { std::move(other._data) }
+	{
+	}
 
 	constexpr sorted_set(std::initializer_list<K> init)
 		: _data { init }
@@ -238,10 +273,21 @@ public:
 		std::sort(_data.begin(), _data.end(), Compare {});
 	}
 
-	constexpr ~sorted_set() = default;
+	constexpr ~sorted_set() noexcept
+	{
+	}
 
-	sorted_set& operator=(const sorted_set& rhs) = default;
-	sorted_set& operator=(sorted_set&& rhs) noexcept = default;
+	sorted_set& operator=(const sorted_set& rhs)
+	{
+		_data = rhs._data;
+		return *this;
+	}
+
+	sorted_set& operator=(sorted_set&& rhs) noexcept
+	{
+		_data = std::move(rhs._data);
+		return *this;
+	}
 
 	constexpr bool operator==(const sorted_set& rhs) const noexcept
 	{
@@ -365,10 +411,15 @@ private:
 
 struct shorter_or_less
 {
-	constexpr shorter_or_less() = default;
-	constexpr ~shorter_or_less() = default;
+	constexpr shorter_or_less() noexcept
+	{
+	}
 
-	constexpr bool operator()(const std::string_view& lhs, const std::string_view& rhs) const
+	constexpr ~shorter_or_less() noexcept
+	{
+	}
+
+	constexpr bool operator()(const std::string_view& lhs, const std::string_view& rhs) const noexcept
 	{
 		return lhs.size() == rhs.size() ? lhs < rhs : lhs.size() < rhs.size();
 	}

--- a/include/graphqlservice/internal/SortedMap.h
+++ b/include/graphqlservice/internal/SortedMap.h
@@ -43,7 +43,7 @@ constexpr std::pair<Iterator, Iterator> find_sorted_map_key(
 		[](sorted_map_key<K, V> lhs, sorted_map_key<K, V> rhs) noexcept {
 			return Compare {}(lhs.key, rhs.key);
 		});
-};
+}
 
 template <class K, class V, class Compare = std::less<K>>
 class sorted_map

--- a/include/graphqlservice/internal/SortedMap.h
+++ b/include/graphqlservice/internal/SortedMap.h
@@ -24,7 +24,9 @@ public:
 	using const_reverse_iterator = typename vector_type::const_reverse_iterator;
 	using mapped_type = V;
 
-	sorted_map() = default;
+	constexpr sorted_map() = default;
+	constexpr sorted_map(const sorted_map& other) = default;
+	sorted_map(sorted_map&& other) noexcept = default;
 
 	constexpr sorted_map(std::initializer_list<std::pair<K, V>> init)
 		: _data { init }
@@ -33,6 +35,11 @@ public:
 			return Compare {}(lhs.first, rhs.first);
 		});
 	}
+
+	constexpr ~sorted_map() = default;
+
+	sorted_map& operator=(const sorted_map& rhs) = default;
+	sorted_map& operator=(sorted_map&& rhs) noexcept = default;
 
 	constexpr bool operator==(const sorted_map& rhs) const noexcept
 	{
@@ -205,6 +212,8 @@ private:
 		{
 		}
 
+		constexpr ~sorted_map_key() = default;
+
 		const K& key;
 	};
 
@@ -219,13 +228,20 @@ public:
 	using const_iterator = typename vector_type::const_iterator;
 	using const_reverse_iterator = typename vector_type::const_reverse_iterator;
 
-	sorted_set() = default;
+	constexpr sorted_set() = default;
+	constexpr sorted_set(const sorted_set& other) = default;
+	sorted_set(sorted_set&& other) noexcept = default;
 
 	constexpr sorted_set(std::initializer_list<K> init)
 		: _data { init }
 	{
 		std::sort(_data.begin(), _data.end(), Compare {});
 	}
+
+	constexpr ~sorted_set() = default;
+
+	sorted_set& operator=(const sorted_set& rhs) = default;
+	sorted_set& operator=(sorted_set&& rhs) noexcept = default;
 
 	constexpr bool operator==(const sorted_set& rhs) const noexcept
 	{

--- a/include/graphqlservice/internal/SortedMap.h
+++ b/include/graphqlservice/internal/SortedMap.h
@@ -7,9 +7,7 @@
 #define GRAPHQLSORTEDMAP_H
 
 #include <algorithm>
-#include <functional>
 #include <initializer_list>
-#include <iterator>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -20,103 +18,28 @@ template <class K, class V, class Compare = std::less<K>>
 class sorted_map
 {
 public:
-	struct value_type
-	{
-		constexpr value_type(K first, V second) noexcept
-			: first { std::move(first) }
-			, second { std::move(second) }
-		{
-		}
-
-		constexpr value_type(const value_type& other)
-			: first { other.first }
-			, second { other.second }
-		{
-		}
-
-		value_type(value_type&& other) noexcept
-			: first { std::move(other.first) }
-			, second { std::move(other.second) }
-		{
-		}
-
-		constexpr ~value_type() noexcept
-		{
-		}
-
-		value_type& operator=(const value_type& rhs)
-		{
-			first = rhs.first;
-			second = rhs.second;
-			return *this;
-		}
-
-		value_type& operator=(value_type&& rhs) noexcept
-		{
-			first = std::move(rhs.first);
-			second = std::move(rhs.second);
-			return *this;
-		}
-
-		constexpr bool operator==(const value_type& rhs) const noexcept
-		{
-			return first == rhs.first && second == rhs.second;
-		}
-
-		K first;
-		V second;
-	};
-
-	using vector_type = std::vector<value_type>;
+	using vector_type = std::vector<std::pair<K, V>>;
 	using const_iterator = typename vector_type::const_iterator;
 	using const_reverse_iterator = typename vector_type::const_reverse_iterator;
 	using mapped_type = V;
 
-	constexpr sorted_map() noexcept
-		: _data {}
-	{
-	}
+	constexpr sorted_map() noexcept = default;
 
-	constexpr sorted_map(const sorted_map& other)
-		: _data { other._data }
-	{
-	}
-
-	sorted_map(sorted_map&& other) noexcept
-		: _data { std::move(other._data) }
-	{
-	}
+	constexpr sorted_map(const sorted_map& other) = default;
+	sorted_map(sorted_map&& other) noexcept = default;
 
 	constexpr sorted_map(std::initializer_list<std::pair<K, V>> init)
-		: _data {}
+		: _data { init }
 	{
-		_data.reserve(init.size());
-		std::transform(init.begin(),
-			init.end(),
-			std::back_inserter(_data),
-			[](auto& entry) noexcept {
-				return value_type { std::move(entry.first), std::move(entry.second) };
-			});
 		std::sort(_data.begin(), _data.end(), [](const auto& lhs, const auto& rhs) noexcept {
 			return Compare {}(lhs.first, rhs.first);
 		});
 	}
 
-	constexpr ~sorted_map() noexcept
-	{
-	}
+	constexpr ~sorted_map() noexcept = default;
 
-	sorted_map& operator=(const sorted_map& rhs)
-	{
-		_data = rhs._data;
-		return *this;
-	}
-
-	sorted_map& operator=(sorted_map&& rhs) noexcept
-	{
-		_data = std::move(rhs._data);
-		return *this;
-	}
+	sorted_map& operator=(const sorted_map& rhs) = default;
+	sorted_map& operator=(sorted_map&& rhs) noexcept = default;
 
 	constexpr bool operator==(const sorted_map& rhs) const noexcept
 	{
@@ -279,7 +202,7 @@ public:
 private:
 	struct sorted_map_key
 	{
-		constexpr sorted_map_key(const value_type& entry) noexcept
+		constexpr sorted_map_key(const std::pair<K, V>& entry) noexcept
 			: key { entry.first }
 		{
 		}
@@ -289,9 +212,7 @@ private:
 		{
 		}
 
-		constexpr ~sorted_map_key() noexcept
-		{
-		}
+		constexpr ~sorted_map_key() noexcept = default;
 
 		const K& key;
 	};
@@ -307,20 +228,9 @@ public:
 	using const_iterator = typename vector_type::const_iterator;
 	using const_reverse_iterator = typename vector_type::const_reverse_iterator;
 
-	constexpr sorted_set() noexcept
-		: _data {}
-	{
-	}
-
-	constexpr sorted_set(const sorted_set& other)
-		: _data { other._data }
-	{
-	}
-
-	sorted_set(sorted_set&& other) noexcept
-		: _data { std::move(other._data) }
-	{
-	}
+	constexpr sorted_set() noexcept = default;
+	constexpr sorted_set(const sorted_set& other) = default;
+	sorted_set(sorted_set&& other) noexcept = default;
 
 	constexpr sorted_set(std::initializer_list<K> init)
 		: _data { init }
@@ -328,21 +238,10 @@ public:
 		std::sort(_data.begin(), _data.end(), Compare {});
 	}
 
-	constexpr ~sorted_set() noexcept
-	{
-	}
+	constexpr ~sorted_set() noexcept = default;
 
-	sorted_set& operator=(const sorted_set& rhs)
-	{
-		_data = rhs._data;
-		return *this;
-	}
-
-	sorted_set& operator=(sorted_set&& rhs) noexcept
-	{
-		_data = std::move(rhs._data);
-		return *this;
-	}
+	sorted_set& operator=(const sorted_set& rhs) = default;
+	sorted_set& operator=(sorted_set&& rhs) noexcept = default;
 
 	constexpr bool operator==(const sorted_set& rhs) const noexcept
 	{
@@ -466,14 +365,6 @@ private:
 
 struct shorter_or_less
 {
-	constexpr shorter_or_less() noexcept
-	{
-	}
-
-	constexpr ~shorter_or_less() noexcept
-	{
-	}
-
 	constexpr bool operator()(
 		const std::string_view& lhs, const std::string_view& rhs) const noexcept
 	{

--- a/include/graphqlservice/internal/SortedMap.h
+++ b/include/graphqlservice/internal/SortedMap.h
@@ -365,6 +365,9 @@ private:
 
 struct shorter_or_less
 {
+	constexpr shorter_or_less() = default;
+	constexpr ~shorter_or_less() = default;
+
 	constexpr bool operator()(const std::string_view& lhs, const std::string_view& rhs) const
 	{
 		return lhs.size() == rhs.size() ? lhs < rhs : lhs.size() < rhs.size();

--- a/include/graphqlservice/internal/SyntaxTree.h
+++ b/include/graphqlservice/internal/SyntaxTree.h
@@ -23,7 +23,7 @@ namespace graphql::peg {
 using namespace tao::graphqlpeg;
 namespace peginternal = tao::graphqlpeg::internal;
 
-class ast_node
+class [[nodiscard]] ast_node
 {
 public:
 	// Must be default constructible
@@ -147,7 +147,7 @@ private:
 };
 
 template <class ParseInput>
-class depth_limit_input : public ParseInput
+class [[nodiscard]] depth_limit_input : public ParseInput
 {
 public:
 	template <typename... Args>
@@ -171,7 +171,7 @@ private:
 using ast_file = depth_limit_input<file_input<>>;
 using ast_memory = depth_limit_input<memory_input<>>;
 
-struct ast_input
+struct [[nodiscard]] ast_input
 {
 	std::variant<std::vector<char>, std::unique_ptr<ast_file>, std::string_view> data;
 };

--- a/include/graphqlservice/introspection/DirectiveObject.h
+++ b/include/graphqlservice/introspection/DirectiveObject.h
@@ -12,31 +12,31 @@
 
 namespace graphql::introspection::object {
 
-class Directive final
+class [[nodiscard]] Directive final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveLocations(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveIsRepeatable(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveLocations(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveIsRepeatable(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::AwaitableScalar<std::string> getName() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		virtual service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
-		virtual service::AwaitableScalar<bool> getIsRepeatable() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsRepeatable() const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -44,27 +44,27 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
+		[[nodiscard]] service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
 		{
 			return { _pimpl->getLocations() };
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		service::AwaitableScalar<bool> getIsRepeatable() const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsRepeatable() const final
 		{
 			return { _pimpl->getIsRepeatable() };
 		}
@@ -75,8 +75,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT Directive(std::shared_ptr<introspection::Directive> pimpl) noexcept;

--- a/include/graphqlservice/introspection/EnumValueObject.h
+++ b/include/graphqlservice/introspection/EnumValueObject.h
@@ -12,29 +12,29 @@
 
 namespace graphql::introspection::object {
 
-class EnumValue final
+class [[nodiscard]] EnumValue final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::AwaitableScalar<std::string> getName() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -42,22 +42,22 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::AwaitableScalar<bool> getIsDeprecated() const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}
@@ -68,8 +68,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT EnumValue(std::shared_ptr<introspection::EnumValue> pimpl) noexcept;

--- a/include/graphqlservice/introspection/FieldObject.h
+++ b/include/graphqlservice/introspection/FieldObject.h
@@ -12,33 +12,33 @@
 
 namespace graphql::introspection::object {
 
-class Field final
+class [[nodiscard]] Field final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::AwaitableScalar<std::string> getName() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
-		virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -46,32 +46,32 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		service::AwaitableObject<std::shared_ptr<Type>> getType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		service::AwaitableScalar<bool> getIsDeprecated() const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}
@@ -82,8 +82,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT Field(std::shared_ptr<introspection::Field> pimpl) noexcept;

--- a/include/graphqlservice/introspection/InputValueObject.h
+++ b/include/graphqlservice/introspection/InputValueObject.h
@@ -12,29 +12,29 @@
 
 namespace graphql::introspection::object {
 
-class InputValue final
+class [[nodiscard]] InputValue final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDefaultValue(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDefaultValue(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::AwaitableScalar<std::string> getName() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -42,22 +42,22 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::AwaitableObject<std::shared_ptr<Type>> getType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
 		{
 			return { _pimpl->getDefaultValue() };
 		}
@@ -68,8 +68,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT InputValue(std::shared_ptr<introspection::InputValue> pimpl) noexcept;

--- a/include/graphqlservice/introspection/IntrospectionSchema.h
+++ b/include/graphqlservice/introspection/IntrospectionSchema.h
@@ -50,6 +50,22 @@ constexpr auto getTypeKindNames() noexcept
 	};
 }
 
+constexpr auto getTypeKindValues() noexcept
+{
+	using namespace std::literals;
+
+	return internal::string_view_map<TypeKind> {
+		{ R"gql(ENUM)gql"sv, TypeKind::ENUM },
+		{ R"gql(LIST)gql"sv, TypeKind::LIST },
+		{ R"gql(UNION)gql"sv, TypeKind::UNION },
+		{ R"gql(OBJECT)gql"sv, TypeKind::OBJECT },
+		{ R"gql(SCALAR)gql"sv, TypeKind::SCALAR },
+		{ R"gql(NON_NULL)gql"sv, TypeKind::NON_NULL },
+		{ R"gql(INTERFACE)gql"sv, TypeKind::INTERFACE },
+		{ R"gql(INPUT_OBJECT)gql"sv, TypeKind::INPUT_OBJECT }
+	};
+}
+
 enum class DirectiveLocation
 {
 	QUERY,
@@ -97,6 +113,33 @@ constexpr auto getDirectiveLocationNames() noexcept
 		R"gql(ENUM_VALUE)gql"sv,
 		R"gql(INPUT_OBJECT)gql"sv,
 		R"gql(INPUT_FIELD_DEFINITION)gql"sv
+	};
+}
+
+constexpr auto getDirectiveLocationValues() noexcept
+{
+	using namespace std::literals;
+
+	return internal::string_view_map<DirectiveLocation> {
+		{ R"gql(ENUM)gql"sv, DirectiveLocation::ENUM },
+		{ R"gql(FIELD)gql"sv, DirectiveLocation::FIELD },
+		{ R"gql(QUERY)gql"sv, DirectiveLocation::QUERY },
+		{ R"gql(UNION)gql"sv, DirectiveLocation::UNION },
+		{ R"gql(OBJECT)gql"sv, DirectiveLocation::OBJECT },
+		{ R"gql(SCALAR)gql"sv, DirectiveLocation::SCALAR },
+		{ R"gql(SCHEMA)gql"sv, DirectiveLocation::SCHEMA },
+		{ R"gql(MUTATION)gql"sv, DirectiveLocation::MUTATION },
+		{ R"gql(INTERFACE)gql"sv, DirectiveLocation::INTERFACE },
+		{ R"gql(ENUM_VALUE)gql"sv, DirectiveLocation::ENUM_VALUE },
+		{ R"gql(INPUT_OBJECT)gql"sv, DirectiveLocation::INPUT_OBJECT },
+		{ R"gql(SUBSCRIPTION)gql"sv, DirectiveLocation::SUBSCRIPTION },
+		{ R"gql(FRAGMENT_SPREAD)gql"sv, DirectiveLocation::FRAGMENT_SPREAD },
+		{ R"gql(INLINE_FRAGMENT)gql"sv, DirectiveLocation::INLINE_FRAGMENT },
+		{ R"gql(FIELD_DEFINITION)gql"sv, DirectiveLocation::FIELD_DEFINITION },
+		{ R"gql(ARGUMENT_DEFINITION)gql"sv, DirectiveLocation::ARGUMENT_DEFINITION },
+		{ R"gql(FRAGMENT_DEFINITION)gql"sv, DirectiveLocation::FRAGMENT_DEFINITION },
+		{ R"gql(VARIABLE_DEFINITION)gql"sv, DirectiveLocation::VARIABLE_DEFINITION },
+		{ R"gql(INPUT_FIELD_DEFINITION)gql"sv, DirectiveLocation::INPUT_FIELD_DEFINITION }
 	};
 }
 

--- a/include/graphqlservice/introspection/IntrospectionSchema.h
+++ b/include/graphqlservice/introspection/IntrospectionSchema.h
@@ -22,7 +22,7 @@ static_assert(graphql::internal::MinorVersion == 2, "regenerate with schemagen: 
 namespace graphql {
 namespace introspection {
 
-enum class [[nodiscard]] TypeKind
+enum class TypeKind
 {
 	SCALAR,
 	OBJECT,
@@ -66,7 +66,7 @@ enum class [[nodiscard]] TypeKind
 	};
 }
 
-enum class [[nodiscard]] DirectiveLocation
+enum class DirectiveLocation
 {
 	QUERY,
 	MUTATION,

--- a/include/graphqlservice/introspection/IntrospectionSchema.h
+++ b/include/graphqlservice/introspection/IntrospectionSchema.h
@@ -54,15 +54,15 @@ constexpr auto getTypeKindValues() noexcept
 {
 	using namespace std::literals;
 
-	return internal::string_view_map<TypeKind> {
-		{ R"gql(ENUM)gql"sv, TypeKind::ENUM },
-		{ R"gql(LIST)gql"sv, TypeKind::LIST },
-		{ R"gql(UNION)gql"sv, TypeKind::UNION },
-		{ R"gql(OBJECT)gql"sv, TypeKind::OBJECT },
-		{ R"gql(SCALAR)gql"sv, TypeKind::SCALAR },
-		{ R"gql(NON_NULL)gql"sv, TypeKind::NON_NULL },
-		{ R"gql(INTERFACE)gql"sv, TypeKind::INTERFACE },
-		{ R"gql(INPUT_OBJECT)gql"sv, TypeKind::INPUT_OBJECT }
+	return std::array<std::pair<std::string_view, TypeKind>, 8> {
+		std::make_pair(R"gql(ENUM)gql"sv, TypeKind::ENUM),
+		std::make_pair(R"gql(LIST)gql"sv, TypeKind::LIST),
+		std::make_pair(R"gql(UNION)gql"sv, TypeKind::UNION),
+		std::make_pair(R"gql(OBJECT)gql"sv, TypeKind::OBJECT),
+		std::make_pair(R"gql(SCALAR)gql"sv, TypeKind::SCALAR),
+		std::make_pair(R"gql(NON_NULL)gql"sv, TypeKind::NON_NULL),
+		std::make_pair(R"gql(INTERFACE)gql"sv, TypeKind::INTERFACE),
+		std::make_pair(R"gql(INPUT_OBJECT)gql"sv, TypeKind::INPUT_OBJECT)
 	};
 }
 
@@ -120,26 +120,26 @@ constexpr auto getDirectiveLocationValues() noexcept
 {
 	using namespace std::literals;
 
-	return internal::string_view_map<DirectiveLocation> {
-		{ R"gql(ENUM)gql"sv, DirectiveLocation::ENUM },
-		{ R"gql(FIELD)gql"sv, DirectiveLocation::FIELD },
-		{ R"gql(QUERY)gql"sv, DirectiveLocation::QUERY },
-		{ R"gql(UNION)gql"sv, DirectiveLocation::UNION },
-		{ R"gql(OBJECT)gql"sv, DirectiveLocation::OBJECT },
-		{ R"gql(SCALAR)gql"sv, DirectiveLocation::SCALAR },
-		{ R"gql(SCHEMA)gql"sv, DirectiveLocation::SCHEMA },
-		{ R"gql(MUTATION)gql"sv, DirectiveLocation::MUTATION },
-		{ R"gql(INTERFACE)gql"sv, DirectiveLocation::INTERFACE },
-		{ R"gql(ENUM_VALUE)gql"sv, DirectiveLocation::ENUM_VALUE },
-		{ R"gql(INPUT_OBJECT)gql"sv, DirectiveLocation::INPUT_OBJECT },
-		{ R"gql(SUBSCRIPTION)gql"sv, DirectiveLocation::SUBSCRIPTION },
-		{ R"gql(FRAGMENT_SPREAD)gql"sv, DirectiveLocation::FRAGMENT_SPREAD },
-		{ R"gql(INLINE_FRAGMENT)gql"sv, DirectiveLocation::INLINE_FRAGMENT },
-		{ R"gql(FIELD_DEFINITION)gql"sv, DirectiveLocation::FIELD_DEFINITION },
-		{ R"gql(ARGUMENT_DEFINITION)gql"sv, DirectiveLocation::ARGUMENT_DEFINITION },
-		{ R"gql(FRAGMENT_DEFINITION)gql"sv, DirectiveLocation::FRAGMENT_DEFINITION },
-		{ R"gql(VARIABLE_DEFINITION)gql"sv, DirectiveLocation::VARIABLE_DEFINITION },
-		{ R"gql(INPUT_FIELD_DEFINITION)gql"sv, DirectiveLocation::INPUT_FIELD_DEFINITION }
+	return std::array<std::pair<std::string_view, DirectiveLocation>, 19> {
+		std::make_pair(R"gql(ENUM)gql"sv, DirectiveLocation::ENUM),
+		std::make_pair(R"gql(FIELD)gql"sv, DirectiveLocation::FIELD),
+		std::make_pair(R"gql(QUERY)gql"sv, DirectiveLocation::QUERY),
+		std::make_pair(R"gql(UNION)gql"sv, DirectiveLocation::UNION),
+		std::make_pair(R"gql(OBJECT)gql"sv, DirectiveLocation::OBJECT),
+		std::make_pair(R"gql(SCALAR)gql"sv, DirectiveLocation::SCALAR),
+		std::make_pair(R"gql(SCHEMA)gql"sv, DirectiveLocation::SCHEMA),
+		std::make_pair(R"gql(MUTATION)gql"sv, DirectiveLocation::MUTATION),
+		std::make_pair(R"gql(INTERFACE)gql"sv, DirectiveLocation::INTERFACE),
+		std::make_pair(R"gql(ENUM_VALUE)gql"sv, DirectiveLocation::ENUM_VALUE),
+		std::make_pair(R"gql(INPUT_OBJECT)gql"sv, DirectiveLocation::INPUT_OBJECT),
+		std::make_pair(R"gql(SUBSCRIPTION)gql"sv, DirectiveLocation::SUBSCRIPTION),
+		std::make_pair(R"gql(FRAGMENT_SPREAD)gql"sv, DirectiveLocation::FRAGMENT_SPREAD),
+		std::make_pair(R"gql(INLINE_FRAGMENT)gql"sv, DirectiveLocation::INLINE_FRAGMENT),
+		std::make_pair(R"gql(FIELD_DEFINITION)gql"sv, DirectiveLocation::FIELD_DEFINITION),
+		std::make_pair(R"gql(ARGUMENT_DEFINITION)gql"sv, DirectiveLocation::ARGUMENT_DEFINITION),
+		std::make_pair(R"gql(FRAGMENT_DEFINITION)gql"sv, DirectiveLocation::FRAGMENT_DEFINITION),
+		std::make_pair(R"gql(VARIABLE_DEFINITION)gql"sv, DirectiveLocation::VARIABLE_DEFINITION),
+		std::make_pair(R"gql(INPUT_FIELD_DEFINITION)gql"sv, DirectiveLocation::INPUT_FIELD_DEFINITION)
 	};
 }
 

--- a/include/graphqlservice/introspection/IntrospectionSchema.h
+++ b/include/graphqlservice/introspection/IntrospectionSchema.h
@@ -22,7 +22,7 @@ static_assert(graphql::internal::MinorVersion == 2, "regenerate with schemagen: 
 namespace graphql {
 namespace introspection {
 
-enum class TypeKind
+enum class [[nodiscard]] TypeKind
 {
 	SCALAR,
 	OBJECT,
@@ -34,7 +34,7 @@ enum class TypeKind
 	NON_NULL
 };
 
-constexpr auto getTypeKindNames() noexcept
+[[nodiscard]] constexpr auto getTypeKindNames() noexcept
 {
 	using namespace std::literals;
 
@@ -50,7 +50,7 @@ constexpr auto getTypeKindNames() noexcept
 	};
 }
 
-constexpr auto getTypeKindValues() noexcept
+[[nodiscard]] constexpr auto getTypeKindValues() noexcept
 {
 	using namespace std::literals;
 
@@ -66,7 +66,7 @@ constexpr auto getTypeKindValues() noexcept
 	};
 }
 
-enum class DirectiveLocation
+enum class [[nodiscard]] DirectiveLocation
 {
 	QUERY,
 	MUTATION,
@@ -89,7 +89,7 @@ enum class DirectiveLocation
 	INPUT_FIELD_DEFINITION
 };
 
-constexpr auto getDirectiveLocationNames() noexcept
+[[nodiscard]] constexpr auto getDirectiveLocationNames() noexcept
 {
 	using namespace std::literals;
 
@@ -116,7 +116,7 @@ constexpr auto getDirectiveLocationNames() noexcept
 	};
 }
 
-constexpr auto getDirectiveLocationValues() noexcept
+[[nodiscard]] constexpr auto getDirectiveLocationValues() noexcept
 {
 	using namespace std::literals;
 

--- a/include/graphqlservice/introspection/SchemaObject.h
+++ b/include/graphqlservice/introspection/SchemaObject.h
@@ -12,33 +12,33 @@
 
 namespace graphql::introspection::object {
 
-class Schema final
+class [[nodiscard]] Schema final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveTypes(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveQueryType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveMutationType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveSubscriptionType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDirectives(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveTypes(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveQueryType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveMutationType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveSubscriptionType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDirectives(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -46,32 +46,32 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
 		{
 			return { _pimpl->getTypes() };
 		}
 
-		service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
 		{
 			return { _pimpl->getQueryType() };
 		}
 
-		service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
 		{
 			return { _pimpl->getMutationType() };
 		}
 
-		service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
 		{
 			return { _pimpl->getSubscriptionType() };
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
 		{
 			return { _pimpl->getDirectives() };
 		}
@@ -82,8 +82,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT Schema(std::shared_ptr<introspection::Schema> pimpl) noexcept;

--- a/include/graphqlservice/introspection/TypeObject.h
+++ b/include/graphqlservice/introspection/TypeObject.h
@@ -12,41 +12,41 @@
 
 namespace graphql::introspection::object {
 
-class Type final
+class [[nodiscard]] Type final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveKind(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveFields(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveInterfaces(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolvePossibleTypes(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveEnumValues(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveInputFields(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveOfType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveSpecifiedByURL(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveKind(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveFields(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveInterfaces(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolvePossibleTypes(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveEnumValues(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveInputFields(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveOfType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveSpecifiedByURL(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::AwaitableScalar<TypeKind> getKind() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getName() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Type>> getOfType() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<TypeKind> getKind() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getName() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getOfType() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -54,52 +54,52 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<TypeKind> getKind() const final
+		[[nodiscard]] service::AwaitableScalar<TypeKind> getKind() const final
 		{
 			return { _pimpl->getKind() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getFields(std::move(includeDeprecatedArg)) };
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
 		{
 			return { _pimpl->getInterfaces() };
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
 		{
 			return { _pimpl->getPossibleTypes() };
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getEnumValues(std::move(includeDeprecatedArg)) };
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
 		{
 			return { _pimpl->getInputFields() };
 		}
 
-		service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
 		{
 			return { _pimpl->getOfType() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
 		{
 			return { _pimpl->getSpecifiedByURL() };
 		}
@@ -110,8 +110,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT Type(std::shared_ptr<introspection::Type> pimpl) noexcept;

--- a/samples/client/mutate/MutateClient.h
+++ b/samples/client/mutate/MutateClient.h
@@ -48,7 +48,7 @@ const std::string& GetRequestText() noexcept;
 // Return a pre-parsed, pre-validated request object.
 const peg::ast& GetRequestObject() noexcept;
 
-enum class TaskState
+enum class [[nodiscard]] TaskState
 {
 	New,
 	Started,

--- a/samples/client/query/QueryClient.h
+++ b/samples/client/query/QueryClient.h
@@ -96,7 +96,7 @@ const std::string& GetRequestText() noexcept;
 // Return a pre-parsed, pre-validated request object.
 const peg::ast& GetRequestObject() noexcept;
 
-enum class TaskState
+enum class [[nodiscard]] TaskState
 {
 	New,
 	Started,

--- a/samples/learn/schema/CharacterObject.h
+++ b/samples/learn/schema/CharacterObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::learn::object {
 
-class Character final
+class [[nodiscard]] Character final
 	: public service::Object
 {
 private:
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::TypeNames getTypeNames() const noexcept = 0;
-		virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/learn/schema/DroidObject.h
+++ b/samples/learn/schema/DroidObject.h
@@ -94,34 +94,34 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::DroidHas
 
-class Droid final
+class [[nodiscard]] Droid final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveFriends(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveAppearsIn(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolvePrimaryFunction(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveFriends(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveAppearsIn(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolvePrimaryFunction(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -129,7 +129,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getIdWithParams<T>)
 			{
@@ -142,7 +142,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getNameWithParams<T>)
 			{
@@ -155,7 +155,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getFriendsWithParams<T>)
 			{
@@ -168,7 +168,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getAppearsInWithParams<T>)
 			{
@@ -181,7 +181,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getPrimaryFunctionWithParams<T>)
 			{
@@ -220,13 +220,13 @@ private:
 	friend Character;
 
 	template <class I>
-	static constexpr bool implements() noexcept
+	[[nodiscard]] static constexpr bool implements() noexcept
 	{
 		return implements::DroidIs<I>;
 	}
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -240,7 +240,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Droid)gql" };
 	}

--- a/samples/learn/schema/HumanObject.h
+++ b/samples/learn/schema/HumanObject.h
@@ -94,34 +94,34 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::HumanHas
 
-class Human final
+class [[nodiscard]] Human final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveFriends(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveAppearsIn(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveHomePlanet(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveFriends(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveAppearsIn(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveHomePlanet(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -129,7 +129,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getIdWithParams<T>)
 			{
@@ -142,7 +142,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getNameWithParams<T>)
 			{
@@ -155,7 +155,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getFriendsWithParams<T>)
 			{
@@ -168,7 +168,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getAppearsInWithParams<T>)
 			{
@@ -181,7 +181,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getHomePlanetWithParams<T>)
 			{
@@ -220,13 +220,13 @@ private:
 	friend Character;
 
 	template <class I>
-	static constexpr bool implements() noexcept
+	[[nodiscard]] static constexpr bool implements() noexcept
 	{
 		return implements::HumanIs<I>;
 	}
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -240,7 +240,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Human)gql" };
 	}

--- a/samples/learn/schema/MutationObject.h
+++ b/samples/learn/schema/MutationObject.h
@@ -39,26 +39,26 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutationHas
 
-class Mutation final
+class [[nodiscard]] Mutation final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveCreateReview(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveCreateReview(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const final
 		{
 			if constexpr (methods::MutationHas::applyCreateReviewWithParams<T>)
 			{
@@ -101,8 +101,8 @@ private:
 
 	Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -116,7 +116,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Mutation)gql" };
 	}

--- a/samples/learn/schema/QueryObject.h
+++ b/samples/learn/schema/QueryObject.h
@@ -63,34 +63,34 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::QueryHas
 
-class Query final
+class [[nodiscard]] Query final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveHero(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveHuman(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDroid(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveHero(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveHuman(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDroid(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolve_schema(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolve_type(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_schema(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_type(service::ResolverParams&& params) const;
 
 	std::shared_ptr<schema::Schema> _schema;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, response::IdType&& idArg) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, response::IdType&& idArg) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -98,7 +98,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const final
 		{
 			if constexpr (methods::QueryHas::getHeroWithParams<T>)
 			{
@@ -111,7 +111,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getHumanWithParams<T>)
 			{
@@ -124,7 +124,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getDroidWithParams<T>)
 			{
@@ -159,8 +159,8 @@ private:
 
 	Query(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -174,7 +174,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Query)gql" };
 	}

--- a/samples/learn/schema/ReviewObject.h
+++ b/samples/learn/schema/ReviewObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::ReviewHas
 
-class Review final
+class [[nodiscard]] Review final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveStars(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveCommentary(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveStars(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveCommentary(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<int> getStars(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<int> getStars(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<int> getStars(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getStars(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ReviewHas::getStarsWithParams<T>)
 			{
@@ -93,7 +93,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ReviewHas::getCommentaryWithParams<T>)
 			{
@@ -128,8 +128,8 @@ private:
 
 	Review(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -143,7 +143,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Review)gql" };
 	}

--- a/samples/learn/schema/StarWarsSchema.cpp
+++ b/samples/learn/schema/StarWarsSchema.cpp
@@ -25,6 +25,7 @@ namespace graphql {
 namespace service {
 
 static const auto s_namesEpisode = learn::getEpisodeNames();
+static const auto s_valuesEpisode = learn::getEpisodeValues();
 
 template <>
 learn::Episode ModifiedArgument<learn::Episode>::convert(const response::Value& value)
@@ -34,14 +35,14 @@ learn::Episode ModifiedArgument<learn::Episode>::convert(const response::Value& 
 		throw service::schema_exception { { R"ex(not a valid Episode value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesEpisode.cbegin(), s_namesEpisode.cend(), value.get<std::string>());
+	const auto itr = s_valuesEpisode.find(value.get<std::string>());
 
-	if (itr == s_namesEpisode.cend())
+	if (itr == s_valuesEpisode.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid Episode value)ex" } };
 	}
 
-	return static_cast<learn::Episode>(itr - s_namesEpisode.cbegin());
+	return itr->second;
 }
 
 template <>
@@ -66,9 +67,9 @@ void ModifiedResult<learn::Episode>::validateScalar(const response::Value& value
 		throw service::schema_exception { { R"ex(not a valid Episode value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesEpisode.cbegin(), s_namesEpisode.cend(), value.get<std::string>());
+	const auto itr = s_valuesEpisode.find(value.get<std::string>());
 
-	if (itr == s_namesEpisode.cend())
+	if (itr == s_valuesEpisode.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid Episode value)ex" } };
 	}

--- a/samples/learn/schema/StarWarsSchema.cpp
+++ b/samples/learn/schema/StarWarsSchema.cpp
@@ -16,7 +16,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
-#include <tuple>
+#include <utility>
 #include <vector>
 
 using namespace std::literals;
@@ -35,9 +35,12 @@ learn::Episode ModifiedArgument<learn::Episode>::convert(const response::Value& 
 		throw service::schema_exception { { R"ex(not a valid Episode value)ex" } };
 	}
 
-	const auto itr = s_valuesEpisode.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesEpisode.begin(),
+		s_valuesEpisode.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesEpisode.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid Episode value)ex" } };
 	}
@@ -67,9 +70,12 @@ void ModifiedResult<learn::Episode>::validateScalar(const response::Value& value
 		throw service::schema_exception { { R"ex(not a valid Episode value)ex" } };
 	}
 
-	const auto itr = s_valuesEpisode.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesEpisode.begin(),
+		s_valuesEpisode.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesEpisode.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid Episode value)ex" } };
 	}

--- a/samples/learn/schema/StarWarsSchema.cpp
+++ b/samples/learn/schema/StarWarsSchema.cpp
@@ -35,17 +35,16 @@ learn::Episode ModifiedArgument<learn::Episode>::convert(const response::Value& 
 		throw service::schema_exception { { R"ex(not a valid Episode value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
-		s_valuesEpisode.begin(),
-		s_valuesEpisode.end(),
+	const auto result = internal::sorted_map_lookup<internal::shorter_or_less>(
+		s_valuesEpisode,
 		std::string_view { value.get<std::string>() });
 
-	if (itr == itrEnd)
+	if (!result)
 	{
 		throw service::schema_exception { { R"ex(not a valid Episode value)ex" } };
 	}
 
-	return itr->second;
+	return *result;
 }
 
 template <>
@@ -70,7 +69,7 @@ void ModifiedResult<learn::Episode>::validateScalar(const response::Value& value
 		throw service::schema_exception { { R"ex(not a valid Episode value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+	const auto [itr, itrEnd] = internal::sorted_map_equal_range<internal::shorter_or_less>(
 		s_valuesEpisode.begin(),
 		s_valuesEpisode.end(),
 		std::string_view { value.get<std::string>() });

--- a/samples/learn/schema/StarWarsSchema.h
+++ b/samples/learn/schema/StarWarsSchema.h
@@ -22,14 +22,14 @@ static_assert(graphql::internal::MinorVersion == 2, "regenerate with schemagen: 
 namespace graphql {
 namespace learn {
 
-enum class Episode
+enum class [[nodiscard]] Episode
 {
 	NEW_HOPE,
 	EMPIRE,
 	JEDI
 };
 
-constexpr auto getEpisodeNames() noexcept
+[[nodiscard]] constexpr auto getEpisodeNames() noexcept
 {
 	using namespace std::literals;
 
@@ -40,7 +40,7 @@ constexpr auto getEpisodeNames() noexcept
 	};
 }
 
-constexpr auto getEpisodeValues() noexcept
+[[nodiscard]] constexpr auto getEpisodeValues() noexcept
 {
 	using namespace std::literals;
 
@@ -69,7 +69,7 @@ class Mutation;
 
 } // namespace object
 
-class Operations final
+class [[nodiscard]] Operations final
 	: public service::Request
 {
 public:
@@ -101,7 +101,7 @@ std::shared_ptr<schema::Schema> GetSchema();
 namespace service {
 
 template <>
-constexpr bool isInputType<learn::ReviewInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<learn::ReviewInput>() noexcept
 {
 	return true;
 }

--- a/samples/learn/schema/StarWarsSchema.h
+++ b/samples/learn/schema/StarWarsSchema.h
@@ -40,6 +40,17 @@ constexpr auto getEpisodeNames() noexcept
 	};
 }
 
+constexpr auto getEpisodeValues() noexcept
+{
+	using namespace std::literals;
+
+	return internal::string_view_map<Episode> {
+		{ R"gql(JEDI)gql"sv, Episode::JEDI },
+		{ R"gql(EMPIRE)gql"sv, Episode::EMPIRE },
+		{ R"gql(NEW_HOPE)gql"sv, Episode::NEW_HOPE }
+	};
+}
+
 struct ReviewInput
 {
 	int stars {};

--- a/samples/learn/schema/StarWarsSchema.h
+++ b/samples/learn/schema/StarWarsSchema.h
@@ -44,10 +44,10 @@ constexpr auto getEpisodeValues() noexcept
 {
 	using namespace std::literals;
 
-	return internal::string_view_map<Episode> {
-		{ R"gql(JEDI)gql"sv, Episode::JEDI },
-		{ R"gql(EMPIRE)gql"sv, Episode::EMPIRE },
-		{ R"gql(NEW_HOPE)gql"sv, Episode::NEW_HOPE }
+	return std::array<std::pair<std::string_view, Episode>, 3> {
+		std::make_pair(R"gql(JEDI)gql"sv, Episode::JEDI),
+		std::make_pair(R"gql(EMPIRE)gql"sv, Episode::EMPIRE),
+		std::make_pair(R"gql(NEW_HOPE)gql"sv, Episode::NEW_HOPE)
 	};
 }
 

--- a/samples/today/TodayMock.h
+++ b/samples/today/TodayMock.h
@@ -547,7 +547,7 @@ public:
 
 	std::shared_ptr<object::Node> getNodeChange(const response::IdType&) const
 	{
-		throw std::runtime_error("Unexpected call to getNodeChange");
+		return {};
 	}
 
 private:

--- a/samples/today/benchmark.cpp
+++ b/samples/today/benchmark.cpp
@@ -106,13 +106,21 @@ int main(int argc, char** argv)
 			})gql"sv);
 			const auto startValidate = std::chrono::steady_clock::now();
 
-			service->validate(query);
+			if (!service->validate(query).empty())
+			{
+				std::cerr << "Failed to validate the query!" << std::endl;
+				break;
+			}
 
 			const auto startResolve = std::chrono::steady_clock::now();
 			auto response = service->resolve({ query }).get();
 			const auto startToJson = std::chrono::steady_clock::now();
 
-			response::toJSON(std::move(response));
+			if (response::toJSON(std::move(response)).empty())
+			{
+				std::cerr << "Failed to convert to JSON!" << std::endl;
+				break;
+			}
 
 			const auto endToJson = std::chrono::steady_clock::now();
 

--- a/samples/today/nointrospection/AppointmentConnectionObject.h
+++ b/samples/today/nointrospection/AppointmentConnectionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentConnectionHas
 
-class AppointmentConnection final
+class [[nodiscard]] AppointmentConnection final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getEdgesWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	AppointmentConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(AppointmentConnection)gql" };
 	}

--- a/samples/today/nointrospection/AppointmentEdgeObject.h
+++ b/samples/today/nointrospection/AppointmentEdgeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentEdgeHas
 
-class AppointmentEdge final
+class [[nodiscard]] AppointmentEdge final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getCursorWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	AppointmentEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(AppointmentEdge)gql" };
 	}

--- a/samples/today/nointrospection/AppointmentObject.h
+++ b/samples/today/nointrospection/AppointmentObject.h
@@ -94,34 +94,34 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentHas
 
-class Appointment final
+class [[nodiscard]] Appointment final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveWhen(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveSubject(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveIsNow(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveForceError(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveWhen(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveSubject(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveIsNow(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveForceError(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -129,7 +129,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIdWithParams<T>)
 			{
@@ -145,7 +145,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getWhenWithParams<T>)
 			{
@@ -161,7 +161,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getSubjectWithParams<T>)
 			{
@@ -177,7 +177,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIsNowWithParams<T>)
 			{
@@ -193,7 +193,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getForceErrorWithParams<T>)
 			{
@@ -238,13 +238,13 @@ private:
 	friend UnionType;
 
 	template <class I>
-	static constexpr bool implements() noexcept
+	[[nodiscard]] static constexpr bool implements() noexcept
 	{
 		return implements::AppointmentIs<I>;
 	}
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -258,7 +258,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Appointment)gql" };
 	}

--- a/samples/today/nointrospection/CompleteTaskPayloadObject.h
+++ b/samples/today/nointrospection/CompleteTaskPayloadObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::CompleteTaskPayloadHas
 
-class CompleteTaskPayload final
+class [[nodiscard]] CompleteTaskPayload final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveTask(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveClientMutationId(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveTask(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveClientMutationId(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getClientMutationIdWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	CompleteTaskPayload(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(CompleteTaskPayload)gql" };
 	}

--- a/samples/today/nointrospection/ExpensiveObject.h
+++ b/samples/today/nointrospection/ExpensiveObject.h
@@ -39,26 +39,26 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::ExpensiveHas
 
-class Expensive final
+class [[nodiscard]] Expensive final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveOrder(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveOrder(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::getOrderWithParams<T>)
 			{
@@ -104,8 +104,8 @@ private:
 
 	Expensive(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -119,7 +119,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Expensive)gql" };
 	}

--- a/samples/today/nointrospection/FolderConnectionObject.h
+++ b/samples/today/nointrospection/FolderConnectionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderConnectionHas
 
-class FolderConnection final
+class [[nodiscard]] FolderConnection final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getEdgesWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	FolderConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(FolderConnection)gql" };
 	}

--- a/samples/today/nointrospection/FolderEdgeObject.h
+++ b/samples/today/nointrospection/FolderEdgeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderEdgeHas
 
-class FolderEdge final
+class [[nodiscard]] FolderEdge final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getCursorWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	FolderEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(FolderEdge)gql" };
 	}

--- a/samples/today/nointrospection/FolderObject.h
+++ b/samples/today/nointrospection/FolderObject.h
@@ -70,30 +70,30 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderHas
 
-class Folder final
+class [[nodiscard]] Folder final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveUnreadCount(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveUnreadCount(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -101,7 +101,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getNameWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getUnreadCountWithParams<T>)
 			{
@@ -178,13 +178,13 @@ private:
 	friend UnionType;
 
 	template <class I>
-	static constexpr bool implements() noexcept
+	[[nodiscard]] static constexpr bool implements() noexcept
 	{
 		return implements::FolderIs<I>;
 	}
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -198,7 +198,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Folder)gql" };
 	}

--- a/samples/today/nointrospection/MutationObject.h
+++ b/samples/today/nointrospection/MutationObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutationHas
 
-class Mutation final
+class [[nodiscard]] Mutation final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveCompleteTask(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveSetFloat(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveCompleteTask(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveSetFloat(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const = 0;
-		virtual service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
 		{
 			if constexpr (methods::MutationHas::applyCompleteTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
+		[[nodiscard]] service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
 		{
 			if constexpr (methods::MutationHas::applySetFloatWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Mutation)gql" };
 	}

--- a/samples/today/nointrospection/NestedTypeObject.h
+++ b/samples/today/nointrospection/NestedTypeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::NestedTypeHas
 
-class NestedType final
+class [[nodiscard]] NestedType final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveDepth(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDepth(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getDepthWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getNestedWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	NestedType(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(NestedType)gql" };
 	}

--- a/samples/today/nointrospection/NodeObject.h
+++ b/samples/today/nointrospection/NodeObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::today::object {
 
-class Node final
+class [[nodiscard]] Node final
 	: public service::Object
 {
 private:
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::TypeNames getTypeNames() const noexcept = 0;
-		virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/today/nointrospection/PageInfoObject.h
+++ b/samples/today/nointrospection/PageInfoObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::PageInfoHas
 
-class PageInfo final
+class [[nodiscard]] PageInfo final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveHasNextPage(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveHasPreviousPage(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveHasNextPage(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveHasPreviousPage(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasNextPageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasPreviousPageWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	PageInfo(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(PageInfo)gql" };
 	}

--- a/samples/today/nointrospection/QueryObject.h
+++ b/samples/today/nointrospection/QueryObject.h
@@ -183,50 +183,50 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::QueryHas
 
-class Query final
+class [[nodiscard]] Query final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveAppointments(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveTasks(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveUnreadCounts(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveAppointmentsById(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveTasksById(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveUnreadCountsById(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveUnimplemented(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveExpensive(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveTestTaskState(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveAnyType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDefault(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveAppointments(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveTasks(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveUnreadCounts(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveAppointmentsById(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveTasksById(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveUnreadCountsById(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveUnimplemented(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveExpensive(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveTestTaskState(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveAnyType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDefault(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -234,7 +234,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getNodeWithParams<T>)
 			{
@@ -250,7 +250,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsWithParams<T>)
 			{
@@ -266,7 +266,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksWithParams<T>)
 			{
@@ -282,7 +282,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsWithParams<T>)
 			{
@@ -298,7 +298,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsByIdWithParams<T>)
 			{
@@ -314,7 +314,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksByIdWithParams<T>)
 			{
@@ -330,7 +330,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsByIdWithParams<T>)
 			{
@@ -346,7 +346,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getNestedWithParams<T>)
 			{
@@ -362,7 +362,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getUnimplementedWithParams<T>)
 			{
@@ -378,7 +378,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getExpensiveWithParams<T>)
 			{
@@ -394,7 +394,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getTestTaskStateWithParams<T>)
 			{
@@ -410,7 +410,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAnyTypeWithParams<T>)
 			{
@@ -426,7 +426,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getDefaultWithParams<T>)
 			{
@@ -464,8 +464,8 @@ private:
 
 	Query(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -479,7 +479,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Query)gql" };
 	}

--- a/samples/today/nointrospection/SubscriptionObject.h
+++ b/samples/today/nointrospection/SubscriptionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::SubscriptionHas
 
-class Subscription final
+class [[nodiscard]] Subscription final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveNextAppointmentChange(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveNodeChange(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNextAppointmentChange(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNodeChange(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNextAppointmentChangeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNodeChangeWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Subscription)gql" };
 	}

--- a/samples/today/nointrospection/TaskConnectionObject.h
+++ b/samples/today/nointrospection/TaskConnectionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskConnectionHas
 
-class TaskConnection final
+class [[nodiscard]] TaskConnection final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getEdgesWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	TaskConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(TaskConnection)gql" };
 	}

--- a/samples/today/nointrospection/TaskEdgeObject.h
+++ b/samples/today/nointrospection/TaskEdgeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskEdgeHas
 
-class TaskEdge final
+class [[nodiscard]] TaskEdge final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getCursorWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	TaskEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(TaskEdge)gql" };
 	}

--- a/samples/today/nointrospection/TaskObject.h
+++ b/samples/today/nointrospection/TaskObject.h
@@ -70,30 +70,30 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskHas
 
-class Task final
+class [[nodiscard]] Task final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveTitle(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveIsComplete(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveTitle(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveIsComplete(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -101,7 +101,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getTitleWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIsCompleteWithParams<T>)
 			{
@@ -178,13 +178,13 @@ private:
 	friend UnionType;
 
 	template <class I>
-	static constexpr bool implements() noexcept
+	[[nodiscard]] static constexpr bool implements() noexcept
 	{
 		return implements::TaskIs<I>;
 	}
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -198,7 +198,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Task)gql" };
 	}

--- a/samples/today/nointrospection/TodaySchema.cpp
+++ b/samples/today/nointrospection/TodaySchema.cpp
@@ -36,17 +36,16 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Val
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
-		s_valuesTaskState.begin(),
-		s_valuesTaskState.end(),
+	const auto result = internal::sorted_map_lookup<internal::shorter_or_less>(
+		s_valuesTaskState,
 		std::string_view { value.get<std::string>() });
 
-	if (itr == itrEnd)
+	if (!result)
 	{
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	return itr->second;
+	return *result;
 }
 
 template <>
@@ -71,7 +70,7 @@ void ModifiedResult<today::TaskState>::validateScalar(const response::Value& val
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+	const auto [itr, itrEnd] = internal::sorted_map_equal_range<internal::shorter_or_less>(
 		s_valuesTaskState.begin(),
 		s_valuesTaskState.end(),
 		std::string_view { value.get<std::string>() });

--- a/samples/today/nointrospection/TodaySchema.cpp
+++ b/samples/today/nointrospection/TodaySchema.cpp
@@ -17,7 +17,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
-#include <tuple>
+#include <utility>
 #include <vector>
 
 using namespace std::literals;
@@ -36,9 +36,12 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Val
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	const auto itr = s_valuesTaskState.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesTaskState.begin(),
+		s_valuesTaskState.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesTaskState.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
@@ -68,9 +71,12 @@ void ModifiedResult<today::TaskState>::validateScalar(const response::Value& val
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	const auto itr = s_valuesTaskState.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesTaskState.begin(),
+		s_valuesTaskState.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesTaskState.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}

--- a/samples/today/nointrospection/TodaySchema.cpp
+++ b/samples/today/nointrospection/TodaySchema.cpp
@@ -26,6 +26,7 @@ namespace graphql {
 namespace service {
 
 static const auto s_namesTaskState = today::getTaskStateNames();
+static const auto s_valuesTaskState = today::getTaskStateValues();
 
 template <>
 today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Value& value)
@@ -35,14 +36,14 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Val
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesTaskState.cbegin(), s_namesTaskState.cend(), value.get<std::string>());
+	const auto itr = s_valuesTaskState.find(value.get<std::string>());
 
-	if (itr == s_namesTaskState.cend())
+	if (itr == s_valuesTaskState.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	return static_cast<today::TaskState>(itr - s_namesTaskState.cbegin());
+	return itr->second;
 }
 
 template <>
@@ -67,9 +68,9 @@ void ModifiedResult<today::TaskState>::validateScalar(const response::Value& val
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesTaskState.cbegin(), s_namesTaskState.cend(), value.get<std::string>());
+	const auto itr = s_valuesTaskState.find(value.get<std::string>());
 
-	if (itr == s_namesTaskState.cend())
+	if (itr == s_valuesTaskState.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}

--- a/samples/today/nointrospection/TodaySchema.h
+++ b/samples/today/nointrospection/TodaySchema.h
@@ -22,7 +22,7 @@ static_assert(graphql::internal::MinorVersion == 2, "regenerate with schemagen: 
 namespace graphql {
 namespace today {
 
-enum class TaskState
+enum class [[nodiscard]] TaskState
 {
 	New,
 	Started,
@@ -30,7 +30,7 @@ enum class TaskState
 	Unassigned
 };
 
-constexpr auto getTaskStateNames() noexcept
+[[nodiscard]] constexpr auto getTaskStateNames() noexcept
 {
 	using namespace std::literals;
 
@@ -42,7 +42,7 @@ constexpr auto getTaskStateNames() noexcept
 	};
 }
 
-constexpr auto getTaskStateValues() noexcept
+[[nodiscard]] constexpr auto getTaskStateValues() noexcept
 {
 	using namespace std::literals;
 
@@ -142,7 +142,7 @@ class Expensive;
 
 } // namespace object
 
-class Operations final
+class [[nodiscard]] Operations final
 	: public service::Request
 {
 public:
@@ -188,55 +188,55 @@ std::shared_ptr<schema::Schema> GetSchema();
 namespace service {
 
 template <>
-constexpr bool isInputType<today::CompleteTaskInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::CompleteTaskInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::ThirdNestedInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::ThirdNestedInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::FourthNestedInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::FourthNestedInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::IncludeNullableSelfInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::IncludeNullableSelfInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::IncludeNonNullableListSelfInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::IncludeNonNullableListSelfInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::StringOperationFilterInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::StringOperationFilterInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::SecondNestedInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::SecondNestedInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::ForwardDeclaredInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::ForwardDeclaredInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::FirstNestedInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::FirstNestedInput>() noexcept
 {
 	return true;
 }

--- a/samples/today/nointrospection/TodaySchema.h
+++ b/samples/today/nointrospection/TodaySchema.h
@@ -46,11 +46,11 @@ constexpr auto getTaskStateValues() noexcept
 {
 	using namespace std::literals;
 
-	return internal::string_view_map<TaskState> {
-		{ R"gql(New)gql"sv, TaskState::New },
-		{ R"gql(Started)gql"sv, TaskState::Started },
-		{ R"gql(Complete)gql"sv, TaskState::Complete },
-		{ R"gql(Unassigned)gql"sv, TaskState::Unassigned }
+	return std::array<std::pair<std::string_view, TaskState>, 4> {
+		std::make_pair(R"gql(New)gql"sv, TaskState::New),
+		std::make_pair(R"gql(Started)gql"sv, TaskState::Started),
+		std::make_pair(R"gql(Complete)gql"sv, TaskState::Complete),
+		std::make_pair(R"gql(Unassigned)gql"sv, TaskState::Unassigned)
 	};
 }
 

--- a/samples/today/nointrospection/TodaySchema.h
+++ b/samples/today/nointrospection/TodaySchema.h
@@ -42,6 +42,18 @@ constexpr auto getTaskStateNames() noexcept
 	};
 }
 
+constexpr auto getTaskStateValues() noexcept
+{
+	using namespace std::literals;
+
+	return internal::string_view_map<TaskState> {
+		{ R"gql(New)gql"sv, TaskState::New },
+		{ R"gql(Started)gql"sv, TaskState::Started },
+		{ R"gql(Complete)gql"sv, TaskState::Complete },
+		{ R"gql(Unassigned)gql"sv, TaskState::Unassigned }
+	};
+}
+
 struct CompleteTaskInput
 {
 	response::IdType id {};

--- a/samples/today/nointrospection/UnionTypeObject.h
+++ b/samples/today/nointrospection/UnionTypeObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::today::object {
 
-class UnionType final
+class [[nodiscard]] UnionType final
 	: public service::Object
 {
 private:
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::TypeNames getTypeNames() const noexcept = 0;
-		virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/today/schema/AppointmentConnectionObject.h
+++ b/samples/today/schema/AppointmentConnectionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentConnectionHas
 
-class AppointmentConnection final
+class [[nodiscard]] AppointmentConnection final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getEdgesWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	AppointmentConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(AppointmentConnection)gql" };
 	}

--- a/samples/today/schema/AppointmentEdgeObject.h
+++ b/samples/today/schema/AppointmentEdgeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentEdgeHas
 
-class AppointmentEdge final
+class [[nodiscard]] AppointmentEdge final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getCursorWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	AppointmentEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(AppointmentEdge)gql" };
 	}

--- a/samples/today/schema/AppointmentObject.h
+++ b/samples/today/schema/AppointmentObject.h
@@ -94,34 +94,34 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentHas
 
-class Appointment final
+class [[nodiscard]] Appointment final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveWhen(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveSubject(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveIsNow(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveForceError(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveWhen(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveSubject(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveIsNow(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveForceError(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -129,7 +129,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIdWithParams<T>)
 			{
@@ -145,7 +145,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getWhenWithParams<T>)
 			{
@@ -161,7 +161,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getSubjectWithParams<T>)
 			{
@@ -177,7 +177,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIsNowWithParams<T>)
 			{
@@ -193,7 +193,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getForceErrorWithParams<T>)
 			{
@@ -238,13 +238,13 @@ private:
 	friend UnionType;
 
 	template <class I>
-	static constexpr bool implements() noexcept
+	[[nodiscard]] static constexpr bool implements() noexcept
 	{
 		return implements::AppointmentIs<I>;
 	}
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -258,7 +258,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Appointment)gql" };
 	}

--- a/samples/today/schema/CompleteTaskPayloadObject.h
+++ b/samples/today/schema/CompleteTaskPayloadObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::CompleteTaskPayloadHas
 
-class CompleteTaskPayload final
+class [[nodiscard]] CompleteTaskPayload final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveTask(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveClientMutationId(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveTask(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveClientMutationId(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getClientMutationIdWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	CompleteTaskPayload(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(CompleteTaskPayload)gql" };
 	}

--- a/samples/today/schema/ExpensiveObject.h
+++ b/samples/today/schema/ExpensiveObject.h
@@ -39,26 +39,26 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::ExpensiveHas
 
-class Expensive final
+class [[nodiscard]] Expensive final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveOrder(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveOrder(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::getOrderWithParams<T>)
 			{
@@ -104,8 +104,8 @@ private:
 
 	Expensive(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -119,7 +119,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Expensive)gql" };
 	}

--- a/samples/today/schema/FolderConnectionObject.h
+++ b/samples/today/schema/FolderConnectionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderConnectionHas
 
-class FolderConnection final
+class [[nodiscard]] FolderConnection final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getEdgesWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	FolderConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(FolderConnection)gql" };
 	}

--- a/samples/today/schema/FolderEdgeObject.h
+++ b/samples/today/schema/FolderEdgeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderEdgeHas
 
-class FolderEdge final
+class [[nodiscard]] FolderEdge final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getCursorWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	FolderEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(FolderEdge)gql" };
 	}

--- a/samples/today/schema/FolderObject.h
+++ b/samples/today/schema/FolderObject.h
@@ -70,30 +70,30 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderHas
 
-class Folder final
+class [[nodiscard]] Folder final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveUnreadCount(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveUnreadCount(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -101,7 +101,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getNameWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getUnreadCountWithParams<T>)
 			{
@@ -178,13 +178,13 @@ private:
 	friend UnionType;
 
 	template <class I>
-	static constexpr bool implements() noexcept
+	[[nodiscard]] static constexpr bool implements() noexcept
 	{
 		return implements::FolderIs<I>;
 	}
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -198,7 +198,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Folder)gql" };
 	}

--- a/samples/today/schema/MutationObject.h
+++ b/samples/today/schema/MutationObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutationHas
 
-class Mutation final
+class [[nodiscard]] Mutation final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveCompleteTask(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveSetFloat(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveCompleteTask(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveSetFloat(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const = 0;
-		virtual service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
 		{
 			if constexpr (methods::MutationHas::applyCompleteTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
+		[[nodiscard]] service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
 		{
 			if constexpr (methods::MutationHas::applySetFloatWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Mutation)gql" };
 	}

--- a/samples/today/schema/NestedTypeObject.h
+++ b/samples/today/schema/NestedTypeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::NestedTypeHas
 
-class NestedType final
+class [[nodiscard]] NestedType final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveDepth(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDepth(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getDepthWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getNestedWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	NestedType(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(NestedType)gql" };
 	}

--- a/samples/today/schema/NodeObject.h
+++ b/samples/today/schema/NodeObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::today::object {
 
-class Node final
+class [[nodiscard]] Node final
 	: public service::Object
 {
 private:
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::TypeNames getTypeNames() const noexcept = 0;
-		virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/today/schema/PageInfoObject.h
+++ b/samples/today/schema/PageInfoObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::PageInfoHas
 
-class PageInfo final
+class [[nodiscard]] PageInfo final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveHasNextPage(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveHasPreviousPage(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveHasNextPage(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveHasPreviousPage(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasNextPageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasPreviousPageWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	PageInfo(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(PageInfo)gql" };
 	}

--- a/samples/today/schema/QueryObject.h
+++ b/samples/today/schema/QueryObject.h
@@ -183,54 +183,54 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::QueryHas
 
-class Query final
+class [[nodiscard]] Query final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveAppointments(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveTasks(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveUnreadCounts(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveAppointmentsById(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveTasksById(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveUnreadCountsById(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveUnimplemented(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveExpensive(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveTestTaskState(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveAnyType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDefault(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveAppointments(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveTasks(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveUnreadCounts(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveAppointmentsById(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveTasksById(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveUnreadCountsById(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveUnimplemented(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveExpensive(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveTestTaskState(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveAnyType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDefault(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolve_schema(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolve_type(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_schema(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_type(service::ResolverParams&& params) const;
 
 	std::shared_ptr<schema::Schema> _schema;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -238,7 +238,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getNodeWithParams<T>)
 			{
@@ -254,7 +254,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsWithParams<T>)
 			{
@@ -270,7 +270,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksWithParams<T>)
 			{
@@ -286,7 +286,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsWithParams<T>)
 			{
@@ -302,7 +302,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsByIdWithParams<T>)
 			{
@@ -318,7 +318,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksByIdWithParams<T>)
 			{
@@ -334,7 +334,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsByIdWithParams<T>)
 			{
@@ -350,7 +350,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getNestedWithParams<T>)
 			{
@@ -366,7 +366,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getUnimplementedWithParams<T>)
 			{
@@ -382,7 +382,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getExpensiveWithParams<T>)
 			{
@@ -398,7 +398,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getTestTaskStateWithParams<T>)
 			{
@@ -414,7 +414,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAnyTypeWithParams<T>)
 			{
@@ -430,7 +430,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getDefaultWithParams<T>)
 			{
@@ -468,8 +468,8 @@ private:
 
 	Query(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -483,7 +483,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Query)gql" };
 	}

--- a/samples/today/schema/SubscriptionObject.h
+++ b/samples/today/schema/SubscriptionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::SubscriptionHas
 
-class Subscription final
+class [[nodiscard]] Subscription final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveNextAppointmentChange(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveNodeChange(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNextAppointmentChange(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNodeChange(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNextAppointmentChangeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNodeChangeWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Subscription)gql" };
 	}

--- a/samples/today/schema/TaskConnectionObject.h
+++ b/samples/today/schema/TaskConnectionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskConnectionHas
 
-class TaskConnection final
+class [[nodiscard]] TaskConnection final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getEdgesWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	TaskConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(TaskConnection)gql" };
 	}

--- a/samples/today/schema/TaskEdgeObject.h
+++ b/samples/today/schema/TaskEdgeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskEdgeHas
 
-class TaskEdge final
+class [[nodiscard]] TaskEdge final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getCursorWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	TaskEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(TaskEdge)gql" };
 	}

--- a/samples/today/schema/TaskObject.h
+++ b/samples/today/schema/TaskObject.h
@@ -70,30 +70,30 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskHas
 
-class Task final
+class [[nodiscard]] Task final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveTitle(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveIsComplete(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveTitle(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveIsComplete(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -101,7 +101,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getTitleWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIsCompleteWithParams<T>)
 			{
@@ -178,13 +178,13 @@ private:
 	friend UnionType;
 
 	template <class I>
-	static constexpr bool implements() noexcept
+	[[nodiscard]] static constexpr bool implements() noexcept
 	{
 		return implements::TaskIs<I>;
 	}
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -198,7 +198,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Task)gql" };
 	}

--- a/samples/today/schema/TodaySchema.cpp
+++ b/samples/today/schema/TodaySchema.cpp
@@ -36,17 +36,16 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Val
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
-		s_valuesTaskState.begin(),
-		s_valuesTaskState.end(),
+	const auto result = internal::sorted_map_lookup<internal::shorter_or_less>(
+		s_valuesTaskState,
 		std::string_view { value.get<std::string>() });
 
-	if (itr == itrEnd)
+	if (!result)
 	{
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	return itr->second;
+	return *result;
 }
 
 template <>
@@ -71,7 +70,7 @@ void ModifiedResult<today::TaskState>::validateScalar(const response::Value& val
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+	const auto [itr, itrEnd] = internal::sorted_map_equal_range<internal::shorter_or_less>(
 		s_valuesTaskState.begin(),
 		s_valuesTaskState.end(),
 		std::string_view { value.get<std::string>() });

--- a/samples/today/schema/TodaySchema.cpp
+++ b/samples/today/schema/TodaySchema.cpp
@@ -17,7 +17,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
-#include <tuple>
+#include <utility>
 #include <vector>
 
 using namespace std::literals;
@@ -36,9 +36,12 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Val
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	const auto itr = s_valuesTaskState.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesTaskState.begin(),
+		s_valuesTaskState.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesTaskState.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
@@ -68,9 +71,12 @@ void ModifiedResult<today::TaskState>::validateScalar(const response::Value& val
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	const auto itr = s_valuesTaskState.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesTaskState.begin(),
+		s_valuesTaskState.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesTaskState.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}

--- a/samples/today/schema/TodaySchema.cpp
+++ b/samples/today/schema/TodaySchema.cpp
@@ -26,6 +26,7 @@ namespace graphql {
 namespace service {
 
 static const auto s_namesTaskState = today::getTaskStateNames();
+static const auto s_valuesTaskState = today::getTaskStateValues();
 
 template <>
 today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Value& value)
@@ -35,14 +36,14 @@ today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Val
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesTaskState.cbegin(), s_namesTaskState.cend(), value.get<std::string>());
+	const auto itr = s_valuesTaskState.find(value.get<std::string>());
 
-	if (itr == s_namesTaskState.cend())
+	if (itr == s_valuesTaskState.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	return static_cast<today::TaskState>(itr - s_namesTaskState.cbegin());
+	return itr->second;
 }
 
 template <>
@@ -67,9 +68,9 @@ void ModifiedResult<today::TaskState>::validateScalar(const response::Value& val
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesTaskState.cbegin(), s_namesTaskState.cend(), value.get<std::string>());
+	const auto itr = s_valuesTaskState.find(value.get<std::string>());
 
-	if (itr == s_namesTaskState.cend())
+	if (itr == s_valuesTaskState.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid TaskState value)ex" } };
 	}

--- a/samples/today/schema/TodaySchema.h
+++ b/samples/today/schema/TodaySchema.h
@@ -22,7 +22,7 @@ static_assert(graphql::internal::MinorVersion == 2, "regenerate with schemagen: 
 namespace graphql {
 namespace today {
 
-enum class TaskState
+enum class [[nodiscard]] TaskState
 {
 	New,
 	Started,
@@ -30,7 +30,7 @@ enum class TaskState
 	Unassigned
 };
 
-constexpr auto getTaskStateNames() noexcept
+[[nodiscard]] constexpr auto getTaskStateNames() noexcept
 {
 	using namespace std::literals;
 
@@ -42,7 +42,7 @@ constexpr auto getTaskStateNames() noexcept
 	};
 }
 
-constexpr auto getTaskStateValues() noexcept
+[[nodiscard]] constexpr auto getTaskStateValues() noexcept
 {
 	using namespace std::literals;
 
@@ -142,7 +142,7 @@ class Expensive;
 
 } // namespace object
 
-class Operations final
+class [[nodiscard]] Operations final
 	: public service::Request
 {
 public:
@@ -188,55 +188,55 @@ std::shared_ptr<schema::Schema> GetSchema();
 namespace service {
 
 template <>
-constexpr bool isInputType<today::CompleteTaskInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::CompleteTaskInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::ThirdNestedInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::ThirdNestedInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::FourthNestedInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::FourthNestedInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::IncludeNullableSelfInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::IncludeNullableSelfInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::IncludeNonNullableListSelfInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::IncludeNonNullableListSelfInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::StringOperationFilterInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::StringOperationFilterInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::SecondNestedInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::SecondNestedInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::ForwardDeclaredInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::ForwardDeclaredInput>() noexcept
 {
 	return true;
 }
 
 template <>
-constexpr bool isInputType<today::FirstNestedInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<today::FirstNestedInput>() noexcept
 {
 	return true;
 }

--- a/samples/today/schema/TodaySchema.h
+++ b/samples/today/schema/TodaySchema.h
@@ -46,11 +46,11 @@ constexpr auto getTaskStateValues() noexcept
 {
 	using namespace std::literals;
 
-	return internal::string_view_map<TaskState> {
-		{ R"gql(New)gql"sv, TaskState::New },
-		{ R"gql(Started)gql"sv, TaskState::Started },
-		{ R"gql(Complete)gql"sv, TaskState::Complete },
-		{ R"gql(Unassigned)gql"sv, TaskState::Unassigned }
+	return std::array<std::pair<std::string_view, TaskState>, 4> {
+		std::make_pair(R"gql(New)gql"sv, TaskState::New),
+		std::make_pair(R"gql(Started)gql"sv, TaskState::Started),
+		std::make_pair(R"gql(Complete)gql"sv, TaskState::Complete),
+		std::make_pair(R"gql(Unassigned)gql"sv, TaskState::Unassigned)
 	};
 }
 

--- a/samples/today/schema/TodaySchema.h
+++ b/samples/today/schema/TodaySchema.h
@@ -42,6 +42,18 @@ constexpr auto getTaskStateNames() noexcept
 	};
 }
 
+constexpr auto getTaskStateValues() noexcept
+{
+	using namespace std::literals;
+
+	return internal::string_view_map<TaskState> {
+		{ R"gql(New)gql"sv, TaskState::New },
+		{ R"gql(Started)gql"sv, TaskState::Started },
+		{ R"gql(Complete)gql"sv, TaskState::Complete },
+		{ R"gql(Unassigned)gql"sv, TaskState::Unassigned }
+	};
+}
+
 struct CompleteTaskInput
 {
 	response::IdType id {};

--- a/samples/today/schema/UnionTypeObject.h
+++ b/samples/today/schema/UnionTypeObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::today::object {
 
-class UnionType final
+class [[nodiscard]] UnionType final
 	: public service::Object
 {
 private:
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::TypeNames getTypeNames() const noexcept = 0;
-		virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/AlienObject.h
+++ b/samples/validation/schema/AlienObject.h
@@ -58,28 +58,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AlienHas
 
-class Alien final
+class [[nodiscard]] Alien final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveHomePlanet(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveHomePlanet(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -87,7 +87,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AlienHas::getNameWithParams<T>)
 			{
@@ -103,7 +103,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AlienHas::getHomePlanetWithParams<T>)
 			{
@@ -148,13 +148,13 @@ private:
 	friend HumanOrAlien;
 
 	template <class I>
-	static constexpr bool implements() noexcept
+	[[nodiscard]] static constexpr bool implements() noexcept
 	{
 		return implements::AlienIs<I>;
 	}
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -168,7 +168,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Alien)gql" };
 	}

--- a/samples/validation/schema/ArgumentsObject.h
+++ b/samples/validation/schema/ArgumentsObject.h
@@ -123,40 +123,40 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::ArgumentsHas
 
-class Arguments final
+class [[nodiscard]] Arguments final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveMultipleReqs(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveBooleanArgField(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveFloatArgField(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveIntArgField(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveNonNullBooleanArgField(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveNonNullBooleanListField(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveBooleanListArgField(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveOptionalNonNullBooleanArgField(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveMultipleReqs(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveBooleanArgField(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveFloatArgField(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveIntArgField(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNonNullBooleanArgField(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNonNullBooleanListField(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveBooleanListArgField(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveOptionalNonNullBooleanArgField(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const = 0;
-		virtual service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const = 0;
-		virtual service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const = 0;
-		virtual service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const = 0;
-		virtual service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const = 0;
-		virtual service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -164,7 +164,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const final
+		[[nodiscard]] service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getMultipleReqsWithParams<T>)
 			{
@@ -180,7 +180,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getBooleanArgFieldWithParams<T>)
 			{
@@ -196,7 +196,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getFloatArgFieldWithParams<T>)
 			{
@@ -212,7 +212,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getIntArgFieldWithParams<T>)
 			{
@@ -228,7 +228,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getNonNullBooleanArgFieldWithParams<T>)
 			{
@@ -244,7 +244,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getNonNullBooleanListFieldWithParams<T>)
 			{
@@ -260,7 +260,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getBooleanListArgFieldWithParams<T>)
 			{
@@ -276,7 +276,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getOptionalNonNullBooleanArgFieldWithParams<T>)
 			{
@@ -314,8 +314,8 @@ private:
 
 	Arguments(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -329,7 +329,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Arguments)gql" };
 	}

--- a/samples/validation/schema/CatObject.h
+++ b/samples/validation/schema/CatObject.h
@@ -82,32 +82,32 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::CatHas
 
-class Cat final
+class [[nodiscard]] Cat final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveNickname(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDoesKnowCommand(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveMeowVolume(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNickname(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDoesKnowCommand(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveMeowVolume(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const = 0;
-		virtual service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -115,7 +115,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CatHas::getNameWithParams<T>)
 			{
@@ -131,7 +131,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CatHas::getNicknameWithParams<T>)
 			{
@@ -147,7 +147,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const final
 		{
 			if constexpr (methods::CatHas::getDoesKnowCommandWithParams<T>)
 			{
@@ -163,7 +163,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CatHas::getMeowVolumeWithParams<T>)
 			{
@@ -208,13 +208,13 @@ private:
 	friend CatOrDog;
 
 	template <class I>
-	static constexpr bool implements() noexcept
+	[[nodiscard]] static constexpr bool implements() noexcept
 	{
 		return implements::CatIs<I>;
 	}
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -228,7 +228,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Cat)gql" };
 	}

--- a/samples/validation/schema/CatOrDogObject.h
+++ b/samples/validation/schema/CatOrDogObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class CatOrDog final
+class [[nodiscard]] CatOrDog final
 	: public service::Object
 {
 private:
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::TypeNames getTypeNames() const noexcept = 0;
-		virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/DogObject.h
+++ b/samples/validation/schema/DogObject.h
@@ -106,36 +106,36 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::DogHas
 
-class Dog final
+class [[nodiscard]] Dog final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveNickname(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveBarkVolume(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDoesKnowCommand(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveIsHousetrained(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveOwner(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNickname(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveBarkVolume(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDoesKnowCommand(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveIsHousetrained(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveOwner(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const = 0;
-		virtual service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -143,7 +143,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getNameWithParams<T>)
 			{
@@ -159,7 +159,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getNicknameWithParams<T>)
 			{
@@ -175,7 +175,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getBarkVolumeWithParams<T>)
 			{
@@ -191,7 +191,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const final
 		{
 			if constexpr (methods::DogHas::getDoesKnowCommandWithParams<T>)
 			{
@@ -207,7 +207,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const final
 		{
 			if constexpr (methods::DogHas::getIsHousetrainedWithParams<T>)
 			{
@@ -223,7 +223,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getOwnerWithParams<T>)
 			{
@@ -269,13 +269,13 @@ private:
 	friend DogOrHuman;
 
 	template <class I>
-	static constexpr bool implements() noexcept
+	[[nodiscard]] static constexpr bool implements() noexcept
 	{
 		return implements::DogIs<I>;
 	}
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -289,7 +289,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Dog)gql" };
 	}

--- a/samples/validation/schema/DogOrHumanObject.h
+++ b/samples/validation/schema/DogOrHumanObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class DogOrHuman final
+class [[nodiscard]] DogOrHuman final
 	: public service::Object
 {
 private:
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::TypeNames getTypeNames() const noexcept = 0;
-		virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/HumanObject.h
+++ b/samples/validation/schema/HumanObject.h
@@ -58,28 +58,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::HumanHas
 
-class Human final
+class [[nodiscard]] Human final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolvePets(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolvePets(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -87,7 +87,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getNameWithParams<T>)
 			{
@@ -103,7 +103,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getPetsWithParams<T>)
 			{
@@ -149,13 +149,13 @@ private:
 	friend HumanOrAlien;
 
 	template <class I>
-	static constexpr bool implements() noexcept
+	[[nodiscard]] static constexpr bool implements() noexcept
 	{
 		return implements::HumanIs<I>;
 	}
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -169,7 +169,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Human)gql" };
 	}

--- a/samples/validation/schema/HumanOrAlienObject.h
+++ b/samples/validation/schema/HumanOrAlienObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class HumanOrAlien final
+class [[nodiscard]] HumanOrAlien final
 	: public service::Object
 {
 private:
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::TypeNames getTypeNames() const noexcept = 0;
-		virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/MessageObject.h
+++ b/samples/validation/schema/MessageObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MessageHas
 
-class Message final
+class [[nodiscard]] Message final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveBody(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveSender(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveBody(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveSender(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MessageHas::getBodyWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MessageHas::getSenderWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	Message(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Message)gql" };
 	}

--- a/samples/validation/schema/MutateDogResultObject.h
+++ b/samples/validation/schema/MutateDogResultObject.h
@@ -39,26 +39,26 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutateDogResultHas
 
-class MutateDogResult final
+class [[nodiscard]] MutateDogResult final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MutateDogResultHas::getIdWithParams<T>)
 			{
@@ -104,8 +104,8 @@ private:
 
 	MutateDogResult(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -119,7 +119,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(MutateDogResult)gql" };
 	}

--- a/samples/validation/schema/MutationObject.h
+++ b/samples/validation/schema/MutationObject.h
@@ -39,26 +39,26 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutationHas
 
-class Mutation final
+class [[nodiscard]] Mutation final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveMutateDog(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveMutateDog(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MutationHas::applyMutateDogWithParams<T>)
 			{
@@ -104,8 +104,8 @@ private:
 
 	Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -119,7 +119,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Mutation)gql" };
 	}

--- a/samples/validation/schema/NodeObject.h
+++ b/samples/validation/schema/NodeObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class Node final
+class [[nodiscard]] Node final
 	: public service::Object
 {
 private:
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::TypeNames getTypeNames() const noexcept = 0;
-		virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/PetObject.h
+++ b/samples/validation/schema/PetObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class Pet final
+class [[nodiscard]] Pet final
 	: public service::Object
 {
 private:
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::TypeNames getTypeNames() const noexcept = 0;
-		virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/QueryObject.h
+++ b/samples/validation/schema/QueryObject.h
@@ -123,40 +123,40 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::QueryHas
 
-class Query final
+class [[nodiscard]] Query final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveDog(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveHuman(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolvePet(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveCatOrDog(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveArguments(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveResource(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveFindDog(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveBooleanList(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDog(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveHuman(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolvePet(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveCatOrDog(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveArguments(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveResource(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveFindDog(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveBooleanList(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::unique_ptr<ComplexInput>&& complexArg) const = 0;
-		virtual service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::unique_ptr<ComplexInput>&& complexArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -164,7 +164,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getDogWithParams<T>)
 			{
@@ -180,7 +180,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getHumanWithParams<T>)
 			{
@@ -196,7 +196,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getPetWithParams<T>)
 			{
@@ -212,7 +212,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getCatOrDogWithParams<T>)
 			{
@@ -228,7 +228,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getArgumentsWithParams<T>)
 			{
@@ -244,7 +244,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getResourceWithParams<T>)
 			{
@@ -260,7 +260,7 @@ private:
 			}
 		}
 
-		service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::unique_ptr<ComplexInput>&& complexArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::unique_ptr<ComplexInput>&& complexArg) const final
 		{
 			if constexpr (methods::QueryHas::getFindDogWithParams<T>)
 			{
@@ -276,7 +276,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const final
 		{
 			if constexpr (methods::QueryHas::getBooleanListWithParams<T>)
 			{
@@ -314,8 +314,8 @@ private:
 
 	Query(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -329,7 +329,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Query)gql" };
 	}

--- a/samples/validation/schema/ResourceObject.h
+++ b/samples/validation/schema/ResourceObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class Resource final
+class [[nodiscard]] Resource final
 	: public service::Object
 {
 private:
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::TypeNames getTypeNames() const noexcept = 0;
-		virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/SentientObject.h
+++ b/samples/validation/schema/SentientObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class Sentient final
+class [[nodiscard]] Sentient final
 	: public service::Object
 {
 private:
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::TypeNames getTypeNames() const noexcept = 0;
-		virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/SubscriptionObject.h
+++ b/samples/validation/schema/SubscriptionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::SubscriptionHas
 
-class Subscription final
+class [[nodiscard]] Subscription final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveNewMessage(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDisallowedSecondRootField(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveNewMessage(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDisallowedSecondRootField(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		virtual service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const = 0;
-		virtual service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNewMessageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getDisallowedSecondRootFieldWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Subscription)gql" };
 	}

--- a/samples/validation/schema/ValidationSchema.cpp
+++ b/samples/validation/schema/ValidationSchema.cpp
@@ -17,7 +17,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
-#include <tuple>
+#include <utility>
 #include <vector>
 
 using namespace std::literals;
@@ -36,9 +36,12 @@ validation::DogCommand ModifiedArgument<validation::DogCommand>::convert(const r
 		throw service::schema_exception { { R"ex(not a valid DogCommand value)ex" } };
 	}
 
-	const auto itr = s_valuesDogCommand.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesDogCommand.begin(),
+		s_valuesDogCommand.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesDogCommand.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid DogCommand value)ex" } };
 	}
@@ -68,9 +71,12 @@ void ModifiedResult<validation::DogCommand>::validateScalar(const response::Valu
 		throw service::schema_exception { { R"ex(not a valid DogCommand value)ex" } };
 	}
 
-	const auto itr = s_valuesDogCommand.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesDogCommand.begin(),
+		s_valuesDogCommand.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesDogCommand.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid DogCommand value)ex" } };
 	}
@@ -87,9 +93,12 @@ validation::CatCommand ModifiedArgument<validation::CatCommand>::convert(const r
 		throw service::schema_exception { { R"ex(not a valid CatCommand value)ex" } };
 	}
 
-	const auto itr = s_valuesCatCommand.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesCatCommand.begin(),
+		s_valuesCatCommand.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesCatCommand.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid CatCommand value)ex" } };
 	}
@@ -119,9 +128,12 @@ void ModifiedResult<validation::CatCommand>::validateScalar(const response::Valu
 		throw service::schema_exception { { R"ex(not a valid CatCommand value)ex" } };
 	}
 
-	const auto itr = s_valuesCatCommand.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesCatCommand.begin(),
+		s_valuesCatCommand.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesCatCommand.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid CatCommand value)ex" } };
 	}

--- a/samples/validation/schema/ValidationSchema.cpp
+++ b/samples/validation/schema/ValidationSchema.cpp
@@ -36,17 +36,16 @@ validation::DogCommand ModifiedArgument<validation::DogCommand>::convert(const r
 		throw service::schema_exception { { R"ex(not a valid DogCommand value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
-		s_valuesDogCommand.begin(),
-		s_valuesDogCommand.end(),
+	const auto result = internal::sorted_map_lookup<internal::shorter_or_less>(
+		s_valuesDogCommand,
 		std::string_view { value.get<std::string>() });
 
-	if (itr == itrEnd)
+	if (!result)
 	{
 		throw service::schema_exception { { R"ex(not a valid DogCommand value)ex" } };
 	}
 
-	return itr->second;
+	return *result;
 }
 
 template <>
@@ -71,7 +70,7 @@ void ModifiedResult<validation::DogCommand>::validateScalar(const response::Valu
 		throw service::schema_exception { { R"ex(not a valid DogCommand value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+	const auto [itr, itrEnd] = internal::sorted_map_equal_range<internal::shorter_or_less>(
 		s_valuesDogCommand.begin(),
 		s_valuesDogCommand.end(),
 		std::string_view { value.get<std::string>() });
@@ -93,17 +92,16 @@ validation::CatCommand ModifiedArgument<validation::CatCommand>::convert(const r
 		throw service::schema_exception { { R"ex(not a valid CatCommand value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
-		s_valuesCatCommand.begin(),
-		s_valuesCatCommand.end(),
+	const auto result = internal::sorted_map_lookup<internal::shorter_or_less>(
+		s_valuesCatCommand,
 		std::string_view { value.get<std::string>() });
 
-	if (itr == itrEnd)
+	if (!result)
 	{
 		throw service::schema_exception { { R"ex(not a valid CatCommand value)ex" } };
 	}
 
-	return itr->second;
+	return *result;
 }
 
 template <>
@@ -128,7 +126,7 @@ void ModifiedResult<validation::CatCommand>::validateScalar(const response::Valu
 		throw service::schema_exception { { R"ex(not a valid CatCommand value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+	const auto [itr, itrEnd] = internal::sorted_map_equal_range<internal::shorter_or_less>(
 		s_valuesCatCommand.begin(),
 		s_valuesCatCommand.end(),
 		std::string_view { value.get<std::string>() });

--- a/samples/validation/schema/ValidationSchema.cpp
+++ b/samples/validation/schema/ValidationSchema.cpp
@@ -26,6 +26,7 @@ namespace graphql {
 namespace service {
 
 static const auto s_namesDogCommand = validation::getDogCommandNames();
+static const auto s_valuesDogCommand = validation::getDogCommandValues();
 
 template <>
 validation::DogCommand ModifiedArgument<validation::DogCommand>::convert(const response::Value& value)
@@ -35,14 +36,14 @@ validation::DogCommand ModifiedArgument<validation::DogCommand>::convert(const r
 		throw service::schema_exception { { R"ex(not a valid DogCommand value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesDogCommand.cbegin(), s_namesDogCommand.cend(), value.get<std::string>());
+	const auto itr = s_valuesDogCommand.find(value.get<std::string>());
 
-	if (itr == s_namesDogCommand.cend())
+	if (itr == s_valuesDogCommand.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid DogCommand value)ex" } };
 	}
 
-	return static_cast<validation::DogCommand>(itr - s_namesDogCommand.cbegin());
+	return itr->second;
 }
 
 template <>
@@ -67,15 +68,16 @@ void ModifiedResult<validation::DogCommand>::validateScalar(const response::Valu
 		throw service::schema_exception { { R"ex(not a valid DogCommand value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesDogCommand.cbegin(), s_namesDogCommand.cend(), value.get<std::string>());
+	const auto itr = s_valuesDogCommand.find(value.get<std::string>());
 
-	if (itr == s_namesDogCommand.cend())
+	if (itr == s_valuesDogCommand.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid DogCommand value)ex" } };
 	}
 }
 
 static const auto s_namesCatCommand = validation::getCatCommandNames();
+static const auto s_valuesCatCommand = validation::getCatCommandValues();
 
 template <>
 validation::CatCommand ModifiedArgument<validation::CatCommand>::convert(const response::Value& value)
@@ -85,14 +87,14 @@ validation::CatCommand ModifiedArgument<validation::CatCommand>::convert(const r
 		throw service::schema_exception { { R"ex(not a valid CatCommand value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesCatCommand.cbegin(), s_namesCatCommand.cend(), value.get<std::string>());
+	const auto itr = s_valuesCatCommand.find(value.get<std::string>());
 
-	if (itr == s_namesCatCommand.cend())
+	if (itr == s_valuesCatCommand.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid CatCommand value)ex" } };
 	}
 
-	return static_cast<validation::CatCommand>(itr - s_namesCatCommand.cbegin());
+	return itr->second;
 }
 
 template <>
@@ -117,9 +119,9 @@ void ModifiedResult<validation::CatCommand>::validateScalar(const response::Valu
 		throw service::schema_exception { { R"ex(not a valid CatCommand value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesCatCommand.cbegin(), s_namesCatCommand.cend(), value.get<std::string>());
+	const auto itr = s_valuesCatCommand.find(value.get<std::string>());
 
-	if (itr == s_namesCatCommand.cend())
+	if (itr == s_valuesCatCommand.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid CatCommand value)ex" } };
 	}

--- a/samples/validation/schema/ValidationSchema.h
+++ b/samples/validation/schema/ValidationSchema.h
@@ -44,10 +44,10 @@ constexpr auto getDogCommandValues() noexcept
 {
 	using namespace std::literals;
 
-	return internal::string_view_map<DogCommand> {
-		{ R"gql(SIT)gql"sv, DogCommand::SIT },
-		{ R"gql(DOWN)gql"sv, DogCommand::DOWN },
-		{ R"gql(HEEL)gql"sv, DogCommand::HEEL }
+	return std::array<std::pair<std::string_view, DogCommand>, 3> {
+		std::make_pair(R"gql(SIT)gql"sv, DogCommand::SIT),
+		std::make_pair(R"gql(DOWN)gql"sv, DogCommand::DOWN),
+		std::make_pair(R"gql(HEEL)gql"sv, DogCommand::HEEL)
 	};
 }
 
@@ -69,8 +69,8 @@ constexpr auto getCatCommandValues() noexcept
 {
 	using namespace std::literals;
 
-	return internal::string_view_map<CatCommand> {
-		{ R"gql(JUMP)gql"sv, CatCommand::JUMP }
+	return std::array<std::pair<std::string_view, CatCommand>, 1> {
+		std::make_pair(R"gql(JUMP)gql"sv, CatCommand::JUMP)
 	};
 }
 

--- a/samples/validation/schema/ValidationSchema.h
+++ b/samples/validation/schema/ValidationSchema.h
@@ -22,14 +22,14 @@ static_assert(graphql::internal::MinorVersion == 2, "regenerate with schemagen: 
 namespace graphql {
 namespace validation {
 
-enum class DogCommand
+enum class [[nodiscard]] DogCommand
 {
 	SIT,
 	DOWN,
 	HEEL
 };
 
-constexpr auto getDogCommandNames() noexcept
+[[nodiscard]] constexpr auto getDogCommandNames() noexcept
 {
 	using namespace std::literals;
 
@@ -40,7 +40,7 @@ constexpr auto getDogCommandNames() noexcept
 	};
 }
 
-constexpr auto getDogCommandValues() noexcept
+[[nodiscard]] constexpr auto getDogCommandValues() noexcept
 {
 	using namespace std::literals;
 
@@ -51,12 +51,12 @@ constexpr auto getDogCommandValues() noexcept
 	};
 }
 
-enum class CatCommand
+enum class [[nodiscard]] CatCommand
 {
 	JUMP
 };
 
-constexpr auto getCatCommandNames() noexcept
+[[nodiscard]] constexpr auto getCatCommandNames() noexcept
 {
 	using namespace std::literals;
 
@@ -65,7 +65,7 @@ constexpr auto getCatCommandNames() noexcept
 	};
 }
 
-constexpr auto getCatCommandValues() noexcept
+[[nodiscard]] constexpr auto getCatCommandValues() noexcept
 {
 	using namespace std::literals;
 
@@ -104,7 +104,7 @@ class Arguments;
 
 } // namespace object
 
-class Operations final
+class [[nodiscard]] Operations final
 	: public service::Request
 {
 public:
@@ -149,7 +149,7 @@ std::shared_ptr<schema::Schema> GetSchema();
 namespace service {
 
 template <>
-constexpr bool isInputType<validation::ComplexInput>() noexcept
+[[nodiscard]] constexpr bool isInputType<validation::ComplexInput>() noexcept
 {
 	return true;
 }

--- a/samples/validation/schema/ValidationSchema.h
+++ b/samples/validation/schema/ValidationSchema.h
@@ -40,6 +40,17 @@ constexpr auto getDogCommandNames() noexcept
 	};
 }
 
+constexpr auto getDogCommandValues() noexcept
+{
+	using namespace std::literals;
+
+	return internal::string_view_map<DogCommand> {
+		{ R"gql(SIT)gql"sv, DogCommand::SIT },
+		{ R"gql(DOWN)gql"sv, DogCommand::DOWN },
+		{ R"gql(HEEL)gql"sv, DogCommand::HEEL }
+	};
+}
+
 enum class CatCommand
 {
 	JUMP
@@ -51,6 +62,15 @@ constexpr auto getCatCommandNames() noexcept
 
 	return std::array<std::string_view, 1> {
 		R"gql(JUMP)gql"sv
+	};
+}
+
+constexpr auto getCatCommandValues() noexcept
+{
+	using namespace std::literals;
+
+	return internal::string_view_map<CatCommand> {
+		{ R"gql(JUMP)gql"sv, CatCommand::JUMP }
 	};
 }
 

--- a/src/ClientGenerator.cpp
+++ b/src/ClientGenerator.cpp
@@ -206,8 +206,8 @@ static_assert(graphql::internal::MinorVersion == )cpp"
 	{
 		pendingSeparator.reset();
 
-		headerFile << R"cpp(enum class )cpp" << _schemaLoader.getCppType(enumType->name())
-				   << R"cpp(
+		headerFile << R"cpp(enum class [[nodiscard]] )cpp"
+				   << _schemaLoader.getCppType(enumType->name()) << R"cpp(
 {
 )cpp";
 		for (const auto& enumValue : enumType->enumValues())

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -207,8 +207,8 @@ constexpr auto get)cpp" << enumType.cppType
 {
 	using namespace std::literals;
 
-	return internal::string_view_map<)cpp"
-					   << enumType.cppType << R"cpp(> {
+	return std::array<std::pair<std::string_view, )cpp"
+					   << enumType.cppType << R"cpp(>, )cpp" << enumType.values.size() << R"cpp(> {
 )cpp";
 
 			std::vector<std::pair<std::string_view, std::string_view>> sortedValues(
@@ -237,8 +237,9 @@ constexpr auto get)cpp" << enumType.cppType
 				}
 
 				firstValue = false;
-				headerFile << R"cpp(		{ R"gql()cpp" << value.first << R"cpp()gql"sv, )cpp"
-						   << enumType.cppType << R"cpp(::)cpp" << value.second << R"cpp( })cpp";
+				headerFile << R"cpp(		std::make_pair(R"gql()cpp" << value.first
+						   << R"cpp()gql"sv, )cpp" << enumType.cppType << R"cpp(::)cpp"
+						   << value.second << R"cpp())cpp";
 			}
 
 			headerFile << R"cpp(
@@ -1207,7 +1208,7 @@ bool Generator::outputSource() const noexcept
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
-#include <tuple>
+#include <utility>
 #include <vector>
 
 using namespace std::literals;
@@ -1243,11 +1244,14 @@ template <>
 					   << enumType.type << R"cpp( value)ex" } };
 	}
 
-	const auto itr = s_values)cpp"
-					   << enumType.cppType << R"cpp(.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_values)cpp" << enumType.cppType
+					   << R"cpp(.begin(),
+		s_values)cpp" << enumType.cppType
+					   << R"cpp(.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_values)cpp"
-					   << enumType.cppType << R"cpp(.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid )cpp"
 					   << enumType.type << R"cpp( value)ex" } };
@@ -1287,11 +1291,14 @@ void ModifiedResult<)cpp"
 					   << enumType.type << R"cpp( value)ex" } };
 	}
 
-	const auto itr = s_values)cpp"
-					   << enumType.cppType << R"cpp(.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_values)cpp" << enumType.cppType
+					   << R"cpp(.begin(),
+		s_values)cpp" << enumType.cppType
+					   << R"cpp(.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_values)cpp"
-					   << enumType.cppType << R"cpp(.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid )cpp"
 					   << enumType.type << R"cpp( value)ex" } };

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -1244,20 +1244,18 @@ template <>
 					   << enumType.type << R"cpp( value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+	const auto result = internal::sorted_map_lookup<internal::shorter_or_less>(
 		s_values)cpp" << enumType.cppType
-					   << R"cpp(.begin(),
-		s_values)cpp" << enumType.cppType
-					   << R"cpp(.end(),
+					   << R"cpp(,
 		std::string_view { value.get<std::string>() });
 
-	if (itr == itrEnd)
+	if (!result)
 	{
 		throw service::schema_exception { { R"ex(not a valid )cpp"
 					   << enumType.type << R"cpp( value)ex" } };
 	}
 
-	return itr->second;
+	return *result;
 }
 
 template <>
@@ -1291,7 +1289,7 @@ void ModifiedResult<)cpp"
 					   << enumType.type << R"cpp( value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+	const auto [itr, itrEnd] = internal::sorted_map_equal_range<internal::shorter_or_less>(
 		s_values)cpp" << enumType.cppType
 					   << R"cpp(.begin(),
 		s_values)cpp" << enumType.cppType

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -153,7 +153,14 @@ static_assert(graphql::internal::MinorVersion == )cpp"
 
 		for (const auto& enumType : _loader.getEnumTypes())
 		{
-			headerFile << R"cpp(enum class [[nodiscard]] )cpp" << enumType.cppType << R"cpp(
+			headerFile << R"cpp(enum class )cpp";
+
+			if (!_loader.isIntrospection())
+			{
+				headerFile << R"cpp([[nodiscard]] )cpp";
+			}
+
+			headerFile << enumType.cppType << R"cpp(
 {
 )cpp";
 

--- a/src/introspection/DirectiveObject.h
+++ b/src/introspection/DirectiveObject.h
@@ -12,31 +12,31 @@
 
 namespace graphql::introspection::object {
 
-class Directive final
+class [[nodiscard]] Directive final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveLocations(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveIsRepeatable(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveLocations(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveIsRepeatable(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::AwaitableScalar<std::string> getName() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		virtual service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
-		virtual service::AwaitableScalar<bool> getIsRepeatable() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsRepeatable() const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -44,27 +44,27 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
+		[[nodiscard]] service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
 		{
 			return { _pimpl->getLocations() };
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		service::AwaitableScalar<bool> getIsRepeatable() const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsRepeatable() const final
 		{
 			return { _pimpl->getIsRepeatable() };
 		}
@@ -75,8 +75,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT Directive(std::shared_ptr<introspection::Directive> pimpl) noexcept;

--- a/src/introspection/EnumValueObject.h
+++ b/src/introspection/EnumValueObject.h
@@ -12,29 +12,29 @@
 
 namespace graphql::introspection::object {
 
-class EnumValue final
+class [[nodiscard]] EnumValue final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::AwaitableScalar<std::string> getName() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -42,22 +42,22 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::AwaitableScalar<bool> getIsDeprecated() const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}
@@ -68,8 +68,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT EnumValue(std::shared_ptr<introspection::EnumValue> pimpl) noexcept;

--- a/src/introspection/FieldObject.h
+++ b/src/introspection/FieldObject.h
@@ -12,33 +12,33 @@
 
 namespace graphql::introspection::object {
 
-class Field final
+class [[nodiscard]] Field final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::AwaitableScalar<std::string> getName() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
-		virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -46,32 +46,32 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		service::AwaitableObject<std::shared_ptr<Type>> getType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		service::AwaitableScalar<bool> getIsDeprecated() const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}
@@ -82,8 +82,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT Field(std::shared_ptr<introspection::Field> pimpl) noexcept;

--- a/src/introspection/InputValueObject.h
+++ b/src/introspection/InputValueObject.h
@@ -12,29 +12,29 @@
 
 namespace graphql::introspection::object {
 
-class InputValue final
+class [[nodiscard]] InputValue final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDefaultValue(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDefaultValue(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::AwaitableScalar<std::string> getName() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -42,22 +42,22 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::AwaitableObject<std::shared_ptr<Type>> getType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
 		{
 			return { _pimpl->getDefaultValue() };
 		}
@@ -68,8 +68,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT InputValue(std::shared_ptr<introspection::InputValue> pimpl) noexcept;

--- a/src/introspection/IntrospectionSchema.cpp
+++ b/src/introspection/IntrospectionSchema.cpp
@@ -20,6 +20,7 @@ namespace graphql {
 namespace service {
 
 static const auto s_namesTypeKind = introspection::getTypeKindNames();
+static const auto s_valuesTypeKind = introspection::getTypeKindValues();
 
 template <>
 introspection::TypeKind ModifiedArgument<introspection::TypeKind>::convert(const response::Value& value)
@@ -29,14 +30,14 @@ introspection::TypeKind ModifiedArgument<introspection::TypeKind>::convert(const
 		throw service::schema_exception { { R"ex(not a valid __TypeKind value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesTypeKind.cbegin(), s_namesTypeKind.cend(), value.get<std::string>());
+	const auto itr = s_valuesTypeKind.find(value.get<std::string>());
 
-	if (itr == s_namesTypeKind.cend())
+	if (itr == s_valuesTypeKind.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid __TypeKind value)ex" } };
 	}
 
-	return static_cast<introspection::TypeKind>(itr - s_namesTypeKind.cbegin());
+	return itr->second;
 }
 
 template <>
@@ -61,15 +62,16 @@ void ModifiedResult<introspection::TypeKind>::validateScalar(const response::Val
 		throw service::schema_exception { { R"ex(not a valid __TypeKind value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesTypeKind.cbegin(), s_namesTypeKind.cend(), value.get<std::string>());
+	const auto itr = s_valuesTypeKind.find(value.get<std::string>());
 
-	if (itr == s_namesTypeKind.cend())
+	if (itr == s_valuesTypeKind.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid __TypeKind value)ex" } };
 	}
 }
 
 static const auto s_namesDirectiveLocation = introspection::getDirectiveLocationNames();
+static const auto s_valuesDirectiveLocation = introspection::getDirectiveLocationValues();
 
 template <>
 introspection::DirectiveLocation ModifiedArgument<introspection::DirectiveLocation>::convert(const response::Value& value)
@@ -79,14 +81,14 @@ introspection::DirectiveLocation ModifiedArgument<introspection::DirectiveLocati
 		throw service::schema_exception { { R"ex(not a valid __DirectiveLocation value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesDirectiveLocation.cbegin(), s_namesDirectiveLocation.cend(), value.get<std::string>());
+	const auto itr = s_valuesDirectiveLocation.find(value.get<std::string>());
 
-	if (itr == s_namesDirectiveLocation.cend())
+	if (itr == s_valuesDirectiveLocation.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid __DirectiveLocation value)ex" } };
 	}
 
-	return static_cast<introspection::DirectiveLocation>(itr - s_namesDirectiveLocation.cbegin());
+	return itr->second;
 }
 
 template <>
@@ -111,9 +113,9 @@ void ModifiedResult<introspection::DirectiveLocation>::validateScalar(const resp
 		throw service::schema_exception { { R"ex(not a valid __DirectiveLocation value)ex" } };
 	}
 
-	const auto itr = std::find(s_namesDirectiveLocation.cbegin(), s_namesDirectiveLocation.cend(), value.get<std::string>());
+	const auto itr = s_valuesDirectiveLocation.find(value.get<std::string>());
 
-	if (itr == s_namesDirectiveLocation.cend())
+	if (itr == s_valuesDirectiveLocation.end())
 	{
 		throw service::schema_exception { { R"ex(not a valid __DirectiveLocation value)ex" } };
 	}

--- a/src/introspection/IntrospectionSchema.cpp
+++ b/src/introspection/IntrospectionSchema.cpp
@@ -30,17 +30,16 @@ introspection::TypeKind ModifiedArgument<introspection::TypeKind>::convert(const
 		throw service::schema_exception { { R"ex(not a valid __TypeKind value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
-		s_valuesTypeKind.begin(),
-		s_valuesTypeKind.end(),
+	const auto result = internal::sorted_map_lookup<internal::shorter_or_less>(
+		s_valuesTypeKind,
 		std::string_view { value.get<std::string>() });
 
-	if (itr == itrEnd)
+	if (!result)
 	{
 		throw service::schema_exception { { R"ex(not a valid __TypeKind value)ex" } };
 	}
 
-	return itr->second;
+	return *result;
 }
 
 template <>
@@ -65,7 +64,7 @@ void ModifiedResult<introspection::TypeKind>::validateScalar(const response::Val
 		throw service::schema_exception { { R"ex(not a valid __TypeKind value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+	const auto [itr, itrEnd] = internal::sorted_map_equal_range<internal::shorter_or_less>(
 		s_valuesTypeKind.begin(),
 		s_valuesTypeKind.end(),
 		std::string_view { value.get<std::string>() });
@@ -87,17 +86,16 @@ introspection::DirectiveLocation ModifiedArgument<introspection::DirectiveLocati
 		throw service::schema_exception { { R"ex(not a valid __DirectiveLocation value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
-		s_valuesDirectiveLocation.begin(),
-		s_valuesDirectiveLocation.end(),
+	const auto result = internal::sorted_map_lookup<internal::shorter_or_less>(
+		s_valuesDirectiveLocation,
 		std::string_view { value.get<std::string>() });
 
-	if (itr == itrEnd)
+	if (!result)
 	{
 		throw service::schema_exception { { R"ex(not a valid __DirectiveLocation value)ex" } };
 	}
 
-	return itr->second;
+	return *result;
 }
 
 template <>
@@ -122,7 +120,7 @@ void ModifiedResult<introspection::DirectiveLocation>::validateScalar(const resp
 		throw service::schema_exception { { R"ex(not a valid __DirectiveLocation value)ex" } };
 	}
 
-	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+	const auto [itr, itrEnd] = internal::sorted_map_equal_range<internal::shorter_or_less>(
 		s_valuesDirectiveLocation.begin(),
 		s_valuesDirectiveLocation.end(),
 		std::string_view { value.get<std::string>() });

--- a/src/introspection/IntrospectionSchema.cpp
+++ b/src/introspection/IntrospectionSchema.cpp
@@ -11,7 +11,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
-#include <tuple>
+#include <utility>
 #include <vector>
 
 using namespace std::literals;
@@ -30,9 +30,12 @@ introspection::TypeKind ModifiedArgument<introspection::TypeKind>::convert(const
 		throw service::schema_exception { { R"ex(not a valid __TypeKind value)ex" } };
 	}
 
-	const auto itr = s_valuesTypeKind.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesTypeKind.begin(),
+		s_valuesTypeKind.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesTypeKind.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid __TypeKind value)ex" } };
 	}
@@ -62,9 +65,12 @@ void ModifiedResult<introspection::TypeKind>::validateScalar(const response::Val
 		throw service::schema_exception { { R"ex(not a valid __TypeKind value)ex" } };
 	}
 
-	const auto itr = s_valuesTypeKind.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesTypeKind.begin(),
+		s_valuesTypeKind.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesTypeKind.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid __TypeKind value)ex" } };
 	}
@@ -81,9 +87,12 @@ introspection::DirectiveLocation ModifiedArgument<introspection::DirectiveLocati
 		throw service::schema_exception { { R"ex(not a valid __DirectiveLocation value)ex" } };
 	}
 
-	const auto itr = s_valuesDirectiveLocation.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesDirectiveLocation.begin(),
+		s_valuesDirectiveLocation.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesDirectiveLocation.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid __DirectiveLocation value)ex" } };
 	}
@@ -113,9 +122,12 @@ void ModifiedResult<introspection::DirectiveLocation>::validateScalar(const resp
 		throw service::schema_exception { { R"ex(not a valid __DirectiveLocation value)ex" } };
 	}
 
-	const auto itr = s_valuesDirectiveLocation.find(value.get<std::string>());
+	const auto [itr, itrEnd] = internal::find_sorted_map_key<internal::shorter_or_less>(
+		s_valuesDirectiveLocation.begin(),
+		s_valuesDirectiveLocation.end(),
+		std::string_view { value.get<std::string>() });
 
-	if (itr == s_valuesDirectiveLocation.end())
+	if (itr == itrEnd)
 	{
 		throw service::schema_exception { { R"ex(not a valid __DirectiveLocation value)ex" } };
 	}

--- a/src/introspection/IntrospectionSchema.h
+++ b/src/introspection/IntrospectionSchema.h
@@ -50,6 +50,22 @@ constexpr auto getTypeKindNames() noexcept
 	};
 }
 
+constexpr auto getTypeKindValues() noexcept
+{
+	using namespace std::literals;
+
+	return internal::string_view_map<TypeKind> {
+		{ R"gql(ENUM)gql"sv, TypeKind::ENUM },
+		{ R"gql(LIST)gql"sv, TypeKind::LIST },
+		{ R"gql(UNION)gql"sv, TypeKind::UNION },
+		{ R"gql(OBJECT)gql"sv, TypeKind::OBJECT },
+		{ R"gql(SCALAR)gql"sv, TypeKind::SCALAR },
+		{ R"gql(NON_NULL)gql"sv, TypeKind::NON_NULL },
+		{ R"gql(INTERFACE)gql"sv, TypeKind::INTERFACE },
+		{ R"gql(INPUT_OBJECT)gql"sv, TypeKind::INPUT_OBJECT }
+	};
+}
+
 enum class DirectiveLocation
 {
 	QUERY,
@@ -97,6 +113,33 @@ constexpr auto getDirectiveLocationNames() noexcept
 		R"gql(ENUM_VALUE)gql"sv,
 		R"gql(INPUT_OBJECT)gql"sv,
 		R"gql(INPUT_FIELD_DEFINITION)gql"sv
+	};
+}
+
+constexpr auto getDirectiveLocationValues() noexcept
+{
+	using namespace std::literals;
+
+	return internal::string_view_map<DirectiveLocation> {
+		{ R"gql(ENUM)gql"sv, DirectiveLocation::ENUM },
+		{ R"gql(FIELD)gql"sv, DirectiveLocation::FIELD },
+		{ R"gql(QUERY)gql"sv, DirectiveLocation::QUERY },
+		{ R"gql(UNION)gql"sv, DirectiveLocation::UNION },
+		{ R"gql(OBJECT)gql"sv, DirectiveLocation::OBJECT },
+		{ R"gql(SCALAR)gql"sv, DirectiveLocation::SCALAR },
+		{ R"gql(SCHEMA)gql"sv, DirectiveLocation::SCHEMA },
+		{ R"gql(MUTATION)gql"sv, DirectiveLocation::MUTATION },
+		{ R"gql(INTERFACE)gql"sv, DirectiveLocation::INTERFACE },
+		{ R"gql(ENUM_VALUE)gql"sv, DirectiveLocation::ENUM_VALUE },
+		{ R"gql(INPUT_OBJECT)gql"sv, DirectiveLocation::INPUT_OBJECT },
+		{ R"gql(SUBSCRIPTION)gql"sv, DirectiveLocation::SUBSCRIPTION },
+		{ R"gql(FRAGMENT_SPREAD)gql"sv, DirectiveLocation::FRAGMENT_SPREAD },
+		{ R"gql(INLINE_FRAGMENT)gql"sv, DirectiveLocation::INLINE_FRAGMENT },
+		{ R"gql(FIELD_DEFINITION)gql"sv, DirectiveLocation::FIELD_DEFINITION },
+		{ R"gql(ARGUMENT_DEFINITION)gql"sv, DirectiveLocation::ARGUMENT_DEFINITION },
+		{ R"gql(FRAGMENT_DEFINITION)gql"sv, DirectiveLocation::FRAGMENT_DEFINITION },
+		{ R"gql(VARIABLE_DEFINITION)gql"sv, DirectiveLocation::VARIABLE_DEFINITION },
+		{ R"gql(INPUT_FIELD_DEFINITION)gql"sv, DirectiveLocation::INPUT_FIELD_DEFINITION }
 	};
 }
 

--- a/src/introspection/IntrospectionSchema.h
+++ b/src/introspection/IntrospectionSchema.h
@@ -22,7 +22,7 @@ static_assert(graphql::internal::MinorVersion == 2, "regenerate with schemagen: 
 namespace graphql {
 namespace introspection {
 
-enum class [[nodiscard]] TypeKind
+enum class TypeKind
 {
 	SCALAR,
 	OBJECT,
@@ -66,7 +66,7 @@ enum class [[nodiscard]] TypeKind
 	};
 }
 
-enum class [[nodiscard]] DirectiveLocation
+enum class DirectiveLocation
 {
 	QUERY,
 	MUTATION,

--- a/src/introspection/IntrospectionSchema.h
+++ b/src/introspection/IntrospectionSchema.h
@@ -54,15 +54,15 @@ constexpr auto getTypeKindValues() noexcept
 {
 	using namespace std::literals;
 
-	return internal::string_view_map<TypeKind> {
-		{ R"gql(ENUM)gql"sv, TypeKind::ENUM },
-		{ R"gql(LIST)gql"sv, TypeKind::LIST },
-		{ R"gql(UNION)gql"sv, TypeKind::UNION },
-		{ R"gql(OBJECT)gql"sv, TypeKind::OBJECT },
-		{ R"gql(SCALAR)gql"sv, TypeKind::SCALAR },
-		{ R"gql(NON_NULL)gql"sv, TypeKind::NON_NULL },
-		{ R"gql(INTERFACE)gql"sv, TypeKind::INTERFACE },
-		{ R"gql(INPUT_OBJECT)gql"sv, TypeKind::INPUT_OBJECT }
+	return std::array<std::pair<std::string_view, TypeKind>, 8> {
+		std::make_pair(R"gql(ENUM)gql"sv, TypeKind::ENUM),
+		std::make_pair(R"gql(LIST)gql"sv, TypeKind::LIST),
+		std::make_pair(R"gql(UNION)gql"sv, TypeKind::UNION),
+		std::make_pair(R"gql(OBJECT)gql"sv, TypeKind::OBJECT),
+		std::make_pair(R"gql(SCALAR)gql"sv, TypeKind::SCALAR),
+		std::make_pair(R"gql(NON_NULL)gql"sv, TypeKind::NON_NULL),
+		std::make_pair(R"gql(INTERFACE)gql"sv, TypeKind::INTERFACE),
+		std::make_pair(R"gql(INPUT_OBJECT)gql"sv, TypeKind::INPUT_OBJECT)
 	};
 }
 
@@ -120,26 +120,26 @@ constexpr auto getDirectiveLocationValues() noexcept
 {
 	using namespace std::literals;
 
-	return internal::string_view_map<DirectiveLocation> {
-		{ R"gql(ENUM)gql"sv, DirectiveLocation::ENUM },
-		{ R"gql(FIELD)gql"sv, DirectiveLocation::FIELD },
-		{ R"gql(QUERY)gql"sv, DirectiveLocation::QUERY },
-		{ R"gql(UNION)gql"sv, DirectiveLocation::UNION },
-		{ R"gql(OBJECT)gql"sv, DirectiveLocation::OBJECT },
-		{ R"gql(SCALAR)gql"sv, DirectiveLocation::SCALAR },
-		{ R"gql(SCHEMA)gql"sv, DirectiveLocation::SCHEMA },
-		{ R"gql(MUTATION)gql"sv, DirectiveLocation::MUTATION },
-		{ R"gql(INTERFACE)gql"sv, DirectiveLocation::INTERFACE },
-		{ R"gql(ENUM_VALUE)gql"sv, DirectiveLocation::ENUM_VALUE },
-		{ R"gql(INPUT_OBJECT)gql"sv, DirectiveLocation::INPUT_OBJECT },
-		{ R"gql(SUBSCRIPTION)gql"sv, DirectiveLocation::SUBSCRIPTION },
-		{ R"gql(FRAGMENT_SPREAD)gql"sv, DirectiveLocation::FRAGMENT_SPREAD },
-		{ R"gql(INLINE_FRAGMENT)gql"sv, DirectiveLocation::INLINE_FRAGMENT },
-		{ R"gql(FIELD_DEFINITION)gql"sv, DirectiveLocation::FIELD_DEFINITION },
-		{ R"gql(ARGUMENT_DEFINITION)gql"sv, DirectiveLocation::ARGUMENT_DEFINITION },
-		{ R"gql(FRAGMENT_DEFINITION)gql"sv, DirectiveLocation::FRAGMENT_DEFINITION },
-		{ R"gql(VARIABLE_DEFINITION)gql"sv, DirectiveLocation::VARIABLE_DEFINITION },
-		{ R"gql(INPUT_FIELD_DEFINITION)gql"sv, DirectiveLocation::INPUT_FIELD_DEFINITION }
+	return std::array<std::pair<std::string_view, DirectiveLocation>, 19> {
+		std::make_pair(R"gql(ENUM)gql"sv, DirectiveLocation::ENUM),
+		std::make_pair(R"gql(FIELD)gql"sv, DirectiveLocation::FIELD),
+		std::make_pair(R"gql(QUERY)gql"sv, DirectiveLocation::QUERY),
+		std::make_pair(R"gql(UNION)gql"sv, DirectiveLocation::UNION),
+		std::make_pair(R"gql(OBJECT)gql"sv, DirectiveLocation::OBJECT),
+		std::make_pair(R"gql(SCALAR)gql"sv, DirectiveLocation::SCALAR),
+		std::make_pair(R"gql(SCHEMA)gql"sv, DirectiveLocation::SCHEMA),
+		std::make_pair(R"gql(MUTATION)gql"sv, DirectiveLocation::MUTATION),
+		std::make_pair(R"gql(INTERFACE)gql"sv, DirectiveLocation::INTERFACE),
+		std::make_pair(R"gql(ENUM_VALUE)gql"sv, DirectiveLocation::ENUM_VALUE),
+		std::make_pair(R"gql(INPUT_OBJECT)gql"sv, DirectiveLocation::INPUT_OBJECT),
+		std::make_pair(R"gql(SUBSCRIPTION)gql"sv, DirectiveLocation::SUBSCRIPTION),
+		std::make_pair(R"gql(FRAGMENT_SPREAD)gql"sv, DirectiveLocation::FRAGMENT_SPREAD),
+		std::make_pair(R"gql(INLINE_FRAGMENT)gql"sv, DirectiveLocation::INLINE_FRAGMENT),
+		std::make_pair(R"gql(FIELD_DEFINITION)gql"sv, DirectiveLocation::FIELD_DEFINITION),
+		std::make_pair(R"gql(ARGUMENT_DEFINITION)gql"sv, DirectiveLocation::ARGUMENT_DEFINITION),
+		std::make_pair(R"gql(FRAGMENT_DEFINITION)gql"sv, DirectiveLocation::FRAGMENT_DEFINITION),
+		std::make_pair(R"gql(VARIABLE_DEFINITION)gql"sv, DirectiveLocation::VARIABLE_DEFINITION),
+		std::make_pair(R"gql(INPUT_FIELD_DEFINITION)gql"sv, DirectiveLocation::INPUT_FIELD_DEFINITION)
 	};
 }
 

--- a/src/introspection/IntrospectionSchema.h
+++ b/src/introspection/IntrospectionSchema.h
@@ -22,7 +22,7 @@ static_assert(graphql::internal::MinorVersion == 2, "regenerate with schemagen: 
 namespace graphql {
 namespace introspection {
 
-enum class TypeKind
+enum class [[nodiscard]] TypeKind
 {
 	SCALAR,
 	OBJECT,
@@ -34,7 +34,7 @@ enum class TypeKind
 	NON_NULL
 };
 
-constexpr auto getTypeKindNames() noexcept
+[[nodiscard]] constexpr auto getTypeKindNames() noexcept
 {
 	using namespace std::literals;
 
@@ -50,7 +50,7 @@ constexpr auto getTypeKindNames() noexcept
 	};
 }
 
-constexpr auto getTypeKindValues() noexcept
+[[nodiscard]] constexpr auto getTypeKindValues() noexcept
 {
 	using namespace std::literals;
 
@@ -66,7 +66,7 @@ constexpr auto getTypeKindValues() noexcept
 	};
 }
 
-enum class DirectiveLocation
+enum class [[nodiscard]] DirectiveLocation
 {
 	QUERY,
 	MUTATION,
@@ -89,7 +89,7 @@ enum class DirectiveLocation
 	INPUT_FIELD_DEFINITION
 };
 
-constexpr auto getDirectiveLocationNames() noexcept
+[[nodiscard]] constexpr auto getDirectiveLocationNames() noexcept
 {
 	using namespace std::literals;
 
@@ -116,7 +116,7 @@ constexpr auto getDirectiveLocationNames() noexcept
 	};
 }
 
-constexpr auto getDirectiveLocationValues() noexcept
+[[nodiscard]] constexpr auto getDirectiveLocationValues() noexcept
 {
 	using namespace std::literals;
 

--- a/src/introspection/SchemaObject.h
+++ b/src/introspection/SchemaObject.h
@@ -12,33 +12,33 @@
 
 namespace graphql::introspection::object {
 
-class Schema final
+class [[nodiscard]] Schema final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveTypes(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveQueryType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveMutationType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveSubscriptionType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDirectives(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveTypes(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveQueryType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveMutationType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveSubscriptionType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDirectives(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const = 0;
-		virtual service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -46,32 +46,32 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
 		{
 			return { _pimpl->getTypes() };
 		}
 
-		service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
 		{
 			return { _pimpl->getQueryType() };
 		}
 
-		service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
 		{
 			return { _pimpl->getMutationType() };
 		}
 
-		service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
 		{
 			return { _pimpl->getSubscriptionType() };
 		}
 
-		service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
 		{
 			return { _pimpl->getDirectives() };
 		}
@@ -82,8 +82,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT Schema(std::shared_ptr<introspection::Schema> pimpl) noexcept;

--- a/src/introspection/TypeObject.h
+++ b/src/introspection/TypeObject.h
@@ -12,41 +12,41 @@
 
 namespace graphql::introspection::object {
 
-class Type final
+class [[nodiscard]] Type final
 	: public service::Object
 {
 private:
-	service::AwaitableResolver resolveKind(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveFields(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveInterfaces(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolvePossibleTypes(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveEnumValues(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveInputFields(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveOfType(service::ResolverParams&& params) const;
-	service::AwaitableResolver resolveSpecifiedByURL(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveKind(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveFields(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveInterfaces(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolvePossibleTypes(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveEnumValues(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveInputFields(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveOfType(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolveSpecifiedByURL(service::ResolverParams&& params) const;
 
-	service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct Concept
+	struct [[nodiscard]] Concept
 	{
 		virtual ~Concept() = default;
 
-		virtual service::AwaitableScalar<TypeKind> getKind() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getName() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const = 0;
-		virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const = 0;
-		virtual service::AwaitableObject<std::shared_ptr<Type>> getOfType() const = 0;
-		virtual service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<TypeKind> getKind() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getName() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const = 0;
+		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getOfType() const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const = 0;
 	};
 
 	template <class T>
-	struct Model
+	struct [[nodiscard]] Model
 		: Concept
 	{
 		Model(std::shared_ptr<T>&& pimpl) noexcept
@@ -54,52 +54,52 @@ private:
 		{
 		}
 
-		service::AwaitableScalar<TypeKind> getKind() const final
+		[[nodiscard]] service::AwaitableScalar<TypeKind> getKind() const final
 		{
 			return { _pimpl->getKind() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getFields(std::move(includeDeprecatedArg)) };
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
 		{
 			return { _pimpl->getInterfaces() };
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
 		{
 			return { _pimpl->getPossibleTypes() };
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getEnumValues(std::move(includeDeprecatedArg)) };
 		}
 
-		service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
 		{
 			return { _pimpl->getInputFields() };
 		}
 
-		service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
 		{
 			return { _pimpl->getOfType() };
 		}
 
-		service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
 		{
 			return { _pimpl->getSpecifiedByURL() };
 		}
@@ -110,8 +110,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	service::TypeNames getTypeNames() const noexcept;
-	service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT Type(std::shared_ptr<introspection::Type> pimpl) noexcept;

--- a/test/ArgumentTests.cpp
+++ b/test/ArgumentTests.cpp
@@ -214,13 +214,12 @@ TEST(ArgumentsCase, TaskStateEnumConstexpr)
 	using namespace std::literals;
 
 	const auto values = today::getTaskStateValues();
-	const auto [itr, itrEnd] =
-		internal::find_sorted_map_key<internal::shorter_or_less>(values.begin(),
-			values.end(),
+	constexpr auto actual =
+		internal::sorted_map_lookup<internal::shorter_or_less>(today::getTaskStateValues(),
 			"Started"sv);
 
-	ASSERT_TRUE(itr != itrEnd) << "should find a value";
-	EXPECT_TRUE(today::TaskState::Started == itr->second) << "should parse the enum";
+	ASSERT_TRUE(actual) << "should find a value";
+	EXPECT_TRUE(today::TaskState::Started == *actual) << "should parse the enum";
 }
 
 TEST(ArgumentsCase, ScalarArgumentMap)

--- a/test/ArgumentTests.cpp
+++ b/test/ArgumentTests.cpp
@@ -218,6 +218,8 @@ TEST(ArgumentsCase, TaskStateEnumConstexpr)
 		internal::sorted_map_lookup<internal::shorter_or_less>(today::getTaskStateValues(),
 			"Started"sv);
 
+	static_assert(today::TaskState::Started == *actual, "can also perform lookups at compile time");
+
 	ASSERT_TRUE(actual) << "should find a value";
 	EXPECT_TRUE(today::TaskState::Started == *actual) << "should parse the enum";
 }

--- a/test/ArgumentTests.cpp
+++ b/test/ArgumentTests.cpp
@@ -209,6 +209,18 @@ TEST(ArgumentsCase, TaskStateEnumFromJSONString)
 	EXPECT_EQ(today::TaskState::Started, actual) << "should parse the enum";
 }
 
+
+TEST(ArgumentsCase, TaskStateEnumConstexpr)
+{
+	using namespace std::literals;
+
+	const auto values = today::getTaskStateValues();
+	const auto itr = values.find("Started"sv);
+
+	ASSERT_TRUE(itr != values.end()) << "should find a value";
+	EXPECT_TRUE(today::TaskState::Started == itr->second) << "should parse the enum";
+}
+
 TEST(ArgumentsCase, ScalarArgumentMap)
 {
 	response::Value response(response::Type::Map);

--- a/test/ArgumentTests.cpp
+++ b/test/ArgumentTests.cpp
@@ -209,15 +209,17 @@ TEST(ArgumentsCase, TaskStateEnumFromJSONString)
 	EXPECT_EQ(today::TaskState::Started, actual) << "should parse the enum";
 }
 
-
 TEST(ArgumentsCase, TaskStateEnumConstexpr)
 {
 	using namespace std::literals;
 
 	const auto values = today::getTaskStateValues();
-	const auto itr = values.find("Started"sv);
+	const auto [itr, itrEnd] =
+		internal::find_sorted_map_key<internal::shorter_or_less>(values.begin(),
+			values.end(),
+			"Started"sv);
 
-	ASSERT_TRUE(itr != values.end()) << "should find a value";
+	ASSERT_TRUE(itr != itrEnd) << "should find a value";
 	EXPECT_TRUE(today::TaskState::Started == itr->second) << "should parse the enum";
 }
 

--- a/test/ArgumentTests.cpp
+++ b/test/ArgumentTests.cpp
@@ -213,7 +213,6 @@ TEST(ArgumentsCase, TaskStateEnumConstexpr)
 {
 	using namespace std::literals;
 
-	const auto values = today::getTaskStateValues();
 	constexpr auto actual =
 		internal::sorted_map_lookup<internal::shorter_or_less>(today::getTaskStateValues(),
 			"Started"sv);


### PR DESCRIPTION
Fix #139 

Unfortunately, `constexpr` support for `std::vector` seems to be lagging behind in GCC and AppleClang, so I was only able to do this by extracting some of the lookup logic an templatizing it on the container and iterator types in `internal::sorted_map_equal_range` and `internal::sorted_map_lookup`. That way it can apply the same logic to perform lookups against a `std::array<std::pair<K, V>>` as it would for an `internal::sorted_map<K, V>`.

The only place where I've actually adopted this is in the generated enum value maps, but this should make looking up an enum value `O(log(n))` instead of `O(n)` at runtime. It also lets you perform compile time mapping between the strings and their enum values.

