### PR TITLE
Miscellaneous warnings and errors which showed up in GCC 12

### DIFF
--- a/include/graphqlservice/GraphQLClient.h
+++ b/include/graphqlservice/GraphQLClient.h
@@ -87,7 +87,6 @@ concept OnlyNoneModifiers = (... && (Other == TypeModifier::None));
 template <typename Type, TypeModifier... Other>
 concept InputVariableUniquePtr = InputVariableClass<Type> && OnlyNoneModifiers<Other...>;
 
-
 // Serialize variable input values with chained type modifiers which add nullable or list wrappers.
 template <typename Type>
 struct ModifiedVariable
@@ -115,7 +114,7 @@ struct ModifiedVariable
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static
+	[[nodiscard]] static inline
 		typename std::enable_if_t<TypeModifier::None == Modifier && sizeof...(Other) == 0,
 			response::Value>
 		serialize(Type&& value)
@@ -126,7 +125,7 @@ struct ModifiedVariable
 
 	// Peel off nullable modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static
+	[[nodiscard]] static inline
 		typename std::enable_if_t<TypeModifier::Nullable == Modifier, response::Value>
 		serialize(typename VariableTraits<Type, Modifier, Other...>::type&& nullableValue)
 	{
@@ -143,8 +142,9 @@ struct ModifiedVariable
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::List == Modifier, response::Value>
-	serialize(typename VariableTraits<Type, Modifier, Other...>::type&& listValue)
+	[[nodiscard]] static inline
+		typename std::enable_if_t<TypeModifier::List == Modifier, response::Value>
+		serialize(typename VariableTraits<Type, Modifier, Other...>::type&& listValue)
 	{
 		response::Value result { response::Type::List };
 
@@ -159,7 +159,7 @@ struct ModifiedVariable
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static
+	[[nodiscard]] static inline
 		typename std::enable_if_t<TypeModifier::None == Modifier && sizeof...(Other) == 0, Type>
 		duplicate(const Type& value)
 	{
@@ -169,7 +169,7 @@ struct ModifiedVariable
 
 	// Peel off nullable modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::Nullable == Modifier,
+	[[nodiscard]] static inline typename std::enable_if_t<TypeModifier::Nullable == Modifier,
 		typename VariableTraits<Type, Modifier, Other...>::type>
 	duplicate(const typename VariableTraits<Type, Modifier, Other...>::type& nullableValue)
 	{
@@ -193,7 +193,7 @@ struct ModifiedVariable
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::List == Modifier,
+	[[nodiscard]] static inline typename std::enable_if_t<TypeModifier::List == Modifier,
 		typename VariableTraits<Type, Modifier, Other...>::type>
 	duplicate(const typename VariableTraits<Type, Modifier, Other...>::type& listValue)
 	{
@@ -259,7 +259,7 @@ struct ModifiedResponse
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static
+	[[nodiscard]] static inline
 		typename std::enable_if_t<TypeModifier::None == Modifier && sizeof...(Other) == 0, Type>
 		parse(response::Value&& response)
 	{
@@ -268,7 +268,7 @@ struct ModifiedResponse
 
 	// Peel off nullable modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::Nullable == Modifier,
+	[[nodiscard]] static inline typename std::enable_if_t<TypeModifier::Nullable == Modifier,
 		std::optional<typename ResponseTraits<Type, Other...>::type>>
 	parse(response::Value&& response)
 	{
@@ -283,7 +283,7 @@ struct ModifiedResponse
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::List == Modifier,
+	[[nodiscard]] static inline typename std::enable_if_t<TypeModifier::List == Modifier,
 		std::vector<typename ResponseTraits<Type, Other...>::type>>
 	parse(response::Value&& response)
 	{

--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -209,6 +209,9 @@ struct ValueTypeTraits<FloatType>
 	using get_type = FloatType;
 };
 
+template <typename ValueType>
+concept ValueTypeMatches = std::is_same_v<std::decay_t<ValueType>, ValueType>;
+
 // Represent a discriminated union of GraphQL response value types.
 struct [[nodiscard]] Value
 {
@@ -265,15 +268,13 @@ struct [[nodiscard]] Value
 
 	// Specialized for all single-value Types.
 	template <typename ValueType>
-	void set(typename std::enable_if_t<std::is_same_v<std::decay_t<ValueType>, ValueType>,
-		typename ValueTypeTraits<ValueType>::set_type>
-			value);
+	void set(
+		typename ValueTypeTraits<ValueType>::set_type value) requires ValueTypeMatches<ValueType>;
 
 	// Specialized for all Types.
 	template <typename ValueType>
-	[[nodiscard]] typename std::enable_if_t<std::is_same_v<std::decay_t<ValueType>, ValueType>,
-		typename ValueTypeTraits<ValueType>::get_type>
-	get() const;
+	[[nodiscard]] typename ValueTypeTraits<ValueType>::get_type get() const requires
+		ValueTypeMatches<ValueType>;
 
 	// Specialized for all Types which allocate extra memory.
 	template <typename ValueType>

--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -396,42 +396,42 @@ private:
 	template <class T>
 	struct Model : Concept
 	{
-		Model(std::unique_ptr<T>&& pimpl)
+		inline Model(std::unique_ptr<T>&& pimpl)
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		void start_object() const final
+		inline void start_object() const final
 		{
 			_pimpl->start_object();
 		}
 
-		void add_member(const std::string& key) const final
+		inline void add_member(const std::string& key) const final
 		{
 			_pimpl->add_member(key);
 		}
 
-		void end_object() const final
+		inline void end_object() const final
 		{
 			_pimpl->end_object();
 		}
 
-		void start_array() const final
+		inline void start_array() const final
 		{
 			_pimpl->start_array();
 		}
 
-		void end_arrary() const final
+		inline void end_arrary() const final
 		{
 			_pimpl->end_arrary();
 		}
 
-		void write_null() const final
+		inline void write_null() const final
 		{
 			_pimpl->write_null();
 		}
 
-		void write_string(const std::string& value) const final
+		inline void write_string(const std::string& value) const final
 		{
 			_pimpl->write_string(value);
 		}
@@ -441,12 +441,12 @@ private:
 			_pimpl->write_bool(value);
 		}
 
-		void write_int(int value) const final
+		inline void write_int(int value) const final
 		{
 			_pimpl->write_int(value);
 		}
 
-		void write_float(double value) const final
+		inline void write_float(double value) const final
 		{
 			_pimpl->write_float(value);
 		}
@@ -459,7 +459,7 @@ private:
 
 public:
 	template <class T>
-	Writer(std::unique_ptr<T> writer)
+	inline Writer(std::unique_ptr<T> writer)
 		: _concept { std::static_pointer_cast<const Concept>(
 			std::make_shared<Model<T>>(std::move(writer))) }
 	{

--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -209,9 +209,6 @@ struct ValueTypeTraits<FloatType>
 	using get_type = FloatType;
 };
 
-template <typename ValueType>
-concept ValueTypeMatches = std::is_same_v<std::decay_t<ValueType>, ValueType>;
-
 // Represent a discriminated union of GraphQL response value types.
 struct [[nodiscard]] Value
 {
@@ -268,13 +265,11 @@ struct [[nodiscard]] Value
 
 	// Specialized for all single-value Types.
 	template <typename ValueType>
-	void set(
-		typename ValueTypeTraits<ValueType>::set_type value) requires ValueTypeMatches<ValueType>;
+	void set(typename ValueTypeTraits<ValueType>::set_type value);
 
 	// Specialized for all Types.
 	template <typename ValueType>
-	[[nodiscard]] typename ValueTypeTraits<ValueType>::get_type get() const requires
-		ValueTypeMatches<ValueType>;
+	[[nodiscard]] typename ValueTypeTraits<ValueType>::get_type get() const;
 
 	// Specialized for all Types which allocate extra memory.
 	template <typename ValueType>

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -892,8 +892,7 @@ struct Result
 		AwaitableObject<std::shared_ptr<const Object>>, AwaitableScalar<Type>>;
 
 	// Convert a single value of the specified type to JSON.
-	[[nodiscard]] static AwaitableResolver convert(
-		typename future_type result, ResolverParams params);
+	[[nodiscard]] static AwaitableResolver convert(future_type result, ResolverParams params);
 
 	// Validate a single scalar value is the expected type.
 	static void validateScalar(const response::Value& value);

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -884,6 +884,10 @@ concept ObjectBaseType = std::is_base_of_v<Object, Type>;
 template <typename Type>
 concept ObjectDerivedType = ObjectBaseType<Type> && !ObjectType<Type>;
 
+// Test if a nullable type is std::shared_ptr<Type> or std::optional<T>.
+template <typename Type, TypeModifier... Other>
+concept NullableSharedPtr = OnlyNoneModifiers<Other...> && ObjectBaseType<Type>;
+
 // Test if this method should std::static_pointer_cast an ObjectDerivedType to
 // std::shared_ptr<const Object>.
 template <typename Type, TypeModifier Modifier, TypeModifier... Other>
@@ -914,8 +918,8 @@ struct ModifiedResult
 	struct ResultTraits
 	{
 		using type = typename std::conditional_t<NullableModifier<Modifier>,
-			typename std::conditional_t<OnlyNoneModifiers<Other...> && ObjectBaseType<U>,
-				std::shared_ptr<U>, std::optional<typename ResultTraits<U, Other...>::type>>,
+			typename std::conditional_t<NullableSharedPtr<U, Other...>, std::shared_ptr<U>,
+				std::optional<typename ResultTraits<U, Other...>::type>>,
 			typename std::conditional_t<ListModifier<Modifier>,
 				std::vector<typename ResultTraits<U, Other...>::type>,
 				typename std::conditional_t<ObjectBaseType<U>, std::shared_ptr<U>, U>>>;

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -197,22 +197,22 @@ private:
 	template <class T>
 	struct [[nodiscard]] Model : Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl)
+		inline Model(std::shared_ptr<T>&& pimpl)
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] bool await_ready() const final
+		[[nodiscard]] inline bool await_ready() const final
 		{
 			return _pimpl->await_ready();
 		}
 
-		void await_suspend(coro::coroutine_handle<> h) const final
+		inline void await_suspend(coro::coroutine_handle<> h) const final
 		{
 			_pimpl->await_suspend(std::move(h));
 		}
 
-		void await_resume() const final
+		inline void await_resume() const final
 		{
 			_pimpl->await_resume();
 		}
@@ -226,7 +226,7 @@ private:
 public:
 	// Type-erased explicit constructor for a custom awaitable.
 	template <class T>
-	explicit await_async(std::shared_ptr<T> pimpl)
+	inline explicit await_async(std::shared_ptr<T> pimpl)
 		: _pimpl { std::make_shared<Model<T>>(std::move(pimpl)) }
 	{
 	}
@@ -300,39 +300,39 @@ class [[nodiscard]] AwaitableScalar
 {
 public:
 	template <typename U>
-	AwaitableScalar(U&& value)
+	inline AwaitableScalar(U&& value)
 		: _value { std::forward<U>(value) }
 	{
 	}
 
 	struct promise_type
 	{
-		[[nodiscard]] AwaitableScalar<T> get_return_object() noexcept
+		[[nodiscard]] inline AwaitableScalar<T> get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
 
-		coro::suspend_never initial_suspend() const noexcept
+		inline coro::suspend_never initial_suspend() const noexcept
 		{
 			return {};
 		}
 
-		coro::suspend_never final_suspend() const noexcept
+		inline coro::suspend_never final_suspend() const noexcept
 		{
 			return {};
 		}
 
-		void return_value(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
+		inline void return_value(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
 		{
 			_promise.set_value(value);
 		}
 
-		void return_value(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
+		inline void return_value(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
 		{
 			_promise.set_value(std::move(value));
 		}
 
-		void unhandled_exception() noexcept
+		inline void unhandled_exception() noexcept
 		{
 			_promise.set_exception(std::current_exception());
 		}
@@ -341,7 +341,7 @@ public:
 		std::promise<T> _promise;
 	};
 
-	[[nodiscard]] bool await_ready() const noexcept
+	[[nodiscard]] inline bool await_ready() const noexcept
 	{
 		return std::visit(
 			[](const auto& value) noexcept {
@@ -366,7 +366,7 @@ public:
 			_value);
 	}
 
-	void await_suspend(coro::coroutine_handle<> h) const
+	inline void await_suspend(coro::coroutine_handle<> h) const
 	{
 		std::thread(
 			[this](coro::coroutine_handle<> h) noexcept {
@@ -377,7 +377,7 @@ public:
 			.detach();
 	}
 
-	[[nodiscard]] T await_resume()
+	[[nodiscard]] inline T await_resume()
 	{
 		return std::visit(
 			[](auto&& value) -> T {
@@ -400,7 +400,7 @@ public:
 			std::move(_value));
 	}
 
-	[[nodiscard]] std::shared_ptr<const response::Value> get_value() noexcept
+	[[nodiscard]] inline std::shared_ptr<const response::Value> get_value() noexcept
 	{
 		return std::visit(
 			[](auto&& value) noexcept {
@@ -429,39 +429,39 @@ class [[nodiscard]] AwaitableObject
 {
 public:
 	template <typename U>
-	AwaitableObject(U&& value)
+	inline AwaitableObject(U&& value)
 		: _value { std::forward<U>(value) }
 	{
 	}
 
 	struct promise_type
 	{
-		[[nodiscard]] AwaitableObject<T> get_return_object() noexcept
+		[[nodiscard]] inline AwaitableObject<T> get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
 
-		coro::suspend_never initial_suspend() const noexcept
+		inline coro::suspend_never initial_suspend() const noexcept
 		{
 			return {};
 		}
 
-		coro::suspend_never final_suspend() const noexcept
+		inline coro::suspend_never final_suspend() const noexcept
 		{
 			return {};
 		}
 
-		void return_value(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
+		inline void return_value(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
 		{
 			_promise.set_value(value);
 		}
 
-		void return_value(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
+		inline void return_value(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
 		{
 			_promise.set_value(std::move(value));
 		}
 
-		void unhandled_exception() noexcept
+		inline void unhandled_exception() noexcept
 		{
 			_promise.set_exception(std::current_exception());
 		}
@@ -470,7 +470,7 @@ public:
 		std::promise<T> _promise;
 	};
 
-	[[nodiscard]] bool await_ready() const noexcept
+	[[nodiscard]] inline bool await_ready() const noexcept
 	{
 		return std::visit(
 			[](const auto& value) noexcept {
@@ -490,7 +490,7 @@ public:
 			_value);
 	}
 
-	void await_suspend(coro::coroutine_handle<> h) const
+	inline void await_suspend(coro::coroutine_handle<> h) const
 	{
 		std::thread(
 			[this](coro::coroutine_handle<> h) noexcept {
@@ -501,7 +501,7 @@ public:
 			.detach();
 	}
 
-	[[nodiscard]] T await_resume()
+	[[nodiscard]] inline T await_resume()
 	{
 		return std::visit(
 			[](auto&& value) -> T {
@@ -638,7 +638,8 @@ struct ModifiedArgument
 	[[nodiscard]] static Type convert(const response::Value& value);
 
 	// Call convert on this type without any modifiers.
-	[[nodiscard]] static Type require(std::string_view name, const response::Value& arguments)
+	[[nodiscard]] static inline Type require(
+		std::string_view name, const response::Value& arguments)
 	{
 		try
 		{
@@ -662,7 +663,7 @@ struct ModifiedArgument
 	}
 
 	// Wrap require in a try/catch block.
-	[[nodiscard]] static std::pair<Type, bool> find(
+	[[nodiscard]] static inline std::pair<Type, bool> find(
 		const std::string& name, const response::Value& arguments) noexcept
 	{
 		try
@@ -677,7 +678,8 @@ struct ModifiedArgument
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::None == Modifier, Type> require(
+	[[nodiscard]] static inline typename std::enable_if_t<TypeModifier::None == Modifier, Type>
+	require(
 		std::string_view name, const response::Value& arguments)
 	{
 		static_assert(sizeof...(Other) == 0, "None modifier should always be last");
@@ -688,7 +690,7 @@ struct ModifiedArgument
 
 	// Peel off nullable modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::Nullable == Modifier,
+	[[nodiscard]] static inline typename std::enable_if_t<TypeModifier::Nullable == Modifier,
 		typename ArgumentTraits<Type, Modifier, Other...>::type>
 	require(std::string_view name, const response::Value& arguments)
 	{
@@ -714,7 +716,7 @@ struct ModifiedArgument
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::List == Modifier,
+	[[nodiscard]] static inline typename std::enable_if_t<TypeModifier::List == Modifier,
 		typename ArgumentTraits<Type, Modifier, Other...>::type>
 	require(std::string_view name, const response::Value& arguments)
 	{
@@ -738,7 +740,8 @@ struct ModifiedArgument
 
 	// Wrap require with modifiers in a try/catch block.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static std::pair<typename ArgumentTraits<Type, Modifier, Other...>::type, bool>
+	[[nodiscard]] static inline std::pair<typename ArgumentTraits<Type, Modifier, Other...>::type,
+		bool>
 	find(std::string_view name, const response::Value& arguments) noexcept
 	{
 		try
@@ -753,7 +756,7 @@ struct ModifiedArgument
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static
+	[[nodiscard]] static inline
 		typename std::enable_if_t<TypeModifier::None == Modifier && sizeof...(Other) == 0, Type>
 		duplicate(const Type& value)
 	{
@@ -763,7 +766,7 @@ struct ModifiedArgument
 
 	// Peel off nullable modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::Nullable == Modifier,
+	[[nodiscard]] static inline typename std::enable_if_t<TypeModifier::Nullable == Modifier,
 		typename ArgumentTraits<Type, Modifier, Other...>::type>
 	duplicate(const typename ArgumentTraits<Type, Modifier, Other...>::type& nullableValue)
 	{
@@ -787,7 +790,7 @@ struct ModifiedArgument
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::List == Modifier,
+	[[nodiscard]] static inline typename std::enable_if_t<TypeModifier::List == Modifier,
 		typename ArgumentTraits<Type, Modifier, Other...>::type>
 	duplicate(const typename ArgumentTraits<Type, Modifier, Other...>::type& listValue)
 	{
@@ -903,7 +906,7 @@ struct ModifiedResult
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::None == Modifier
+	[[nodiscard]] static inline typename std::enable_if_t<TypeModifier::None == Modifier
 			&& !std::is_same_v<Object, Type> && std::is_base_of_v<Object, Type>,
 		AwaitableResolver>
 	convert(AwaitableObject<typename ResultTraits<Type>::type> result, ResolverParams params)
@@ -925,7 +928,7 @@ struct ModifiedResult
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::None == Modifier
+	[[nodiscard]] static inline typename std::enable_if_t<TypeModifier::None == Modifier
 			&& (std::is_same_v<Object, Type> || !std::is_base_of_v<Object, Type>),
 		AwaitableResolver>
 	convert(typename ResultTraits<Type>::future_type result, ResolverParams params)
@@ -938,7 +941,7 @@ struct ModifiedResult
 
 	// Peel off final nullable modifiers for std::shared_ptr of Object and subclasses of Object.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::Nullable == Modifier
+	[[nodiscard]] static inline typename std::enable_if_t<TypeModifier::Nullable == Modifier
 			&& std::is_same_v<std::shared_ptr<Type>, typename ResultTraits<Type, Other...>::type>,
 		AwaitableResolver>
 	convert(
@@ -961,7 +964,7 @@ struct ModifiedResult
 
 	// Peel off nullable modifiers for anything else, which should all be std::optional.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static typename std::enable_if_t<TypeModifier::Nullable == Modifier
+	[[nodiscard]] static inline typename std::enable_if_t<TypeModifier::Nullable == Modifier
 			&& !std::is_same_v<std::shared_ptr<Type>, typename ResultTraits<Type, Other...>::type>,
 		AwaitableResolver>
 	convert(
@@ -1000,7 +1003,7 @@ struct ModifiedResult
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static
+	[[nodiscard]] static inline
 		typename std::enable_if_t<TypeModifier::List == Modifier, AwaitableResolver>
 		convert(typename ResultTraits<Type, Modifier, Other...>::future_type result,
 			ResolverParams params)
@@ -1107,7 +1110,7 @@ private:
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	static void validateScalar(
+	static inline void validateScalar(
 		typename std::enable_if_t<TypeModifier::None == Modifier, const response::Value&> value)
 	{
 		static_assert(sizeof...(Other) == 0, "None modifier should always be last");
@@ -1118,7 +1121,7 @@ private:
 
 	// Peel off nullable modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	static void validateScalar(
+	static inline void validateScalar(
 		typename std::enable_if_t<TypeModifier::Nullable == Modifier, const response::Value&> value)
 	{
 		if (value.type() != response::Type::Null)
@@ -1129,7 +1132,7 @@ private:
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	static void validateScalar(
+	static inline void validateScalar(
 		typename std::enable_if_t<TypeModifier::List == Modifier, const response::Value&> value)
 	{
 		if (value.type() != response::Type::List)
@@ -1146,7 +1149,8 @@ private:
 	using ResolverCallback =
 		std::function<response::Value(typename ResultTraits<Type>::type, const ResolverParams&)>;
 
-	[[nodiscard]] static AwaitableResolver resolve(typename ResultTraits<Type>::future_type result,
+	[[nodiscard]] static inline AwaitableResolver resolve(
+		typename ResultTraits<Type>::future_type result,
 		ResolverParams params, ResolverCallback&& resolver)
 	{
 		static_assert(!std::is_base_of_v<Object, Type>,

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -890,13 +890,13 @@ concept NullableSharedPtr = OnlyNoneModifiers<Other...> && ObjectBaseType<Type>;
 
 // Test if this method should std::static_pointer_cast an ObjectDerivedType to
 // std::shared_ptr<const Object>.
-template <typename Type, TypeModifier Modifier, TypeModifier... Other>
-concept NoneObjectDerivedType = OnlyNoneModifiers<Modifier, Other...> && ObjectDerivedType<Type>;
+template <typename Type, TypeModifier Modifier>
+concept NoneObjectDerivedType = OnlyNoneModifiers<Modifier> && ObjectDerivedType<Type>;
 
 // Test all other result types to see if they should call the specialized convert method without
 // template parameters.
-template <typename Type, TypeModifier Modifier, TypeModifier... Other>
-concept NoneScalarOrObjectType = OnlyNoneModifiers<Modifier, Other...> && !ObjectDerivedType<Type>;
+template <typename Type, TypeModifier Modifier>
+concept NoneScalarOrObjectType = OnlyNoneModifiers<Modifier> && !ObjectDerivedType<Type>;
 
 // Test if this method should return a nullable std::shared_ptr<Type>
 template <typename Type, TypeModifier Modifier, TypeModifier... Other>
@@ -945,7 +945,7 @@ struct ModifiedResult
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
 	[[nodiscard]] static inline AwaitableResolver convert(
 		AwaitableObject<typename ResultTraits<Type>::type> result,
-		ResolverParams params) requires NoneObjectDerivedType<Type, Modifier, Other...>
+		ResolverParams params) requires NoneObjectDerivedType<Type, Modifier>
 	{
 		// Call through to the Object specialization with a static_pointer_cast for subclasses of
 		// Object.
@@ -966,7 +966,7 @@ struct ModifiedResult
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
 	[[nodiscard]] static inline AwaitableResolver convert(
 		typename ResultTraits<Type>::future_type result,
-		ResolverParams params) requires NoneScalarOrObjectType<Type, Modifier, Other...>
+		ResolverParams params) requires NoneScalarOrObjectType<Type, Modifier>
 	{
 		static_assert(sizeof...(Other) == 0, "None modifier should always be last");
 

--- a/include/graphqlservice/internal/Awaitable.h
+++ b/include/graphqlservice/internal/Awaitable.h
@@ -28,39 +28,39 @@ template <>
 class [[nodiscard]] Awaitable<void>
 {
 public:
-	Awaitable(std::future<void> value)
+	inline Awaitable(std::future<void> value)
 		: _value { std::move(value) }
 	{
 	}
 
-	void get()
+	inline void get()
 	{
 		_value.get();
 	}
 
 	struct promise_type
 	{
-		[[nodiscard]] Awaitable get_return_object() noexcept
+		[[nodiscard]] inline Awaitable get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
 
-		coro::suspend_never initial_suspend() const noexcept
+		inline coro::suspend_never initial_suspend() const noexcept
 		{
 			return {};
 		}
 
-		coro::suspend_never final_suspend() const noexcept
+		inline coro::suspend_never final_suspend() const noexcept
 		{
 			return {};
 		}
 
-		void return_void() noexcept
+		inline void return_void() noexcept
 		{
 			_promise.set_value();
 		}
 
-		void unhandled_exception() noexcept
+		inline void unhandled_exception() noexcept
 		{
 			_promise.set_exception(std::current_exception());
 		}
@@ -74,12 +74,12 @@ public:
 		return true;
 	}
 
-	void await_suspend(coro::coroutine_handle<> h) const
+	inline void await_suspend(coro::coroutine_handle<> h) const
 	{
 		h.resume();
 	}
 
-	void await_resume()
+	inline void await_resume()
 	{
 		_value.get();
 	}
@@ -92,44 +92,44 @@ template <typename T>
 class [[nodiscard]] Awaitable
 {
 public:
-	Awaitable(std::future<T> value)
+	inline Awaitable(std::future<T> value)
 		: _value { std::move(value) }
 	{
 	}
 
-	[[nodiscard]] T get()
+	[[nodiscard]] inline T get()
 	{
 		return _value.get();
 	}
 
 	struct promise_type
 	{
-		[[nodiscard]] Awaitable get_return_object() noexcept
+		[[nodiscard]] inline Awaitable get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
 
-		coro::suspend_never initial_suspend() const noexcept
+		inline coro::suspend_never initial_suspend() const noexcept
 		{
 			return {};
 		}
 
-		coro::suspend_never final_suspend() const noexcept
+		inline coro::suspend_never final_suspend() const noexcept
 		{
 			return {};
 		}
 
-		void return_value(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
+		inline void return_value(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
 		{
 			_promise.set_value(value);
 		}
 
-		void return_value(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
+		inline void return_value(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
 		{
 			_promise.set_value(std::move(value));
 		}
 
-		void unhandled_exception() noexcept
+		inline void unhandled_exception() noexcept
 		{
 			_promise.set_exception(std::current_exception());
 		}
@@ -143,12 +143,12 @@ public:
 		return true;
 	}
 
-	void await_suspend(coro::coroutine_handle<> h) const
+	inline void await_suspend(coro::coroutine_handle<> h) const
 	{
 		h.resume();
 	}
 
-	[[nodiscard]] T await_resume()
+	[[nodiscard]] inline T await_resume()
 	{
 		return _value.get();
 	}

--- a/include/graphqlservice/internal/Grammar.h
+++ b/include/graphqlservice/internal/Grammar.h
@@ -18,7 +18,7 @@ namespace graphql::peg {
 using namespace tao::graphqlpeg;
 
 template <typename Rule>
-void for_each_child(const ast_node& n, std::function<void(const ast_node&)>&& func)
+inline void for_each_child(const ast_node& n, std::function<void(const ast_node&)>&& func)
 {
 	for (const auto& child : n.children)
 	{
@@ -30,7 +30,7 @@ void for_each_child(const ast_node& n, std::function<void(const ast_node&)>&& fu
 }
 
 template <typename Rule>
-void on_first_child_if(const ast_node& n, std::function<bool(const ast_node&)>&& func)
+inline void on_first_child_if(const ast_node& n, std::function<bool(const ast_node&)>&& func)
 {
 	for (const auto& child : n.children)
 	{
@@ -42,7 +42,7 @@ void on_first_child_if(const ast_node& n, std::function<bool(const ast_node&)>&&
 }
 
 template <typename Rule>
-void on_first_child(const ast_node& n, std::function<void(const ast_node&)>&& func)
+inline void on_first_child(const ast_node& n, std::function<void(const ast_node&)>&& func)
 {
 	for (const auto& child : n.children)
 	{

--- a/include/graphqlservice/internal/SortedMap.h
+++ b/include/graphqlservice/internal/SortedMap.h
@@ -86,7 +86,7 @@ public:
 		return _data == rhs._data;
 	}
 
-	void reserve(size_t size)
+	inline void reserve(size_t size)
 	{
 		_data.reserve(size);
 	}
@@ -96,7 +96,7 @@ public:
 		return _data.capacity();
 	}
 
-	void clear() noexcept
+	inline void clear() noexcept
 	{
 		_data.clear();
 	}
@@ -147,7 +147,7 @@ public:
 	}
 
 	template <typename KeyArg, typename... ValueArgs>
-	std::pair<const_iterator, bool> emplace(KeyArg&& keyArg, ValueArgs&&... args) noexcept
+	inline std::pair<const_iterator, bool> emplace(KeyArg&& keyArg, ValueArgs&&... args) noexcept
 	{
 		K key { std::forward<KeyArg>(keyArg) };
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
@@ -161,7 +161,7 @@ public:
 			true };
 	}
 
-	const_iterator erase(const K& key) noexcept
+	inline const_iterator erase(const K& key) noexcept
 	{
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
 
@@ -174,20 +174,20 @@ public:
 	}
 
 	template <typename KeyArg>
-	const_iterator erase(KeyArg&& keyArg) noexcept
+	inline const_iterator erase(KeyArg&& keyArg) noexcept
 	{
 		const K key { std::forward<KeyArg>(keyArg) };
 
 		return erase(key);
 	}
 
-	const_iterator erase(const_iterator itr) noexcept
+	inline const_iterator erase(const_iterator itr) noexcept
 	{
 		return _data.erase(itr);
 	}
 
 	template <typename KeyArg>
-	[[nodiscard]] V& operator[](KeyArg&& keyArg) noexcept
+	[[nodiscard]] inline V& operator[](KeyArg&& keyArg) noexcept
 	{
 		K key { std::forward<KeyArg>(keyArg) };
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
@@ -201,7 +201,7 @@ public:
 	}
 
 	template <typename KeyArg>
-	[[nodiscard]] V& at(KeyArg&& keyArg)
+	[[nodiscard]] inline V& at(KeyArg&& keyArg)
 	{
 		const K key { std::forward<KeyArg>(keyArg) };
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
@@ -246,7 +246,7 @@ public:
 		return _data == rhs._data;
 	}
 
-	void reserve(size_t size)
+	inline void reserve(size_t size)
 	{
 		_data.reserve(size);
 	}
@@ -256,7 +256,7 @@ public:
 		return _data.capacity();
 	}
 
-	void clear() noexcept
+	inline void clear() noexcept
 	{
 		_data.clear();
 	}
@@ -310,7 +310,7 @@ public:
 	}
 
 	template <typename Arg>
-	std::pair<const_iterator, bool> emplace(Arg&& key) noexcept
+	inline std::pair<const_iterator, bool> emplace(Arg&& key) noexcept
 	{
 		const auto [itr, itrEnd] = std::equal_range(_data.begin(),
 			_data.end(),
@@ -327,7 +327,7 @@ public:
 		return { _data.emplace(itrEnd, std::forward<Arg>(key)), true };
 	}
 
-	const_iterator erase(const K& key) noexcept
+	inline const_iterator erase(const K& key) noexcept
 	{
 		const auto [itr, itrEnd] = std::equal_range(_data.begin(),
 			_data.end(),
@@ -345,14 +345,14 @@ public:
 	}
 
 	template <typename Arg>
-	const_iterator erase(Arg&& arg) noexcept
+	inline const_iterator erase(Arg&& arg) noexcept
 	{
 		const K key { std::forward<Arg>(arg) };
 
 		return erase(key);
 	}
 
-	const_iterator erase(const_iterator itr) noexcept
+	inline const_iterator erase(const_iterator itr) noexcept
 	{
 		return _data.erase(itr);
 	}

--- a/include/graphqlservice/internal/SortedMap.h
+++ b/include/graphqlservice/internal/SortedMap.h
@@ -23,20 +23,20 @@ struct [[nodiscard]] sorted_map_key
 	{
 	}
 
-	constexpr sorted_map_key(const K& key) noexcept
+	constexpr sorted_map_key(K key) noexcept
 		: key { key }
 	{
 	}
 
 	constexpr ~sorted_map_key() noexcept = default;
 
-	const K& key;
+	K key;
 };
 
 template <class Compare, class Iterator, class K,
 	class V = decltype(std::declval<Iterator>()->second)>
 [[nodiscard]] constexpr std::pair<Iterator, Iterator> sorted_map_equal_range(
-	Iterator itrBegin, Iterator itrEnd, const K& key) noexcept
+	Iterator itrBegin, Iterator itrEnd, K key) noexcept
 {
 	return std::equal_range(itrBegin,
 		itrEnd,
@@ -47,7 +47,7 @@ template <class Compare, class Iterator, class K,
 }
 
 template <class Compare, class Container, class K>
-[[nodiscard]] constexpr auto sorted_map_lookup(const Container& container, const K& key) noexcept
+[[nodiscard]] constexpr auto sorted_map_lookup(const Container& container, K key) noexcept
 {
 	const auto [itr, itrEnd] =
 		sorted_map_equal_range<Compare>(container.begin(), container.end(), key);
@@ -131,7 +131,7 @@ public:
 		return _data.rend();
 	}
 
-	[[nodiscard]] constexpr const_iterator find(const K& key) const noexcept
+	[[nodiscard]] constexpr const_iterator find(K key) const noexcept
 	{
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
 
@@ -161,7 +161,7 @@ public:
 			true };
 	}
 
-	inline const_iterator erase(const K& key) noexcept
+	inline const_iterator erase(K key) noexcept
 	{
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
 
@@ -291,12 +291,11 @@ public:
 		return _data.rend();
 	}
 
-	[[nodiscard]] constexpr const_iterator find(const K& key) const noexcept
+	[[nodiscard]] constexpr const_iterator find(K key) const noexcept
 	{
-		const auto [itr, itrEnd] =
-			std::equal_range(begin(), end(), key, [](const K& lhs, const K& rhs) noexcept {
-				return Compare {}(lhs, rhs);
-			});
+		const auto [itr, itrEnd] = std::equal_range(begin(), end(), key, [](K lhs, K rhs) noexcept {
+			return Compare {}(lhs, rhs);
+		});
 
 		return itr == itrEnd ? _data.end() : itr;
 	}
@@ -312,10 +311,8 @@ public:
 	template <typename Arg>
 	inline std::pair<const_iterator, bool> emplace(Arg&& key) noexcept
 	{
-		const auto [itr, itrEnd] = std::equal_range(_data.begin(),
-			_data.end(),
-			key,
-			[](const auto& lhs, const auto& rhs) noexcept {
+		const auto [itr, itrEnd] =
+			std::equal_range(_data.begin(), _data.end(), key, [](K lhs, K rhs) noexcept {
 				return Compare {}(lhs, rhs);
 			});
 
@@ -327,12 +324,10 @@ public:
 		return { _data.emplace(itrEnd, std::forward<Arg>(key)), true };
 	}
 
-	inline const_iterator erase(const K& key) noexcept
+	inline const_iterator erase(K key) noexcept
 	{
-		const auto [itr, itrEnd] = std::equal_range(_data.begin(),
-			_data.end(),
-			key,
-			[](const K& lhs, const K& rhs) noexcept {
+		const auto [itr, itrEnd] =
+			std::equal_range(_data.begin(), _data.end(), key, [](K lhs, K rhs) noexcept {
 				return Compare {}(lhs, rhs);
 			});
 
@@ -364,7 +359,7 @@ private:
 struct [[nodiscard]] shorter_or_less
 {
 	[[nodiscard]] constexpr bool operator()(
-		const std::string_view& lhs, const std::string_view& rhs) const noexcept
+		std::string_view lhs, std::string_view rhs) const noexcept
 	{
 		return lhs.size() == rhs.size() ? lhs < rhs : lhs.size() < rhs.size();
 	}

--- a/include/graphqlservice/internal/SyntaxTree.h
+++ b/include/graphqlservice/internal/SyntaxTree.h
@@ -32,7 +32,7 @@ public:
 	[[nodiscard]] GRAPHQLPEG_EXPORT std::string_view unescaped_view() const;
 
 	template <typename U>
-	[[nodiscard]] bool is_type() const noexcept
+	[[nodiscard]] inline bool is_type() const noexcept
 	{
 		const auto u = type_name<U>();
 
@@ -48,7 +48,7 @@ public:
 	using basic_node_t = parse_tree::basic_node<ast_node>;
 
 	template <typename Rule, typename ParseInput>
-	void success(const ParseInput& in)
+	inline void success(const ParseInput& in)
 	{
 		basic_node_t::template success<Rule>(in);
 		_type_name = type_name<Rule>();
@@ -57,7 +57,7 @@ public:
 
 private:
 	template <typename U>
-	[[nodiscard]] static std::string_view type_name() noexcept
+	[[nodiscard]] static inline std::string_view type_name() noexcept
 	{
 		// This is cached in a static local variable per-specialization, but each module may have
 		// its own instance of the specialization and the local variable. Within a single module,
@@ -69,7 +69,7 @@ private:
 	}
 
 	template <typename U>
-	[[nodiscard]] static size_t type_hash() noexcept
+	[[nodiscard]] static inline size_t type_hash() noexcept
 	{
 		// This is cached in a static local variable per-specialization, but each module may have
 		// its own instance of the specialization and the local variable.

--- a/include/graphqlservice/introspection/DirectiveObject.h
+++ b/include/graphqlservice/introspection/DirectiveObject.h
@@ -39,32 +39,32 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
 		{
 			return { _pimpl->getLocations() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsRepeatable() const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getIsRepeatable() const final
 		{
 			return { _pimpl->getIsRepeatable() };
 		}

--- a/include/graphqlservice/introspection/EnumValueObject.h
+++ b/include/graphqlservice/introspection/EnumValueObject.h
@@ -37,27 +37,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}

--- a/include/graphqlservice/introspection/FieldObject.h
+++ b/include/graphqlservice/introspection/FieldObject.h
@@ -41,37 +41,37 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}

--- a/include/graphqlservice/introspection/InputValueObject.h
+++ b/include/graphqlservice/introspection/InputValueObject.h
@@ -37,27 +37,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
 		{
 			return { _pimpl->getDefaultValue() };
 		}

--- a/include/graphqlservice/introspection/IntrospectionSchema.h
+++ b/include/graphqlservice/introspection/IntrospectionSchema.h
@@ -177,7 +177,7 @@ namespace service {
 #ifdef GRAPHQL_DLLEXPORTS
 // Export all of the built-in converters
 template <>
-GRAPHQLSERVICE_EXPORT introspection::TypeKind ModifiedArgument<introspection::TypeKind>::convert(
+GRAPHQLSERVICE_EXPORT introspection::TypeKind Argument<introspection::TypeKind>::convert(
 	const response::Value& value);
 template <>
 GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<introspection::TypeKind>::convert(
@@ -186,7 +186,7 @@ template <>
 GRAPHQLSERVICE_EXPORT void ModifiedResult<introspection::TypeKind>::validateScalar(
 	const response::Value& value);
 template <>
-GRAPHQLSERVICE_EXPORT introspection::DirectiveLocation ModifiedArgument<introspection::DirectiveLocation>::convert(
+GRAPHQLSERVICE_EXPORT introspection::DirectiveLocation Argument<introspection::DirectiveLocation>::convert(
 	const response::Value& value);
 template <>
 GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<introspection::DirectiveLocation>::convert(

--- a/include/graphqlservice/introspection/IntrospectionSchema.h
+++ b/include/graphqlservice/introspection/IntrospectionSchema.h
@@ -180,19 +180,19 @@ template <>
 GRAPHQLSERVICE_EXPORT introspection::TypeKind Argument<introspection::TypeKind>::convert(
 	const response::Value& value);
 template <>
-GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<introspection::TypeKind>::convert(
+GRAPHQLSERVICE_EXPORT AwaitableResolver Result<introspection::TypeKind>::convert(
 	AwaitableScalar<introspection::TypeKind> result, ResolverParams params);
 template <>
-GRAPHQLSERVICE_EXPORT void ModifiedResult<introspection::TypeKind>::validateScalar(
+GRAPHQLSERVICE_EXPORT void Result<introspection::TypeKind>::validateScalar(
 	const response::Value& value);
 template <>
 GRAPHQLSERVICE_EXPORT introspection::DirectiveLocation Argument<introspection::DirectiveLocation>::convert(
 	const response::Value& value);
 template <>
-GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<introspection::DirectiveLocation>::convert(
+GRAPHQLSERVICE_EXPORT AwaitableResolver Result<introspection::DirectiveLocation>::convert(
 	AwaitableScalar<introspection::DirectiveLocation> result, ResolverParams params);
 template <>
-GRAPHQLSERVICE_EXPORT void ModifiedResult<introspection::DirectiveLocation>::validateScalar(
+GRAPHQLSERVICE_EXPORT void Result<introspection::DirectiveLocation>::validateScalar(
 	const response::Value& value);
 #endif // GRAPHQL_DLLEXPORTS
 

--- a/include/graphqlservice/introspection/SchemaObject.h
+++ b/include/graphqlservice/introspection/SchemaObject.h
@@ -41,37 +41,37 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
 		{
 			return { _pimpl->getTypes() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
 		{
 			return { _pimpl->getQueryType() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
 		{
 			return { _pimpl->getMutationType() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
 		{
 			return { _pimpl->getSubscriptionType() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
 		{
 			return { _pimpl->getDirectives() };
 		}

--- a/include/graphqlservice/introspection/TypeObject.h
+++ b/include/graphqlservice/introspection/TypeObject.h
@@ -49,57 +49,57 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<TypeKind> getKind() const final
+		[[nodiscard]] inline service::AwaitableScalar<TypeKind> getKind() const final
 		{
 			return { _pimpl->getKind() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getFields(std::move(includeDeprecatedArg)) };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
 		{
 			return { _pimpl->getInterfaces() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
 		{
 			return { _pimpl->getPossibleTypes() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getEnumValues(std::move(includeDeprecatedArg)) };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
 		{
 			return { _pimpl->getInputFields() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
 		{
 			return { _pimpl->getOfType() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
 		{
 			return { _pimpl->getSpecifiedByURL() };
 		}

--- a/samples/client/benchmark/BenchmarkClient.cpp
+++ b/samples/client/benchmark/BenchmarkClient.cpp
@@ -64,7 +64,7 @@ const peg::ast& GetRequestObject() noexcept
 using namespace benchmark;
 
 template <>
-query::Query::Response::appointments_AppointmentConnection::pageInfo_PageInfo ModifiedResponse<query::Query::Response::appointments_AppointmentConnection::pageInfo_PageInfo>::parse(response::Value&& response)
+query::Query::Response::appointments_AppointmentConnection::pageInfo_PageInfo Response<query::Query::Response::appointments_AppointmentConnection::pageInfo_PageInfo>::parse(response::Value&& response)
 {
 	query::Query::Response::appointments_AppointmentConnection::pageInfo_PageInfo result;
 
@@ -86,7 +86,7 @@ query::Query::Response::appointments_AppointmentConnection::pageInfo_PageInfo Mo
 }
 
 template <>
-query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment ModifiedResponse<query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment>::parse(response::Value&& response)
+query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment Response<query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment>::parse(response::Value&& response)
 {
 	query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment result;
 
@@ -123,7 +123,7 @@ query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdg
 }
 
 template <>
-query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge ModifiedResponse<query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge>::parse(response::Value&& response)
+query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge Response<query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge>::parse(response::Value&& response)
 {
 	query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge result;
 
@@ -145,7 +145,7 @@ query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdg
 }
 
 template <>
-query::Query::Response::appointments_AppointmentConnection ModifiedResponse<query::Query::Response::appointments_AppointmentConnection>::parse(response::Value&& response)
+query::Query::Response::appointments_AppointmentConnection Response<query::Query::Response::appointments_AppointmentConnection>::parse(response::Value&& response)
 {
 	query::Query::Response::appointments_AppointmentConnection result;
 

--- a/samples/client/multiple/MultipleQueriesClient.cpp
+++ b/samples/client/multiple/MultipleQueriesClient.cpp
@@ -173,7 +173,7 @@ CompleteTaskInput& CompleteTaskInput::operator=(CompleteTaskInput&& other) noexc
 using namespace multiple;
 
 template <>
-query::Appointments::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment ModifiedResponse<query::Appointments::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment>::parse(response::Value&& response)
+query::Appointments::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment Response<query::Appointments::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment>::parse(response::Value&& response)
 {
 	query::Appointments::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment result;
 
@@ -215,7 +215,7 @@ query::Appointments::Response::appointments_AppointmentConnection::edges_Appoint
 }
 
 template <>
-query::Appointments::Response::appointments_AppointmentConnection::edges_AppointmentEdge ModifiedResponse<query::Appointments::Response::appointments_AppointmentConnection::edges_AppointmentEdge>::parse(response::Value&& response)
+query::Appointments::Response::appointments_AppointmentConnection::edges_AppointmentEdge Response<query::Appointments::Response::appointments_AppointmentConnection::edges_AppointmentEdge>::parse(response::Value&& response)
 {
 	query::Appointments::Response::appointments_AppointmentConnection::edges_AppointmentEdge result;
 
@@ -237,7 +237,7 @@ query::Appointments::Response::appointments_AppointmentConnection::edges_Appoint
 }
 
 template <>
-query::Appointments::Response::appointments_AppointmentConnection ModifiedResponse<query::Appointments::Response::appointments_AppointmentConnection>::parse(response::Value&& response)
+query::Appointments::Response::appointments_AppointmentConnection Response<query::Appointments::Response::appointments_AppointmentConnection>::parse(response::Value&& response)
 {
 	query::Appointments::Response::appointments_AppointmentConnection result;
 
@@ -291,7 +291,7 @@ Response parseResponse(response::Value&& response)
 } // namespace query::Appointments
 
 template <>
-query::Tasks::Response::tasks_TaskConnection::edges_TaskEdge::node_Task ModifiedResponse<query::Tasks::Response::tasks_TaskConnection::edges_TaskEdge::node_Task>::parse(response::Value&& response)
+query::Tasks::Response::tasks_TaskConnection::edges_TaskEdge::node_Task Response<query::Tasks::Response::tasks_TaskConnection::edges_TaskEdge::node_Task>::parse(response::Value&& response)
 {
 	query::Tasks::Response::tasks_TaskConnection::edges_TaskEdge::node_Task result;
 
@@ -328,7 +328,7 @@ query::Tasks::Response::tasks_TaskConnection::edges_TaskEdge::node_Task Modified
 }
 
 template <>
-query::Tasks::Response::tasks_TaskConnection::edges_TaskEdge ModifiedResponse<query::Tasks::Response::tasks_TaskConnection::edges_TaskEdge>::parse(response::Value&& response)
+query::Tasks::Response::tasks_TaskConnection::edges_TaskEdge Response<query::Tasks::Response::tasks_TaskConnection::edges_TaskEdge>::parse(response::Value&& response)
 {
 	query::Tasks::Response::tasks_TaskConnection::edges_TaskEdge result;
 
@@ -350,7 +350,7 @@ query::Tasks::Response::tasks_TaskConnection::edges_TaskEdge ModifiedResponse<qu
 }
 
 template <>
-query::Tasks::Response::tasks_TaskConnection ModifiedResponse<query::Tasks::Response::tasks_TaskConnection>::parse(response::Value&& response)
+query::Tasks::Response::tasks_TaskConnection Response<query::Tasks::Response::tasks_TaskConnection>::parse(response::Value&& response)
 {
 	query::Tasks::Response::tasks_TaskConnection result;
 
@@ -404,7 +404,7 @@ Response parseResponse(response::Value&& response)
 } // namespace query::Tasks
 
 template <>
-query::UnreadCounts::Response::unreadCounts_FolderConnection::edges_FolderEdge::node_Folder ModifiedResponse<query::UnreadCounts::Response::unreadCounts_FolderConnection::edges_FolderEdge::node_Folder>::parse(response::Value&& response)
+query::UnreadCounts::Response::unreadCounts_FolderConnection::edges_FolderEdge::node_Folder Response<query::UnreadCounts::Response::unreadCounts_FolderConnection::edges_FolderEdge::node_Folder>::parse(response::Value&& response)
 {
 	query::UnreadCounts::Response::unreadCounts_FolderConnection::edges_FolderEdge::node_Folder result;
 
@@ -441,7 +441,7 @@ query::UnreadCounts::Response::unreadCounts_FolderConnection::edges_FolderEdge::
 }
 
 template <>
-query::UnreadCounts::Response::unreadCounts_FolderConnection::edges_FolderEdge ModifiedResponse<query::UnreadCounts::Response::unreadCounts_FolderConnection::edges_FolderEdge>::parse(response::Value&& response)
+query::UnreadCounts::Response::unreadCounts_FolderConnection::edges_FolderEdge Response<query::UnreadCounts::Response::unreadCounts_FolderConnection::edges_FolderEdge>::parse(response::Value&& response)
 {
 	query::UnreadCounts::Response::unreadCounts_FolderConnection::edges_FolderEdge result;
 
@@ -463,7 +463,7 @@ query::UnreadCounts::Response::unreadCounts_FolderConnection::edges_FolderEdge M
 }
 
 template <>
-query::UnreadCounts::Response::unreadCounts_FolderConnection ModifiedResponse<query::UnreadCounts::Response::unreadCounts_FolderConnection>::parse(response::Value&& response)
+query::UnreadCounts::Response::unreadCounts_FolderConnection Response<query::UnreadCounts::Response::unreadCounts_FolderConnection>::parse(response::Value&& response)
 {
 	query::UnreadCounts::Response::unreadCounts_FolderConnection result;
 
@@ -524,7 +524,7 @@ static const std::array<std::pair<std::string_view, TaskState>, 4> s_valuesTaskS
 };
 
 template <>
-TaskState ModifiedResponse<TaskState>::parse(response::Value&& value)
+TaskState Response<TaskState>::parse(response::Value&& value)
 {
 	if (!value.maybe_enum())
 	{
@@ -544,7 +544,7 @@ TaskState ModifiedResponse<TaskState>::parse(response::Value&& value)
 }
 
 template <>
-query::Miscellaneous::Response::anyType_UnionType ModifiedResponse<query::Miscellaneous::Response::anyType_UnionType>::parse(response::Value&& response)
+query::Miscellaneous::Response::anyType_UnionType Response<query::Miscellaneous::Response::anyType_UnionType>::parse(response::Value&& response)
 {
 	query::Miscellaneous::Response::anyType_UnionType result;
 
@@ -645,7 +645,7 @@ static const std::array<std::string_view, 4> s_namesTaskState = {
 };
 
 template <>
-response::Value ModifiedVariable<TaskState>::serialize(TaskState&& value)
+response::Value Variable<TaskState>::serialize(TaskState&& value)
 {
 	response::Value result { response::Type::EnumValue };
 
@@ -655,7 +655,7 @@ response::Value ModifiedVariable<TaskState>::serialize(TaskState&& value)
 }
 
 template <>
-response::Value ModifiedVariable<CompleteTaskInput>::serialize(CompleteTaskInput&& inputValue)
+response::Value Variable<CompleteTaskInput>::serialize(CompleteTaskInput&& inputValue)
 {
 	response::Value result { response::Type::Map };
 
@@ -668,7 +668,7 @@ response::Value ModifiedVariable<CompleteTaskInput>::serialize(CompleteTaskInput
 }
 
 template <>
-mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload::completedTask_Task ModifiedResponse<mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload::completedTask_Task>::parse(response::Value&& response)
+mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload::completedTask_Task Response<mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload::completedTask_Task>::parse(response::Value&& response)
 {
 	mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload::completedTask_Task result;
 
@@ -700,7 +700,7 @@ mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload::com
 }
 
 template <>
-mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload ModifiedResponse<mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload>::parse(response::Value&& response)
+mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload Response<mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload>::parse(response::Value&& response)
 {
 	mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload result;
 

--- a/samples/client/mutate/MutateClient.cpp
+++ b/samples/client/mutate/MutateClient.cpp
@@ -113,7 +113,7 @@ static const std::array<std::string_view, 4> s_namesTaskState = {
 };
 
 template <>
-response::Value ModifiedVariable<TaskState>::serialize(TaskState&& value)
+response::Value Variable<TaskState>::serialize(TaskState&& value)
 {
 	response::Value result { response::Type::EnumValue };
 
@@ -123,7 +123,7 @@ response::Value ModifiedVariable<TaskState>::serialize(TaskState&& value)
 }
 
 template <>
-response::Value ModifiedVariable<CompleteTaskInput>::serialize(CompleteTaskInput&& inputValue)
+response::Value Variable<CompleteTaskInput>::serialize(CompleteTaskInput&& inputValue)
 {
 	response::Value result { response::Type::Map };
 
@@ -143,7 +143,7 @@ static const std::array<std::pair<std::string_view, TaskState>, 4> s_valuesTaskS
 };
 
 template <>
-TaskState ModifiedResponse<TaskState>::parse(response::Value&& value)
+TaskState Response<TaskState>::parse(response::Value&& value)
 {
 	if (!value.maybe_enum())
 	{
@@ -163,7 +163,7 @@ TaskState ModifiedResponse<TaskState>::parse(response::Value&& value)
 }
 
 template <>
-mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload::completedTask_Task ModifiedResponse<mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload::completedTask_Task>::parse(response::Value&& response)
+mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload::completedTask_Task Response<mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload::completedTask_Task>::parse(response::Value&& response)
 {
 	mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload::completedTask_Task result;
 
@@ -195,7 +195,7 @@ mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload::com
 }
 
 template <>
-mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload ModifiedResponse<mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload>::parse(response::Value&& response)
+mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload Response<mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload>::parse(response::Value&& response)
 {
 	mutation::CompleteTaskMutation::Response::completedTask_CompleteTaskPayload result;
 

--- a/samples/client/nestedinput/NestedInputClient.cpp
+++ b/samples/client/nestedinput/NestedInputClient.cpp
@@ -201,7 +201,7 @@ InputBC& InputBC::operator=(InputBC&& other) noexcept
 using namespace nestedinput;
 
 template <>
-response::Value ModifiedVariable<InputA>::serialize(InputA&& inputValue)
+response::Value Variable<InputA>::serialize(InputA&& inputValue)
 {
 	response::Value result { response::Type::Map };
 
@@ -211,7 +211,7 @@ response::Value ModifiedVariable<InputA>::serialize(InputA&& inputValue)
 }
 
 template <>
-response::Value ModifiedVariable<InputB>::serialize(InputB&& inputValue)
+response::Value Variable<InputB>::serialize(InputB&& inputValue)
 {
 	response::Value result { response::Type::Map };
 
@@ -221,7 +221,7 @@ response::Value ModifiedVariable<InputB>::serialize(InputB&& inputValue)
 }
 
 template <>
-response::Value ModifiedVariable<InputABCD>::serialize(InputABCD&& inputValue)
+response::Value Variable<InputABCD>::serialize(InputABCD&& inputValue)
 {
 	response::Value result { response::Type::Map };
 
@@ -234,7 +234,7 @@ response::Value ModifiedVariable<InputABCD>::serialize(InputABCD&& inputValue)
 }
 
 template <>
-response::Value ModifiedVariable<InputBC>::serialize(InputBC&& inputValue)
+response::Value Variable<InputBC>::serialize(InputBC&& inputValue)
 {
 	response::Value result { response::Type::Map };
 
@@ -245,7 +245,7 @@ response::Value ModifiedVariable<InputBC>::serialize(InputBC&& inputValue)
 }
 
 template <>
-query::testQuery::Response::control_Control::test_Output ModifiedResponse<query::testQuery::Response::control_Control::test_Output>::parse(response::Value&& response)
+query::testQuery::Response::control_Control::test_Output Response<query::testQuery::Response::control_Control::test_Output>::parse(response::Value&& response)
 {
 	query::testQuery::Response::control_Control::test_Output result;
 
@@ -267,7 +267,7 @@ query::testQuery::Response::control_Control::test_Output ModifiedResponse<query:
 }
 
 template <>
-query::testQuery::Response::control_Control ModifiedResponse<query::testQuery::Response::control_Control>::parse(response::Value&& response)
+query::testQuery::Response::control_Control Response<query::testQuery::Response::control_Control>::parse(response::Value&& response)
 {
 	query::testQuery::Response::control_Control result;
 

--- a/samples/client/query/QueryClient.cpp
+++ b/samples/client/query/QueryClient.cpp
@@ -114,7 +114,7 @@ static const std::array<std::pair<std::string_view, TaskState>, 4> s_valuesTaskS
 };
 
 template <>
-TaskState ModifiedResponse<TaskState>::parse(response::Value&& value)
+TaskState Response<TaskState>::parse(response::Value&& value)
 {
 	if (!value.maybe_enum())
 	{
@@ -134,7 +134,7 @@ TaskState ModifiedResponse<TaskState>::parse(response::Value&& value)
 }
 
 template <>
-query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment ModifiedResponse<query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment>::parse(response::Value&& response)
+query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment Response<query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment>::parse(response::Value&& response)
 {
 	query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge::node_Appointment result;
 
@@ -176,7 +176,7 @@ query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdg
 }
 
 template <>
-query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge ModifiedResponse<query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge>::parse(response::Value&& response)
+query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge Response<query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge>::parse(response::Value&& response)
 {
 	query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdge result;
 
@@ -198,7 +198,7 @@ query::Query::Response::appointments_AppointmentConnection::edges_AppointmentEdg
 }
 
 template <>
-query::Query::Response::appointments_AppointmentConnection ModifiedResponse<query::Query::Response::appointments_AppointmentConnection>::parse(response::Value&& response)
+query::Query::Response::appointments_AppointmentConnection Response<query::Query::Response::appointments_AppointmentConnection>::parse(response::Value&& response)
 {
 	query::Query::Response::appointments_AppointmentConnection result;
 
@@ -220,7 +220,7 @@ query::Query::Response::appointments_AppointmentConnection ModifiedResponse<quer
 }
 
 template <>
-query::Query::Response::tasks_TaskConnection::edges_TaskEdge::node_Task ModifiedResponse<query::Query::Response::tasks_TaskConnection::edges_TaskEdge::node_Task>::parse(response::Value&& response)
+query::Query::Response::tasks_TaskConnection::edges_TaskEdge::node_Task Response<query::Query::Response::tasks_TaskConnection::edges_TaskEdge::node_Task>::parse(response::Value&& response)
 {
 	query::Query::Response::tasks_TaskConnection::edges_TaskEdge::node_Task result;
 
@@ -257,7 +257,7 @@ query::Query::Response::tasks_TaskConnection::edges_TaskEdge::node_Task Modified
 }
 
 template <>
-query::Query::Response::tasks_TaskConnection::edges_TaskEdge ModifiedResponse<query::Query::Response::tasks_TaskConnection::edges_TaskEdge>::parse(response::Value&& response)
+query::Query::Response::tasks_TaskConnection::edges_TaskEdge Response<query::Query::Response::tasks_TaskConnection::edges_TaskEdge>::parse(response::Value&& response)
 {
 	query::Query::Response::tasks_TaskConnection::edges_TaskEdge result;
 
@@ -279,7 +279,7 @@ query::Query::Response::tasks_TaskConnection::edges_TaskEdge ModifiedResponse<qu
 }
 
 template <>
-query::Query::Response::tasks_TaskConnection ModifiedResponse<query::Query::Response::tasks_TaskConnection>::parse(response::Value&& response)
+query::Query::Response::tasks_TaskConnection Response<query::Query::Response::tasks_TaskConnection>::parse(response::Value&& response)
 {
 	query::Query::Response::tasks_TaskConnection result;
 
@@ -301,7 +301,7 @@ query::Query::Response::tasks_TaskConnection ModifiedResponse<query::Query::Resp
 }
 
 template <>
-query::Query::Response::unreadCounts_FolderConnection::edges_FolderEdge::node_Folder ModifiedResponse<query::Query::Response::unreadCounts_FolderConnection::edges_FolderEdge::node_Folder>::parse(response::Value&& response)
+query::Query::Response::unreadCounts_FolderConnection::edges_FolderEdge::node_Folder Response<query::Query::Response::unreadCounts_FolderConnection::edges_FolderEdge::node_Folder>::parse(response::Value&& response)
 {
 	query::Query::Response::unreadCounts_FolderConnection::edges_FolderEdge::node_Folder result;
 
@@ -338,7 +338,7 @@ query::Query::Response::unreadCounts_FolderConnection::edges_FolderEdge::node_Fo
 }
 
 template <>
-query::Query::Response::unreadCounts_FolderConnection::edges_FolderEdge ModifiedResponse<query::Query::Response::unreadCounts_FolderConnection::edges_FolderEdge>::parse(response::Value&& response)
+query::Query::Response::unreadCounts_FolderConnection::edges_FolderEdge Response<query::Query::Response::unreadCounts_FolderConnection::edges_FolderEdge>::parse(response::Value&& response)
 {
 	query::Query::Response::unreadCounts_FolderConnection::edges_FolderEdge result;
 
@@ -360,7 +360,7 @@ query::Query::Response::unreadCounts_FolderConnection::edges_FolderEdge Modified
 }
 
 template <>
-query::Query::Response::unreadCounts_FolderConnection ModifiedResponse<query::Query::Response::unreadCounts_FolderConnection>::parse(response::Value&& response)
+query::Query::Response::unreadCounts_FolderConnection Response<query::Query::Response::unreadCounts_FolderConnection>::parse(response::Value&& response)
 {
 	query::Query::Response::unreadCounts_FolderConnection result;
 
@@ -382,7 +382,7 @@ query::Query::Response::unreadCounts_FolderConnection ModifiedResponse<query::Qu
 }
 
 template <>
-query::Query::Response::anyType_UnionType ModifiedResponse<query::Query::Response::anyType_UnionType>::parse(response::Value&& response)
+query::Query::Response::anyType_UnionType Response<query::Query::Response::anyType_UnionType>::parse(response::Value&& response)
 {
 	query::Query::Response::anyType_UnionType result;
 

--- a/samples/client/subscribe/SubscribeClient.cpp
+++ b/samples/client/subscribe/SubscribeClient.cpp
@@ -57,7 +57,7 @@ const peg::ast& GetRequestObject() noexcept
 using namespace subscribe;
 
 template <>
-subscription::TestSubscription::Response::nextAppointment_Appointment ModifiedResponse<subscription::TestSubscription::Response::nextAppointment_Appointment>::parse(response::Value&& response)
+subscription::TestSubscription::Response::nextAppointment_Appointment Response<subscription::TestSubscription::Response::nextAppointment_Appointment>::parse(response::Value&& response)
 {
 	subscription::TestSubscription::Response::nextAppointment_Appointment result;
 

--- a/samples/learn/schema/CharacterObject.h
+++ b/samples/learn/schema/CharacterObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	Character(std::shared_ptr<T> pimpl) noexcept
+	inline Character(std::shared_ptr<T> pimpl) noexcept
 		: Character { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Character>(), "Character is not implemented");

--- a/samples/learn/schema/DroidObject.cpp
+++ b/samples/learn/schema/DroidObject.cpp
@@ -109,7 +109,7 @@ service::AwaitableResolver Droid::resolvePrimaryFunction(service::ResolverParams
 
 service::AwaitableResolver Droid::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Droid)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Droid)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/learn/schema/DroidObject.h
+++ b/samples/learn/schema/DroidObject.h
@@ -124,12 +124,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getIdWithParams<T>)
 			{
@@ -142,7 +142,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getNameWithParams<T>)
 			{
@@ -155,7 +155,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getFriendsWithParams<T>)
 			{
@@ -168,7 +168,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getAppearsInWithParams<T>)
 			{
@@ -181,7 +181,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getPrimaryFunctionWithParams<T>)
 			{
@@ -194,7 +194,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::DroidHas::beginSelectionSet<T>)
 			{
@@ -202,7 +202,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::DroidHas::endSelectionSet<T>)
 			{
@@ -235,7 +235,7 @@ private:
 
 public:
 	template <class T>
-	Droid(std::shared_ptr<T> pimpl) noexcept
+	inline Droid(std::shared_ptr<T> pimpl) noexcept
 		: Droid { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/learn/schema/HumanObject.cpp
+++ b/samples/learn/schema/HumanObject.cpp
@@ -109,7 +109,7 @@ service::AwaitableResolver Human::resolveHomePlanet(service::ResolverParams&& pa
 
 service::AwaitableResolver Human::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Human)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Human)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/learn/schema/HumanObject.h
+++ b/samples/learn/schema/HumanObject.h
@@ -124,12 +124,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getIdWithParams<T>)
 			{
@@ -142,7 +142,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getNameWithParams<T>)
 			{
@@ -155,7 +155,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getFriendsWithParams<T>)
 			{
@@ -168,7 +168,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getAppearsInWithParams<T>)
 			{
@@ -181,7 +181,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getHomePlanetWithParams<T>)
 			{
@@ -194,7 +194,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::HumanHas::beginSelectionSet<T>)
 			{
@@ -202,7 +202,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::HumanHas::endSelectionSet<T>)
 			{
@@ -235,7 +235,7 @@ private:
 
 public:
 	template <class T>
-	Human(std::shared_ptr<T> pimpl) noexcept
+	inline Human(std::shared_ptr<T> pimpl) noexcept
 		: Human { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/learn/schema/MutationObject.cpp
+++ b/samples/learn/schema/MutationObject.cpp
@@ -66,7 +66,7 @@ service::AwaitableResolver Mutation::resolveCreateReview(service::ResolverParams
 
 service::AwaitableResolver Mutation::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Mutation)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Mutation)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/learn/schema/MutationObject.h
+++ b/samples/learn/schema/MutationObject.h
@@ -61,12 +61,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const final
 		{
 			if constexpr (methods::MutationHas::applyCreateReviewWithParams<T>)
 			{
@@ -79,7 +79,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::beginSelectionSet<T>)
 			{
@@ -87,7 +87,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::endSelectionSet<T>)
 			{
@@ -111,7 +111,7 @@ private:
 
 public:
 	template <class T>
-	Mutation(std::shared_ptr<T> pimpl) noexcept
+	inline Mutation(std::shared_ptr<T> pimpl) noexcept
 		: Mutation { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/learn/schema/QueryObject.cpp
+++ b/samples/learn/schema/QueryObject.cpp
@@ -95,12 +95,12 @@ service::AwaitableResolver Query::resolveDroid(service::ResolverParams&& params)
 
 service::AwaitableResolver Query::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Query)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Query)gql" }, std::move(params));
 }
 
 service::AwaitableResolver Query::resolve_schema(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<service::Object>::convert(std::static_pointer_cast<service::Object>(std::make_shared<introspection::object::Schema>(std::make_shared<introspection::Schema>(_schema))), std::move(params));
+	return service::Result<service::Object>::convert(std::static_pointer_cast<service::Object>(std::make_shared<introspection::object::Schema>(std::make_shared<introspection::Schema>(_schema))), std::move(params));
 }
 
 service::AwaitableResolver Query::resolve_type(service::ResolverParams&& params) const

--- a/samples/learn/schema/QueryObject.h
+++ b/samples/learn/schema/QueryObject.h
@@ -93,12 +93,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const final
 		{
 			if constexpr (methods::QueryHas::getHeroWithParams<T>)
 			{
@@ -111,7 +111,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getHumanWithParams<T>)
 			{
@@ -124,7 +124,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getDroidWithParams<T>)
 			{
@@ -137,7 +137,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::beginSelectionSet<T>)
 			{
@@ -145,7 +145,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::endSelectionSet<T>)
 			{
@@ -169,7 +169,7 @@ private:
 
 public:
 	template <class T>
-	Query(std::shared_ptr<T> pimpl) noexcept
+	inline Query(std::shared_ptr<T> pimpl) noexcept
 		: Query { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/learn/schema/ReviewObject.cpp
+++ b/samples/learn/schema/ReviewObject.cpp
@@ -74,7 +74,7 @@ service::AwaitableResolver Review::resolveCommentary(service::ResolverParams&& p
 
 service::AwaitableResolver Review::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Review)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Review)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/learn/schema/ReviewObject.h
+++ b/samples/learn/schema/ReviewObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getStars(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<int> getStars(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ReviewHas::getStarsWithParams<T>)
 			{
@@ -93,7 +93,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ReviewHas::getCommentaryWithParams<T>)
 			{
@@ -106,7 +106,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ReviewHas::beginSelectionSet<T>)
 			{
@@ -114,7 +114,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ReviewHas::endSelectionSet<T>)
 			{
@@ -138,7 +138,7 @@ private:
 
 public:
 	template <class T>
-	Review(std::shared_ptr<T> pimpl) noexcept
+	inline Review(std::shared_ptr<T> pimpl) noexcept
 		: Review { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/learn/schema/StarWarsSchema.cpp
+++ b/samples/learn/schema/StarWarsSchema.cpp
@@ -48,9 +48,9 @@ learn::Episode Argument<learn::Episode>::convert(const response::Value& value)
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<learn::Episode>::convert(service::AwaitableScalar<learn::Episode> result, ResolverParams params)
+service::AwaitableResolver Result<learn::Episode>::convert(service::AwaitableScalar<learn::Episode> result, ResolverParams params)
 {
-	return resolve(std::move(result), std::move(params),
+	return ModifiedResult<learn::Episode>::resolve(std::move(result), std::move(params),
 		[](learn::Episode value, const ResolverParams&)
 		{
 			response::Value result(response::Type::EnumValue);
@@ -62,7 +62,7 @@ service::AwaitableResolver ModifiedResult<learn::Episode>::convert(service::Awai
 }
 
 template <>
-void ModifiedResult<learn::Episode>::validateScalar(const response::Value& value)
+void Result<learn::Episode>::validateScalar(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{

--- a/samples/learn/schema/StarWarsSchema.cpp
+++ b/samples/learn/schema/StarWarsSchema.cpp
@@ -28,7 +28,7 @@ static const auto s_namesEpisode = learn::getEpisodeNames();
 static const auto s_valuesEpisode = learn::getEpisodeValues();
 
 template <>
-learn::Episode ModifiedArgument<learn::Episode>::convert(const response::Value& value)
+learn::Episode Argument<learn::Episode>::convert(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{
@@ -81,7 +81,7 @@ void ModifiedResult<learn::Episode>::validateScalar(const response::Value& value
 }
 
 template <>
-learn::ReviewInput ModifiedArgument<learn::ReviewInput>::convert(const response::Value& value)
+learn::ReviewInput Argument<learn::ReviewInput>::convert(const response::Value& value)
 {
 	auto valueStars = service::ModifiedArgument<int>::require("stars", value);
 	auto valueCommentary = service::ModifiedArgument<std::string>::require<service::TypeModifier::Nullable>("commentary", value);

--- a/samples/today/TodayMock.cpp
+++ b/samples/today/TodayMock.cpp
@@ -22,7 +22,7 @@ namespace graphql::today {
 const response::IdType& getFakeAppointmentId() noexcept
 {
 	static const auto s_fakeId = []() noexcept {
-		std::string fakeIdString("fakeAppointmentId");
+		std::string_view fakeIdString { "fakeAppointmentId" };
 		response::IdType result(fakeIdString.size());
 
 		std::copy(fakeIdString.cbegin(), fakeIdString.cend(), result.begin());
@@ -36,7 +36,7 @@ const response::IdType& getFakeAppointmentId() noexcept
 const response::IdType& getFakeTaskId() noexcept
 {
 	static const auto s_fakeId = []() noexcept {
-		std::string fakeIdString("fakeTaskId");
+		std::string_view fakeIdString { "fakeTaskId" };
 		response::IdType result(fakeIdString.size());
 
 		std::copy(fakeIdString.cbegin(), fakeIdString.cend(), result.begin());
@@ -50,7 +50,7 @@ const response::IdType& getFakeTaskId() noexcept
 const response::IdType& getFakeFolderId() noexcept
 {
 	static const auto s_fakeId = []() noexcept {
-		std::string fakeIdString("fakeFolderId");
+		std::string_view fakeIdString { "fakeFolderId" };
 		response::IdType result(fakeIdString.size());
 
 		std::copy(fakeIdString.cbegin(), fakeIdString.cend(), result.begin());

--- a/samples/today/TodayMock.h
+++ b/samples/today/TodayMock.h
@@ -43,7 +43,7 @@ std::unique_ptr<TodayMockService> mock_service() noexcept;
 
 struct RequestState : service::RequestState
 {
-	RequestState(size_t id)
+	inline RequestState(size_t id)
 		: requestId(id)
 	{
 	}
@@ -125,18 +125,18 @@ private:
 class PageInfo
 {
 public:
-	explicit PageInfo(bool hasNextPage, bool hasPreviousPage)
+	inline explicit PageInfo(bool hasNextPage, bool hasPreviousPage)
 		: _hasNextPage(hasNextPage)
 		, _hasPreviousPage(hasPreviousPage)
 	{
 	}
 
-	bool getHasNextPage() const noexcept
+	inline bool getHasNextPage() const noexcept
 	{
 		return _hasNextPage;
 	}
 
-	bool getHasPreviousPage() const noexcept
+	inline bool getHasPreviousPage() const noexcept
 	{
 		return _hasPreviousPage;
 	}
@@ -153,32 +153,32 @@ public:
 		response::IdType&& id, std::string&& when, std::string&& subject, bool isNow);
 
 	// EdgeConstraints accessor
-	const response::IdType& id() const noexcept
+	inline const response::IdType& id() const noexcept
 	{
 		return _id;
 	}
 
-	service::AwaitableScalar<response::IdType> getId() const noexcept
+	inline service::AwaitableScalar<response::IdType> getId() const noexcept
 	{
 		return _id;
 	}
 
-	std::shared_ptr<const response::Value> getWhen() const noexcept
+	inline std::shared_ptr<const response::Value> getWhen() const noexcept
 	{
 		return _when;
 	}
 
-	std::shared_ptr<const response::Value> getSubject() const noexcept
+	inline std::shared_ptr<const response::Value> getSubject() const noexcept
 	{
 		return _subject;
 	}
 
-	bool getIsNow() const noexcept
+	inline bool getIsNow() const noexcept
 	{
 		return _isNow;
 	}
 
-	std::optional<std::string> getForceError() const
+	inline std::optional<std::string> getForceError() const
 	{
 		throw std::runtime_error(R"ex(this error was forced)ex");
 	}
@@ -193,17 +193,17 @@ private:
 class AppointmentEdge
 {
 public:
-	explicit AppointmentEdge(std::shared_ptr<Appointment> appointment)
+	inline explicit AppointmentEdge(std::shared_ptr<Appointment> appointment)
 		: _appointment(std::move(appointment))
 	{
 	}
 
-	std::shared_ptr<object::Appointment> getNode() const noexcept
+	inline std::shared_ptr<object::Appointment> getNode() const noexcept
 	{
 		return std::make_shared<object::Appointment>(_appointment);
 	}
 
-	service::AwaitableScalar<response::Value> getCursor() const
+	inline service::AwaitableScalar<response::Value> getCursor() const
 	{
 		co_return response::Value(co_await _appointment->getId());
 	}
@@ -215,19 +215,20 @@ private:
 class AppointmentConnection
 {
 public:
-	explicit AppointmentConnection(bool hasNextPage, bool hasPreviousPage,
+	inline explicit AppointmentConnection(bool hasNextPage, bool hasPreviousPage,
 		std::vector<std::shared_ptr<Appointment>> appointments)
 		: _pageInfo(std::make_shared<PageInfo>(hasNextPage, hasPreviousPage))
 		, _appointments(std::move(appointments))
 	{
 	}
 
-	std::shared_ptr<object::PageInfo> getPageInfo() const noexcept
+	inline std::shared_ptr<object::PageInfo> getPageInfo() const noexcept
 	{
 		return std::make_shared<object::PageInfo>(_pageInfo);
 	}
 
-	std::optional<std::vector<std::shared_ptr<object::AppointmentEdge>>> getEdges() const noexcept
+	inline std::optional<std::vector<std::shared_ptr<object::AppointmentEdge>>> getEdges()
+		const noexcept
 	{
 		auto result = std::make_optional<std::vector<std::shared_ptr<object::AppointmentEdge>>>(
 			_appointments.size());
@@ -254,22 +255,22 @@ public:
 	explicit Task(response::IdType&& id, std::string&& title, bool isComplete);
 
 	// EdgeConstraints accessor
-	const response::IdType& id() const
+	inline const response::IdType& id() const
 	{
 		return _id;
 	}
 
-	service::AwaitableScalar<response::IdType> getId() const noexcept
+	inline service::AwaitableScalar<response::IdType> getId() const noexcept
 	{
 		return _id;
 	}
 
-	std::shared_ptr<const response::Value> getTitle() const noexcept
+	inline std::shared_ptr<const response::Value> getTitle() const noexcept
 	{
 		return _title;
 	}
 
-	bool getIsComplete() const noexcept
+	inline bool getIsComplete() const noexcept
 	{
 		return _isComplete;
 	}
@@ -283,17 +284,17 @@ private:
 class TaskEdge
 {
 public:
-	explicit TaskEdge(std::shared_ptr<Task> task)
+	inline explicit TaskEdge(std::shared_ptr<Task> task)
 		: _task(std::move(task))
 	{
 	}
 
-	std::shared_ptr<object::Task> getNode() const noexcept
+	inline std::shared_ptr<object::Task> getNode() const noexcept
 	{
 		return std::make_shared<object::Task>(_task);
 	}
 
-	service::AwaitableScalar<response::Value> getCursor() const noexcept
+	inline service::AwaitableScalar<response::Value> getCursor() const noexcept
 	{
 		co_return response::Value(co_await _task->getId());
 	}
@@ -305,19 +306,19 @@ private:
 class TaskConnection
 {
 public:
-	explicit TaskConnection(
+	inline explicit TaskConnection(
 		bool hasNextPage, bool hasPreviousPage, std::vector<std::shared_ptr<Task>> tasks)
 		: _pageInfo(std::make_shared<PageInfo>(hasNextPage, hasPreviousPage))
 		, _tasks(std::move(tasks))
 	{
 	}
 
-	std::shared_ptr<object::PageInfo> getPageInfo() const noexcept
+	inline std::shared_ptr<object::PageInfo> getPageInfo() const noexcept
 	{
 		return std::make_shared<object::PageInfo>(_pageInfo);
 	}
 
-	std::optional<std::vector<std::shared_ptr<object::TaskEdge>>> getEdges() const noexcept
+	inline std::optional<std::vector<std::shared_ptr<object::TaskEdge>>> getEdges() const noexcept
 	{
 		auto result =
 			std::make_optional<std::vector<std::shared_ptr<object::TaskEdge>>>(_tasks.size());
@@ -343,22 +344,22 @@ public:
 	explicit Folder(response::IdType&& id, std::string&& name, int unreadCount);
 
 	// EdgeConstraints accessor
-	const response::IdType& id() const noexcept
+	inline const response::IdType& id() const noexcept
 	{
 		return _id;
 	}
 
-	service::AwaitableScalar<response::IdType> getId() const noexcept
+	inline service::AwaitableScalar<response::IdType> getId() const noexcept
 	{
 		return _id;
 	}
 
-	std::shared_ptr<const response::Value> getName() const noexcept
+	inline std::shared_ptr<const response::Value> getName() const noexcept
 	{
 		return _name;
 	}
 
-	int getUnreadCount() const noexcept
+	inline int getUnreadCount() const noexcept
 	{
 		return _unreadCount;
 	}
@@ -372,17 +373,17 @@ private:
 class FolderEdge
 {
 public:
-	explicit FolderEdge(std::shared_ptr<Folder> folder)
+	inline explicit FolderEdge(std::shared_ptr<Folder> folder)
 		: _folder(std::move(folder))
 	{
 	}
 
-	std::shared_ptr<object::Folder> getNode() const noexcept
+	inline std::shared_ptr<object::Folder> getNode() const noexcept
 	{
 		return std::make_shared<object::Folder>(_folder);
 	}
 
-	service::AwaitableScalar<response::Value> getCursor() const noexcept
+	inline service::AwaitableScalar<response::Value> getCursor() const noexcept
 	{
 		co_return response::Value(co_await _folder->getId());
 	}
@@ -394,19 +395,19 @@ private:
 class FolderConnection
 {
 public:
-	explicit FolderConnection(
+	inline explicit FolderConnection(
 		bool hasNextPage, bool hasPreviousPage, std::vector<std::shared_ptr<Folder>> folders)
 		: _pageInfo(std::make_shared<PageInfo>(hasNextPage, hasPreviousPage))
 		, _folders(std::move(folders))
 	{
 	}
 
-	std::shared_ptr<object::PageInfo> getPageInfo() const noexcept
+	inline std::shared_ptr<object::PageInfo> getPageInfo() const noexcept
 	{
 		return std::make_shared<object::PageInfo>(_pageInfo);
 	}
 
-	std::optional<std::vector<std::shared_ptr<object::FolderEdge>>> getEdges() const noexcept
+	inline std::optional<std::vector<std::shared_ptr<object::FolderEdge>>> getEdges() const noexcept
 	{
 		auto result =
 			std::make_optional<std::vector<std::shared_ptr<object::FolderEdge>>>(_folders.size());
@@ -429,19 +430,19 @@ private:
 class CompleteTaskPayload
 {
 public:
-	explicit CompleteTaskPayload(
+	inline explicit CompleteTaskPayload(
 		std::shared_ptr<Task> task, std::optional<std::string>&& clientMutationId)
 		: _task(std::move(task))
 		, _clientMutationId(std::move(clientMutationId))
 	{
 	}
 
-	std::shared_ptr<object::Task> getTask() const noexcept
+	inline std::shared_ptr<object::Task> getTask() const noexcept
 	{
 		return std::make_shared<object::Task>(_task);
 	}
 
-	const std::optional<std::string>& getClientMutationId() const noexcept
+	inline const std::optional<std::string>& getClientMutationId() const noexcept
 	{
 		return _clientMutationId;
 	}
@@ -475,12 +476,12 @@ class Subscription
 public:
 	explicit Subscription() = default;
 
-	std::shared_ptr<object::Appointment> getNextAppointmentChange() const
+	inline std::shared_ptr<object::Appointment> getNextAppointmentChange() const
 	{
 		throw std::runtime_error("Unexpected call to getNextAppointmentChange");
 	}
 
-	std::shared_ptr<object::Node> getNodeChange(const response::IdType&) const
+	inline std::shared_ptr<object::Node> getNodeChange(const response::IdType&) const
 	{
 		throw std::runtime_error("Unexpected call to getNodeChange");
 	}
@@ -492,12 +493,12 @@ public:
 	using nextAppointmentChange =
 		std::function<std::shared_ptr<Appointment>(const std::shared_ptr<service::RequestState>&)>;
 
-	explicit NextAppointmentChange(nextAppointmentChange&& changeNextAppointment)
+	inline explicit NextAppointmentChange(nextAppointmentChange&& changeNextAppointment)
 		: _changeNextAppointment(std::move(changeNextAppointment))
 	{
 	}
 
-	static size_t getCount(service::ResolverContext resolverContext)
+	static inline size_t getCount(service::ResolverContext resolverContext)
 	{
 		switch (resolverContext)
 		{
@@ -515,7 +516,7 @@ public:
 		}
 	}
 
-	std::shared_ptr<object::Appointment> getNextAppointmentChange(
+	inline std::shared_ptr<object::Appointment> getNextAppointmentChange(
 		const service::FieldParams& params) const
 	{
 		switch (params.resolverContext)
@@ -545,7 +546,7 @@ public:
 		return std::make_shared<object::Appointment>(_changeNextAppointment(params.state));
 	}
 
-	std::shared_ptr<object::Node> getNodeChange(const response::IdType&) const
+	inline std::shared_ptr<object::Node> getNodeChange(const response::IdType&) const
 	{
 		throw std::runtime_error("Unexpected call to getNodeChange");
 	}
@@ -565,17 +566,17 @@ public:
 		std::function<std::shared_ptr<object::Node>(service::ResolverContext resolverContext,
 			const std::shared_ptr<service::RequestState>&, response::IdType&&)>;
 
-	explicit NodeChange(nodeChange&& changeNode)
+	inline explicit NodeChange(nodeChange&& changeNode)
 		: _changeNode(std::move(changeNode))
 	{
 	}
 
-	std::shared_ptr<object::Appointment> getNextAppointmentChange() const
+	inline std::shared_ptr<object::Appointment> getNextAppointmentChange() const
 	{
 		throw std::runtime_error("Unexpected call to getNextAppointmentChange");
 	}
 
-	std::shared_ptr<object::Node> getNodeChange(
+	inline std::shared_ptr<object::Node> getNodeChange(
 		const service::FieldParams& params, response::IdType&& idArg) const
 	{
 		return _changeNode(params.resolverContext, params.state, std::move(idArg));

--- a/samples/today/TodayMock.h
+++ b/samples/today/TodayMock.h
@@ -43,10 +43,7 @@ std::unique_ptr<TodayMockService> mock_service() noexcept;
 
 struct RequestState : service::RequestState
 {
-	inline RequestState(size_t id)
-		: requestId(id)
-	{
-	}
+	RequestState(size_t id);
 
 	const size_t requestId;
 
@@ -125,21 +122,10 @@ private:
 class PageInfo
 {
 public:
-	inline explicit PageInfo(bool hasNextPage, bool hasPreviousPage)
-		: _hasNextPage(hasNextPage)
-		, _hasPreviousPage(hasPreviousPage)
-	{
-	}
+	explicit PageInfo(bool hasNextPage, bool hasPreviousPage);
 
-	inline bool getHasNextPage() const noexcept
-	{
-		return _hasNextPage;
-	}
-
-	inline bool getHasPreviousPage() const noexcept
-	{
-		return _hasPreviousPage;
-	}
+	bool getHasNextPage() const noexcept;
+	bool getHasPreviousPage() const noexcept;
 
 private:
 	const bool _hasNextPage;
@@ -153,35 +139,13 @@ public:
 		response::IdType&& id, std::string&& when, std::string&& subject, bool isNow);
 
 	// EdgeConstraints accessor
-	inline const response::IdType& id() const noexcept
-	{
-		return _id;
-	}
+	const response::IdType& id() const noexcept;
 
-	inline service::AwaitableScalar<response::IdType> getId() const noexcept
-	{
-		return _id;
-	}
-
-	inline std::shared_ptr<const response::Value> getWhen() const noexcept
-	{
-		return _when;
-	}
-
-	inline std::shared_ptr<const response::Value> getSubject() const noexcept
-	{
-		return _subject;
-	}
-
-	inline bool getIsNow() const noexcept
-	{
-		return _isNow;
-	}
-
-	inline std::optional<std::string> getForceError() const
-	{
-		throw std::runtime_error(R"ex(this error was forced)ex");
-	}
+	service::AwaitableScalar<response::IdType> getId() const noexcept;
+	std::shared_ptr<const response::Value> getWhen() const noexcept;
+	std::shared_ptr<const response::Value> getSubject() const noexcept;
+	bool getIsNow() const noexcept;
+	std::optional<std::string> getForceError() const;
 
 private:
 	response::IdType _id;
@@ -193,20 +157,10 @@ private:
 class AppointmentEdge
 {
 public:
-	inline explicit AppointmentEdge(std::shared_ptr<Appointment> appointment)
-		: _appointment(std::move(appointment))
-	{
-	}
+	explicit AppointmentEdge(std::shared_ptr<Appointment> appointment);
 
-	inline std::shared_ptr<object::Appointment> getNode() const noexcept
-	{
-		return std::make_shared<object::Appointment>(_appointment);
-	}
-
-	inline service::AwaitableScalar<response::Value> getCursor() const
-	{
-		co_return response::Value(co_await _appointment->getId());
-	}
+	std::shared_ptr<object::Appointment> getNode() const noexcept;
+	service::AwaitableScalar<response::Value> getCursor() const;
 
 private:
 	std::shared_ptr<Appointment> _appointment;
@@ -215,34 +169,11 @@ private:
 class AppointmentConnection
 {
 public:
-	inline explicit AppointmentConnection(bool hasNextPage, bool hasPreviousPage,
-		std::vector<std::shared_ptr<Appointment>> appointments)
-		: _pageInfo(std::make_shared<PageInfo>(hasNextPage, hasPreviousPage))
-		, _appointments(std::move(appointments))
-	{
-	}
+	explicit AppointmentConnection(bool hasNextPage, bool hasPreviousPage,
+		std::vector<std::shared_ptr<Appointment>> appointments);
 
-	inline std::shared_ptr<object::PageInfo> getPageInfo() const noexcept
-	{
-		return std::make_shared<object::PageInfo>(_pageInfo);
-	}
-
-	inline std::optional<std::vector<std::shared_ptr<object::AppointmentEdge>>> getEdges()
-		const noexcept
-	{
-		auto result = std::make_optional<std::vector<std::shared_ptr<object::AppointmentEdge>>>(
-			_appointments.size());
-
-		std::transform(_appointments.cbegin(),
-			_appointments.cend(),
-			result->begin(),
-			[](const std::shared_ptr<Appointment>& node) {
-				return std::make_shared<object::AppointmentEdge>(
-					std::make_shared<AppointmentEdge>(node));
-			});
-
-		return result;
-	}
+	std::shared_ptr<object::PageInfo> getPageInfo() const noexcept;
+	std::optional<std::vector<std::shared_ptr<object::AppointmentEdge>>> getEdges() const noexcept;
 
 private:
 	std::shared_ptr<PageInfo> _pageInfo;
@@ -255,25 +186,11 @@ public:
 	explicit Task(response::IdType&& id, std::string&& title, bool isComplete);
 
 	// EdgeConstraints accessor
-	inline const response::IdType& id() const
-	{
-		return _id;
-	}
+	const response::IdType& id() const;
 
-	inline service::AwaitableScalar<response::IdType> getId() const noexcept
-	{
-		return _id;
-	}
-
-	inline std::shared_ptr<const response::Value> getTitle() const noexcept
-	{
-		return _title;
-	}
-
-	inline bool getIsComplete() const noexcept
-	{
-		return _isComplete;
-	}
+	service::AwaitableScalar<response::IdType> getId() const noexcept;
+	std::shared_ptr<const response::Value> getTitle() const noexcept;
+	bool getIsComplete() const noexcept;
 
 private:
 	response::IdType _id;
@@ -284,20 +201,10 @@ private:
 class TaskEdge
 {
 public:
-	inline explicit TaskEdge(std::shared_ptr<Task> task)
-		: _task(std::move(task))
-	{
-	}
+	explicit TaskEdge(std::shared_ptr<Task> task);
 
-	inline std::shared_ptr<object::Task> getNode() const noexcept
-	{
-		return std::make_shared<object::Task>(_task);
-	}
-
-	inline service::AwaitableScalar<response::Value> getCursor() const noexcept
-	{
-		co_return response::Value(co_await _task->getId());
-	}
+	std::shared_ptr<object::Task> getNode() const noexcept;
+	service::AwaitableScalar<response::Value> getCursor() const noexcept;
 
 private:
 	std::shared_ptr<Task> _task;
@@ -306,32 +213,11 @@ private:
 class TaskConnection
 {
 public:
-	inline explicit TaskConnection(
-		bool hasNextPage, bool hasPreviousPage, std::vector<std::shared_ptr<Task>> tasks)
-		: _pageInfo(std::make_shared<PageInfo>(hasNextPage, hasPreviousPage))
-		, _tasks(std::move(tasks))
-	{
-	}
+	explicit TaskConnection(
+		bool hasNextPage, bool hasPreviousPage, std::vector<std::shared_ptr<Task>> tasks);
 
-	inline std::shared_ptr<object::PageInfo> getPageInfo() const noexcept
-	{
-		return std::make_shared<object::PageInfo>(_pageInfo);
-	}
-
-	inline std::optional<std::vector<std::shared_ptr<object::TaskEdge>>> getEdges() const noexcept
-	{
-		auto result =
-			std::make_optional<std::vector<std::shared_ptr<object::TaskEdge>>>(_tasks.size());
-
-		std::transform(_tasks.cbegin(),
-			_tasks.cend(),
-			result->begin(),
-			[](const std::shared_ptr<Task>& node) {
-				return std::make_shared<object::TaskEdge>(std::make_shared<TaskEdge>(node));
-			});
-
-		return result;
-	}
+	std::shared_ptr<object::PageInfo> getPageInfo() const noexcept;
+	std::optional<std::vector<std::shared_ptr<object::TaskEdge>>> getEdges() const noexcept;
 
 private:
 	std::shared_ptr<PageInfo> _pageInfo;
@@ -344,25 +230,11 @@ public:
 	explicit Folder(response::IdType&& id, std::string&& name, int unreadCount);
 
 	// EdgeConstraints accessor
-	inline const response::IdType& id() const noexcept
-	{
-		return _id;
-	}
+	const response::IdType& id() const noexcept;
 
-	inline service::AwaitableScalar<response::IdType> getId() const noexcept
-	{
-		return _id;
-	}
-
-	inline std::shared_ptr<const response::Value> getName() const noexcept
-	{
-		return _name;
-	}
-
-	inline int getUnreadCount() const noexcept
-	{
-		return _unreadCount;
-	}
+	service::AwaitableScalar<response::IdType> getId() const noexcept;
+	std::shared_ptr<const response::Value> getName() const noexcept;
+	int getUnreadCount() const noexcept;
 
 private:
 	response::IdType _id;
@@ -373,20 +245,10 @@ private:
 class FolderEdge
 {
 public:
-	inline explicit FolderEdge(std::shared_ptr<Folder> folder)
-		: _folder(std::move(folder))
-	{
-	}
+	explicit FolderEdge(std::shared_ptr<Folder> folder);
 
-	inline std::shared_ptr<object::Folder> getNode() const noexcept
-	{
-		return std::make_shared<object::Folder>(_folder);
-	}
-
-	inline service::AwaitableScalar<response::Value> getCursor() const noexcept
-	{
-		co_return response::Value(co_await _folder->getId());
-	}
+	std::shared_ptr<object::Folder> getNode() const noexcept;
+	service::AwaitableScalar<response::Value> getCursor() const noexcept;
 
 private:
 	std::shared_ptr<Folder> _folder;
@@ -395,32 +257,11 @@ private:
 class FolderConnection
 {
 public:
-	inline explicit FolderConnection(
-		bool hasNextPage, bool hasPreviousPage, std::vector<std::shared_ptr<Folder>> folders)
-		: _pageInfo(std::make_shared<PageInfo>(hasNextPage, hasPreviousPage))
-		, _folders(std::move(folders))
-	{
-	}
+	explicit FolderConnection(
+		bool hasNextPage, bool hasPreviousPage, std::vector<std::shared_ptr<Folder>> folders);
 
-	inline std::shared_ptr<object::PageInfo> getPageInfo() const noexcept
-	{
-		return std::make_shared<object::PageInfo>(_pageInfo);
-	}
-
-	inline std::optional<std::vector<std::shared_ptr<object::FolderEdge>>> getEdges() const noexcept
-	{
-		auto result =
-			std::make_optional<std::vector<std::shared_ptr<object::FolderEdge>>>(_folders.size());
-
-		std::transform(_folders.cbegin(),
-			_folders.cend(),
-			result->begin(),
-			[](const std::shared_ptr<Folder>& node) {
-				return std::make_shared<object::FolderEdge>(std::make_shared<FolderEdge>(node));
-			});
-
-		return result;
-	}
+	std::shared_ptr<object::PageInfo> getPageInfo() const noexcept;
+	std::optional<std::vector<std::shared_ptr<object::FolderEdge>>> getEdges() const noexcept;
 
 private:
 	std::shared_ptr<PageInfo> _pageInfo;
@@ -430,22 +271,11 @@ private:
 class CompleteTaskPayload
 {
 public:
-	inline explicit CompleteTaskPayload(
-		std::shared_ptr<Task> task, std::optional<std::string>&& clientMutationId)
-		: _task(std::move(task))
-		, _clientMutationId(std::move(clientMutationId))
-	{
-	}
+	explicit CompleteTaskPayload(
+		std::shared_ptr<Task> task, std::optional<std::string>&& clientMutationId);
 
-	inline std::shared_ptr<object::Task> getTask() const noexcept
-	{
-		return std::make_shared<object::Task>(_task);
-	}
-
-	inline const std::optional<std::string>& getClientMutationId() const noexcept
-	{
-		return _clientMutationId;
-	}
+	std::shared_ptr<object::Task> getTask() const noexcept;
+	const std::optional<std::string>& getClientMutationId() const noexcept;
 
 private:
 	std::shared_ptr<Task> _task;
@@ -476,15 +306,8 @@ class Subscription
 public:
 	explicit Subscription() = default;
 
-	inline std::shared_ptr<object::Appointment> getNextAppointmentChange() const
-	{
-		throw std::runtime_error("Unexpected call to getNextAppointmentChange");
-	}
-
-	inline std::shared_ptr<object::Node> getNodeChange(const response::IdType&) const
-	{
-		throw std::runtime_error("Unexpected call to getNodeChange");
-	}
+	std::shared_ptr<object::Appointment> getNextAppointmentChange() const;
+	std::shared_ptr<object::Node> getNodeChange(const response::IdType&) const;
 };
 
 class NextAppointmentChange
@@ -493,63 +316,13 @@ public:
 	using nextAppointmentChange =
 		std::function<std::shared_ptr<Appointment>(const std::shared_ptr<service::RequestState>&)>;
 
-	inline explicit NextAppointmentChange(nextAppointmentChange&& changeNextAppointment)
-		: _changeNextAppointment(std::move(changeNextAppointment))
-	{
-	}
+	explicit NextAppointmentChange(nextAppointmentChange&& changeNextAppointment);
 
-	static inline size_t getCount(service::ResolverContext resolverContext)
-	{
-		switch (resolverContext)
-		{
-			case service::ResolverContext::NotifySubscribe:
-				return _notifySubscribeCount;
+	static size_t getCount(service::ResolverContext resolverContext);
 
-			case service::ResolverContext::Subscription:
-				return _subscriptionCount;
-
-			case service::ResolverContext::NotifyUnsubscribe:
-				return _notifyUnsubscribeCount;
-
-			default:
-				throw std::runtime_error("Unexpected ResolverContext");
-		}
-	}
-
-	inline std::shared_ptr<object::Appointment> getNextAppointmentChange(
-		const service::FieldParams& params) const
-	{
-		switch (params.resolverContext)
-		{
-			case service::ResolverContext::NotifySubscribe:
-			{
-				++_notifySubscribeCount;
-				break;
-			}
-
-			case service::ResolverContext::Subscription:
-			{
-				++_subscriptionCount;
-				break;
-			}
-
-			case service::ResolverContext::NotifyUnsubscribe:
-			{
-				++_notifyUnsubscribeCount;
-				break;
-			}
-
-			default:
-				throw std::runtime_error("Unexpected ResolverContext");
-		}
-
-		return std::make_shared<object::Appointment>(_changeNextAppointment(params.state));
-	}
-
-	inline std::shared_ptr<object::Node> getNodeChange(const response::IdType&) const
-	{
-		throw std::runtime_error("Unexpected call to getNodeChange");
-	}
+	std::shared_ptr<object::Appointment> getNextAppointmentChange(
+		const service::FieldParams& params) const;
+	std::shared_ptr<object::Node> getNodeChange(const response::IdType&) const;
 
 private:
 	nextAppointmentChange _changeNextAppointment;
@@ -566,21 +339,11 @@ public:
 		std::function<std::shared_ptr<object::Node>(service::ResolverContext resolverContext,
 			const std::shared_ptr<service::RequestState>&, response::IdType&&)>;
 
-	inline explicit NodeChange(nodeChange&& changeNode)
-		: _changeNode(std::move(changeNode))
-	{
-	}
+	explicit NodeChange(nodeChange&& changeNode);
 
-	inline std::shared_ptr<object::Appointment> getNextAppointmentChange() const
-	{
-		throw std::runtime_error("Unexpected call to getNextAppointmentChange");
-	}
-
-	inline std::shared_ptr<object::Node> getNodeChange(
-		const service::FieldParams& params, response::IdType&& idArg) const
-	{
-		return _changeNode(params.resolverContext, params.state, std::move(idArg));
-	}
+	std::shared_ptr<object::Appointment> getNextAppointmentChange() const;
+	std::shared_ptr<object::Node> getNodeChange(
+		const service::FieldParams& params, response::IdType&& idArg) const;
 
 private:
 	nodeChange _changeNode;

--- a/samples/today/nointrospection/AppointmentConnectionObject.cpp
+++ b/samples/today/nointrospection/AppointmentConnectionObject.cpp
@@ -76,7 +76,7 @@ service::AwaitableResolver AppointmentConnection::resolveEdges(service::Resolver
 
 service::AwaitableResolver AppointmentConnection::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(AppointmentConnection)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(AppointmentConnection)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/AppointmentConnectionObject.h
+++ b/samples/today/nointrospection/AppointmentConnectionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getEdgesWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	AppointmentConnection(std::shared_ptr<T> pimpl) noexcept
+	inline AppointmentConnection(std::shared_ptr<T> pimpl) noexcept
 		: AppointmentConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/AppointmentEdgeObject.cpp
+++ b/samples/today/nointrospection/AppointmentEdgeObject.cpp
@@ -75,7 +75,7 @@ service::AwaitableResolver AppointmentEdge::resolveCursor(service::ResolverParam
 
 service::AwaitableResolver AppointmentEdge::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(AppointmentEdge)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(AppointmentEdge)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/AppointmentEdgeObject.h
+++ b/samples/today/nointrospection/AppointmentEdgeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getCursorWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	AppointmentEdge(std::shared_ptr<T> pimpl) noexcept
+	inline AppointmentEdge(std::shared_ptr<T> pimpl) noexcept
 		: AppointmentEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/AppointmentObject.cpp
+++ b/samples/today/nointrospection/AppointmentObject.cpp
@@ -109,7 +109,7 @@ service::AwaitableResolver Appointment::resolveForceError(service::ResolverParam
 
 service::AwaitableResolver Appointment::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Appointment)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Appointment)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/AppointmentObject.h
+++ b/samples/today/nointrospection/AppointmentObject.h
@@ -124,12 +124,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIdWithParams<T>)
 			{
@@ -145,7 +145,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getWhenWithParams<T>)
 			{
@@ -161,7 +161,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getSubjectWithParams<T>)
 			{
@@ -177,7 +177,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIsNowWithParams<T>)
 			{
@@ -193,7 +193,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getForceErrorWithParams<T>)
 			{
@@ -209,7 +209,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentHas::beginSelectionSet<T>)
 			{
@@ -217,7 +217,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentHas::endSelectionSet<T>)
 			{
@@ -253,7 +253,7 @@ private:
 
 public:
 	template <class T>
-	Appointment(std::shared_ptr<T> pimpl) noexcept
+	inline Appointment(std::shared_ptr<T> pimpl) noexcept
 		: Appointment { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/CompleteTaskPayloadObject.cpp
+++ b/samples/today/nointrospection/CompleteTaskPayloadObject.cpp
@@ -75,7 +75,7 @@ service::AwaitableResolver CompleteTaskPayload::resolveClientMutationId(service:
 
 service::AwaitableResolver CompleteTaskPayload::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(CompleteTaskPayload)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(CompleteTaskPayload)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/CompleteTaskPayloadObject.h
+++ b/samples/today/nointrospection/CompleteTaskPayloadObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getClientMutationIdWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	CompleteTaskPayload(std::shared_ptr<T> pimpl) noexcept
+	inline CompleteTaskPayload(std::shared_ptr<T> pimpl) noexcept
 		: CompleteTaskPayload { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/ExpensiveObject.cpp
+++ b/samples/today/nointrospection/ExpensiveObject.cpp
@@ -63,7 +63,7 @@ service::AwaitableResolver Expensive::resolveOrder(service::ResolverParams&& par
 
 service::AwaitableResolver Expensive::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Expensive)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Expensive)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/ExpensiveObject.h
+++ b/samples/today/nointrospection/ExpensiveObject.h
@@ -61,12 +61,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::getOrderWithParams<T>)
 			{
@@ -82,7 +82,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::beginSelectionSet<T>)
 			{
@@ -90,7 +90,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::endSelectionSet<T>)
 			{
@@ -114,7 +114,7 @@ private:
 
 public:
 	template <class T>
-	Expensive(std::shared_ptr<T> pimpl) noexcept
+	inline Expensive(std::shared_ptr<T> pimpl) noexcept
 		: Expensive { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/FolderConnectionObject.cpp
+++ b/samples/today/nointrospection/FolderConnectionObject.cpp
@@ -76,7 +76,7 @@ service::AwaitableResolver FolderConnection::resolveEdges(service::ResolverParam
 
 service::AwaitableResolver FolderConnection::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(FolderConnection)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(FolderConnection)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/FolderConnectionObject.h
+++ b/samples/today/nointrospection/FolderConnectionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getEdgesWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	FolderConnection(std::shared_ptr<T> pimpl) noexcept
+	inline FolderConnection(std::shared_ptr<T> pimpl) noexcept
 		: FolderConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/FolderEdgeObject.cpp
+++ b/samples/today/nointrospection/FolderEdgeObject.cpp
@@ -75,7 +75,7 @@ service::AwaitableResolver FolderEdge::resolveCursor(service::ResolverParams&& p
 
 service::AwaitableResolver FolderEdge::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(FolderEdge)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(FolderEdge)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/FolderEdgeObject.h
+++ b/samples/today/nointrospection/FolderEdgeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getCursorWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	FolderEdge(std::shared_ptr<T> pimpl) noexcept
+	inline FolderEdge(std::shared_ptr<T> pimpl) noexcept
 		: FolderEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/FolderObject.cpp
+++ b/samples/today/nointrospection/FolderObject.cpp
@@ -87,7 +87,7 @@ service::AwaitableResolver Folder::resolveUnreadCount(service::ResolverParams&& 
 
 service::AwaitableResolver Folder::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Folder)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Folder)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/FolderObject.h
+++ b/samples/today/nointrospection/FolderObject.h
@@ -96,12 +96,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getNameWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getUnreadCountWithParams<T>)
 			{
@@ -149,7 +149,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderHas::beginSelectionSet<T>)
 			{
@@ -157,7 +157,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderHas::endSelectionSet<T>)
 			{
@@ -193,7 +193,7 @@ private:
 
 public:
 	template <class T>
-	Folder(std::shared_ptr<T> pimpl) noexcept
+	inline Folder(std::shared_ptr<T> pimpl) noexcept
 		: Folder { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/MutationObject.cpp
+++ b/samples/today/nointrospection/MutationObject.cpp
@@ -77,7 +77,7 @@ service::AwaitableResolver Mutation::resolveSetFloat(service::ResolverParams&& p
 
 service::AwaitableResolver Mutation::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Mutation)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Mutation)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/MutationObject.h
+++ b/samples/today/nointrospection/MutationObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
 		{
 			if constexpr (methods::MutationHas::applyCompleteTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
 		{
 			if constexpr (methods::MutationHas::applySetFloatWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	Mutation(std::shared_ptr<T> pimpl) noexcept
+	inline Mutation(std::shared_ptr<T> pimpl) noexcept
 		: Mutation { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/NestedTypeObject.cpp
+++ b/samples/today/nointrospection/NestedTypeObject.cpp
@@ -75,7 +75,7 @@ service::AwaitableResolver NestedType::resolveNested(service::ResolverParams&& p
 
 service::AwaitableResolver NestedType::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(NestedType)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(NestedType)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/NestedTypeObject.h
+++ b/samples/today/nointrospection/NestedTypeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getDepthWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getNestedWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	NestedType(std::shared_ptr<T> pimpl) noexcept
+	inline NestedType(std::shared_ptr<T> pimpl) noexcept
 		: NestedType { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/NodeObject.h
+++ b/samples/today/nointrospection/NodeObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	Node(std::shared_ptr<T> pimpl) noexcept
+	inline Node(std::shared_ptr<T> pimpl) noexcept
 		: Node { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Node>(), "Node is not implemented");

--- a/samples/today/nointrospection/PageInfoObject.cpp
+++ b/samples/today/nointrospection/PageInfoObject.cpp
@@ -74,7 +74,7 @@ service::AwaitableResolver PageInfo::resolveHasPreviousPage(service::ResolverPar
 
 service::AwaitableResolver PageInfo::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(PageInfo)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(PageInfo)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/PageInfoObject.h
+++ b/samples/today/nointrospection/PageInfoObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasNextPageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasPreviousPageWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::PageInfoHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::PageInfoHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	PageInfo(std::shared_ptr<T> pimpl) noexcept
+	inline PageInfo(std::shared_ptr<T> pimpl) noexcept
 		: PageInfo { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/QueryObject.cpp
+++ b/samples/today/nointrospection/QueryObject.cpp
@@ -244,7 +244,7 @@ service::AwaitableResolver Query::resolveDefault(service::ResolverParams&& param
 
 service::AwaitableResolver Query::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Query)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Query)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/QueryObject.h
+++ b/samples/today/nointrospection/QueryObject.h
@@ -229,12 +229,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getNodeWithParams<T>)
 			{
@@ -250,7 +250,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsWithParams<T>)
 			{
@@ -266,7 +266,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksWithParams<T>)
 			{
@@ -282,7 +282,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsWithParams<T>)
 			{
@@ -298,7 +298,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsByIdWithParams<T>)
 			{
@@ -314,7 +314,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksByIdWithParams<T>)
 			{
@@ -330,7 +330,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsByIdWithParams<T>)
 			{
@@ -346,7 +346,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getNestedWithParams<T>)
 			{
@@ -362,7 +362,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getUnimplementedWithParams<T>)
 			{
@@ -378,7 +378,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getExpensiveWithParams<T>)
 			{
@@ -394,7 +394,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getTestTaskStateWithParams<T>)
 			{
@@ -410,7 +410,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAnyTypeWithParams<T>)
 			{
@@ -426,7 +426,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getDefaultWithParams<T>)
 			{
@@ -442,7 +442,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::beginSelectionSet<T>)
 			{
@@ -450,7 +450,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::endSelectionSet<T>)
 			{
@@ -474,7 +474,7 @@ private:
 
 public:
 	template <class T>
-	Query(std::shared_ptr<T> pimpl) noexcept
+	inline Query(std::shared_ptr<T> pimpl) noexcept
 		: Query { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/SubscriptionObject.cpp
+++ b/samples/today/nointrospection/SubscriptionObject.cpp
@@ -77,7 +77,7 @@ service::AwaitableResolver Subscription::resolveNodeChange(service::ResolverPara
 
 service::AwaitableResolver Subscription::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Subscription)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Subscription)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/SubscriptionObject.h
+++ b/samples/today/nointrospection/SubscriptionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNextAppointmentChangeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNodeChangeWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	Subscription(std::shared_ptr<T> pimpl) noexcept
+	inline Subscription(std::shared_ptr<T> pimpl) noexcept
 		: Subscription { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/TaskConnectionObject.cpp
+++ b/samples/today/nointrospection/TaskConnectionObject.cpp
@@ -76,7 +76,7 @@ service::AwaitableResolver TaskConnection::resolveEdges(service::ResolverParams&
 
 service::AwaitableResolver TaskConnection::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(TaskConnection)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(TaskConnection)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/TaskConnectionObject.h
+++ b/samples/today/nointrospection/TaskConnectionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getEdgesWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	TaskConnection(std::shared_ptr<T> pimpl) noexcept
+	inline TaskConnection(std::shared_ptr<T> pimpl) noexcept
 		: TaskConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/TaskEdgeObject.cpp
+++ b/samples/today/nointrospection/TaskEdgeObject.cpp
@@ -75,7 +75,7 @@ service::AwaitableResolver TaskEdge::resolveCursor(service::ResolverParams&& par
 
 service::AwaitableResolver TaskEdge::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(TaskEdge)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(TaskEdge)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/TaskEdgeObject.h
+++ b/samples/today/nointrospection/TaskEdgeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getCursorWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	TaskEdge(std::shared_ptr<T> pimpl) noexcept
+	inline TaskEdge(std::shared_ptr<T> pimpl) noexcept
 		: TaskEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/TaskObject.cpp
+++ b/samples/today/nointrospection/TaskObject.cpp
@@ -87,7 +87,7 @@ service::AwaitableResolver Task::resolveIsComplete(service::ResolverParams&& par
 
 service::AwaitableResolver Task::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Task)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Task)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/nointrospection/TaskObject.h
+++ b/samples/today/nointrospection/TaskObject.h
@@ -96,12 +96,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getTitleWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIsCompleteWithParams<T>)
 			{
@@ -149,7 +149,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskHas::beginSelectionSet<T>)
 			{
@@ -157,7 +157,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskHas::endSelectionSet<T>)
 			{
@@ -193,7 +193,7 @@ private:
 
 public:
 	template <class T>
-	Task(std::shared_ptr<T> pimpl) noexcept
+	inline Task(std::shared_ptr<T> pimpl) noexcept
 		: Task { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/TodaySchema.cpp
+++ b/samples/today/nointrospection/TodaySchema.cpp
@@ -29,7 +29,7 @@ static const auto s_namesTaskState = today::getTaskStateNames();
 static const auto s_valuesTaskState = today::getTaskStateValues();
 
 template <>
-today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Value& value)
+today::TaskState Argument<today::TaskState>::convert(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{
@@ -82,7 +82,7 @@ void ModifiedResult<today::TaskState>::validateScalar(const response::Value& val
 }
 
 template <>
-today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(const response::Value& value)
+today::CompleteTaskInput Argument<today::CompleteTaskInput>::convert(const response::Value& value)
 {
 	const auto defaultValue = []()
 	{
@@ -112,7 +112,7 @@ today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(con
 }
 
 template <>
-today::ThirdNestedInput ModifiedArgument<today::ThirdNestedInput>::convert(const response::Value& value)
+today::ThirdNestedInput Argument<today::ThirdNestedInput>::convert(const response::Value& value)
 {
 	auto valueId = service::ModifiedArgument<response::IdType>::require("id", value);
 	auto valueSecond = service::ModifiedArgument<today::SecondNestedInput>::require<service::TypeModifier::Nullable>("second", value);
@@ -124,7 +124,7 @@ today::ThirdNestedInput ModifiedArgument<today::ThirdNestedInput>::convert(const
 }
 
 template <>
-today::FourthNestedInput ModifiedArgument<today::FourthNestedInput>::convert(const response::Value& value)
+today::FourthNestedInput Argument<today::FourthNestedInput>::convert(const response::Value& value)
 {
 	auto valueId = service::ModifiedArgument<response::IdType>::require("id", value);
 
@@ -134,7 +134,7 @@ today::FourthNestedInput ModifiedArgument<today::FourthNestedInput>::convert(con
 }
 
 template <>
-today::IncludeNullableSelfInput ModifiedArgument<today::IncludeNullableSelfInput>::convert(const response::Value& value)
+today::IncludeNullableSelfInput Argument<today::IncludeNullableSelfInput>::convert(const response::Value& value)
 {
 	auto valueSelf = service::ModifiedArgument<today::IncludeNullableSelfInput>::require<service::TypeModifier::Nullable>("self", value);
 
@@ -144,7 +144,7 @@ today::IncludeNullableSelfInput ModifiedArgument<today::IncludeNullableSelfInput
 }
 
 template <>
-today::IncludeNonNullableListSelfInput ModifiedArgument<today::IncludeNonNullableListSelfInput>::convert(const response::Value& value)
+today::IncludeNonNullableListSelfInput Argument<today::IncludeNonNullableListSelfInput>::convert(const response::Value& value)
 {
 	auto valueSelves = service::ModifiedArgument<today::IncludeNonNullableListSelfInput>::require<service::TypeModifier::List>("selves", value);
 
@@ -154,7 +154,7 @@ today::IncludeNonNullableListSelfInput ModifiedArgument<today::IncludeNonNullabl
 }
 
 template <>
-today::StringOperationFilterInput ModifiedArgument<today::StringOperationFilterInput>::convert(const response::Value& value)
+today::StringOperationFilterInput Argument<today::StringOperationFilterInput>::convert(const response::Value& value)
 {
 	auto valueAnd_ = service::ModifiedArgument<today::StringOperationFilterInput>::require<service::TypeModifier::Nullable, service::TypeModifier::List>("and", value);
 	auto valueOr_ = service::ModifiedArgument<today::StringOperationFilterInput>::require<service::TypeModifier::Nullable, service::TypeModifier::List>("or", value);
@@ -186,7 +186,7 @@ today::StringOperationFilterInput ModifiedArgument<today::StringOperationFilterI
 }
 
 template <>
-today::SecondNestedInput ModifiedArgument<today::SecondNestedInput>::convert(const response::Value& value)
+today::SecondNestedInput Argument<today::SecondNestedInput>::convert(const response::Value& value)
 {
 	auto valueId = service::ModifiedArgument<response::IdType>::require("id", value);
 	auto valueThird = service::ModifiedArgument<today::ThirdNestedInput>::require("third", value);
@@ -198,7 +198,7 @@ today::SecondNestedInput ModifiedArgument<today::SecondNestedInput>::convert(con
 }
 
 template <>
-today::ForwardDeclaredInput ModifiedArgument<today::ForwardDeclaredInput>::convert(const response::Value& value)
+today::ForwardDeclaredInput Argument<today::ForwardDeclaredInput>::convert(const response::Value& value)
 {
 	auto valueNullableSelf = service::ModifiedArgument<today::IncludeNullableSelfInput>::require<service::TypeModifier::Nullable>("nullableSelf", value);
 	auto valueListSelves = service::ModifiedArgument<today::IncludeNonNullableListSelfInput>::require("listSelves", value);
@@ -210,7 +210,7 @@ today::ForwardDeclaredInput ModifiedArgument<today::ForwardDeclaredInput>::conve
 }
 
 template <>
-today::FirstNestedInput ModifiedArgument<today::FirstNestedInput>::convert(const response::Value& value)
+today::FirstNestedInput Argument<today::FirstNestedInput>::convert(const response::Value& value)
 {
 	auto valueId = service::ModifiedArgument<response::IdType>::require("id", value);
 	auto valueSecond = service::ModifiedArgument<today::SecondNestedInput>::require("second", value);

--- a/samples/today/nointrospection/TodaySchema.cpp
+++ b/samples/today/nointrospection/TodaySchema.cpp
@@ -49,9 +49,9 @@ today::TaskState Argument<today::TaskState>::convert(const response::Value& valu
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<today::TaskState>::convert(service::AwaitableScalar<today::TaskState> result, ResolverParams params)
+service::AwaitableResolver Result<today::TaskState>::convert(service::AwaitableScalar<today::TaskState> result, ResolverParams params)
 {
-	return resolve(std::move(result), std::move(params),
+	return ModifiedResult<today::TaskState>::resolve(std::move(result), std::move(params),
 		[](today::TaskState value, const ResolverParams&)
 		{
 			response::Value result(response::Type::EnumValue);
@@ -63,7 +63,7 @@ service::AwaitableResolver ModifiedResult<today::TaskState>::convert(service::Aw
 }
 
 template <>
-void ModifiedResult<today::TaskState>::validateScalar(const response::Value& value)
+void Result<today::TaskState>::validateScalar(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{

--- a/samples/today/nointrospection/UnionTypeObject.h
+++ b/samples/today/nointrospection/UnionTypeObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	UnionType(std::shared_ptr<T> pimpl) noexcept
+	inline UnionType(std::shared_ptr<T> pimpl) noexcept
 		: UnionType { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<UnionType>(), "UnionType is not implemented");

--- a/samples/today/schema/AppointmentConnectionObject.cpp
+++ b/samples/today/schema/AppointmentConnectionObject.cpp
@@ -76,7 +76,7 @@ service::AwaitableResolver AppointmentConnection::resolveEdges(service::Resolver
 
 service::AwaitableResolver AppointmentConnection::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(AppointmentConnection)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(AppointmentConnection)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/AppointmentConnectionObject.h
+++ b/samples/today/schema/AppointmentConnectionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getEdgesWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	AppointmentConnection(std::shared_ptr<T> pimpl) noexcept
+	inline AppointmentConnection(std::shared_ptr<T> pimpl) noexcept
 		: AppointmentConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/AppointmentEdgeObject.cpp
+++ b/samples/today/schema/AppointmentEdgeObject.cpp
@@ -75,7 +75,7 @@ service::AwaitableResolver AppointmentEdge::resolveCursor(service::ResolverParam
 
 service::AwaitableResolver AppointmentEdge::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(AppointmentEdge)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(AppointmentEdge)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/AppointmentEdgeObject.h
+++ b/samples/today/schema/AppointmentEdgeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getCursorWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	AppointmentEdge(std::shared_ptr<T> pimpl) noexcept
+	inline AppointmentEdge(std::shared_ptr<T> pimpl) noexcept
 		: AppointmentEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/AppointmentObject.cpp
+++ b/samples/today/schema/AppointmentObject.cpp
@@ -109,7 +109,7 @@ service::AwaitableResolver Appointment::resolveForceError(service::ResolverParam
 
 service::AwaitableResolver Appointment::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Appointment)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Appointment)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/AppointmentObject.h
+++ b/samples/today/schema/AppointmentObject.h
@@ -124,12 +124,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIdWithParams<T>)
 			{
@@ -145,7 +145,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getWhenWithParams<T>)
 			{
@@ -161,7 +161,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getSubjectWithParams<T>)
 			{
@@ -177,7 +177,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIsNowWithParams<T>)
 			{
@@ -193,7 +193,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getForceErrorWithParams<T>)
 			{
@@ -209,7 +209,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentHas::beginSelectionSet<T>)
 			{
@@ -217,7 +217,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentHas::endSelectionSet<T>)
 			{
@@ -253,7 +253,7 @@ private:
 
 public:
 	template <class T>
-	Appointment(std::shared_ptr<T> pimpl) noexcept
+	inline Appointment(std::shared_ptr<T> pimpl) noexcept
 		: Appointment { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/CompleteTaskPayloadObject.cpp
+++ b/samples/today/schema/CompleteTaskPayloadObject.cpp
@@ -75,7 +75,7 @@ service::AwaitableResolver CompleteTaskPayload::resolveClientMutationId(service:
 
 service::AwaitableResolver CompleteTaskPayload::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(CompleteTaskPayload)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(CompleteTaskPayload)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/CompleteTaskPayloadObject.h
+++ b/samples/today/schema/CompleteTaskPayloadObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getClientMutationIdWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	CompleteTaskPayload(std::shared_ptr<T> pimpl) noexcept
+	inline CompleteTaskPayload(std::shared_ptr<T> pimpl) noexcept
 		: CompleteTaskPayload { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/ExpensiveObject.cpp
+++ b/samples/today/schema/ExpensiveObject.cpp
@@ -63,7 +63,7 @@ service::AwaitableResolver Expensive::resolveOrder(service::ResolverParams&& par
 
 service::AwaitableResolver Expensive::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Expensive)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Expensive)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/ExpensiveObject.h
+++ b/samples/today/schema/ExpensiveObject.h
@@ -61,12 +61,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::getOrderWithParams<T>)
 			{
@@ -82,7 +82,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::beginSelectionSet<T>)
 			{
@@ -90,7 +90,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::endSelectionSet<T>)
 			{
@@ -114,7 +114,7 @@ private:
 
 public:
 	template <class T>
-	Expensive(std::shared_ptr<T> pimpl) noexcept
+	inline Expensive(std::shared_ptr<T> pimpl) noexcept
 		: Expensive { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/FolderConnectionObject.cpp
+++ b/samples/today/schema/FolderConnectionObject.cpp
@@ -76,7 +76,7 @@ service::AwaitableResolver FolderConnection::resolveEdges(service::ResolverParam
 
 service::AwaitableResolver FolderConnection::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(FolderConnection)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(FolderConnection)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/FolderConnectionObject.h
+++ b/samples/today/schema/FolderConnectionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getEdgesWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	FolderConnection(std::shared_ptr<T> pimpl) noexcept
+	inline FolderConnection(std::shared_ptr<T> pimpl) noexcept
 		: FolderConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/FolderEdgeObject.cpp
+++ b/samples/today/schema/FolderEdgeObject.cpp
@@ -75,7 +75,7 @@ service::AwaitableResolver FolderEdge::resolveCursor(service::ResolverParams&& p
 
 service::AwaitableResolver FolderEdge::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(FolderEdge)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(FolderEdge)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/FolderEdgeObject.h
+++ b/samples/today/schema/FolderEdgeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getCursorWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	FolderEdge(std::shared_ptr<T> pimpl) noexcept
+	inline FolderEdge(std::shared_ptr<T> pimpl) noexcept
 		: FolderEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/FolderObject.cpp
+++ b/samples/today/schema/FolderObject.cpp
@@ -87,7 +87,7 @@ service::AwaitableResolver Folder::resolveUnreadCount(service::ResolverParams&& 
 
 service::AwaitableResolver Folder::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Folder)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Folder)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/FolderObject.h
+++ b/samples/today/schema/FolderObject.h
@@ -96,12 +96,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getNameWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getUnreadCountWithParams<T>)
 			{
@@ -149,7 +149,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderHas::beginSelectionSet<T>)
 			{
@@ -157,7 +157,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderHas::endSelectionSet<T>)
 			{
@@ -193,7 +193,7 @@ private:
 
 public:
 	template <class T>
-	Folder(std::shared_ptr<T> pimpl) noexcept
+	inline Folder(std::shared_ptr<T> pimpl) noexcept
 		: Folder { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/MutationObject.cpp
+++ b/samples/today/schema/MutationObject.cpp
@@ -77,7 +77,7 @@ service::AwaitableResolver Mutation::resolveSetFloat(service::ResolverParams&& p
 
 service::AwaitableResolver Mutation::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Mutation)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Mutation)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/MutationObject.h
+++ b/samples/today/schema/MutationObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
 		{
 			if constexpr (methods::MutationHas::applyCompleteTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
 		{
 			if constexpr (methods::MutationHas::applySetFloatWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	Mutation(std::shared_ptr<T> pimpl) noexcept
+	inline Mutation(std::shared_ptr<T> pimpl) noexcept
 		: Mutation { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/NestedTypeObject.cpp
+++ b/samples/today/schema/NestedTypeObject.cpp
@@ -75,7 +75,7 @@ service::AwaitableResolver NestedType::resolveNested(service::ResolverParams&& p
 
 service::AwaitableResolver NestedType::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(NestedType)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(NestedType)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/NestedTypeObject.h
+++ b/samples/today/schema/NestedTypeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getDepthWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getNestedWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	NestedType(std::shared_ptr<T> pimpl) noexcept
+	inline NestedType(std::shared_ptr<T> pimpl) noexcept
 		: NestedType { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/NodeObject.h
+++ b/samples/today/schema/NodeObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	Node(std::shared_ptr<T> pimpl) noexcept
+	inline Node(std::shared_ptr<T> pimpl) noexcept
 		: Node { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Node>(), "Node is not implemented");

--- a/samples/today/schema/PageInfoObject.cpp
+++ b/samples/today/schema/PageInfoObject.cpp
@@ -74,7 +74,7 @@ service::AwaitableResolver PageInfo::resolveHasPreviousPage(service::ResolverPar
 
 service::AwaitableResolver PageInfo::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(PageInfo)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(PageInfo)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/PageInfoObject.h
+++ b/samples/today/schema/PageInfoObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasNextPageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasPreviousPageWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::PageInfoHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::PageInfoHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	PageInfo(std::shared_ptr<T> pimpl) noexcept
+	inline PageInfo(std::shared_ptr<T> pimpl) noexcept
 		: PageInfo { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/QueryObject.cpp
+++ b/samples/today/schema/QueryObject.cpp
@@ -248,12 +248,12 @@ service::AwaitableResolver Query::resolveDefault(service::ResolverParams&& param
 
 service::AwaitableResolver Query::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Query)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Query)gql" }, std::move(params));
 }
 
 service::AwaitableResolver Query::resolve_schema(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<service::Object>::convert(std::static_pointer_cast<service::Object>(std::make_shared<introspection::object::Schema>(std::make_shared<introspection::Schema>(_schema))), std::move(params));
+	return service::Result<service::Object>::convert(std::static_pointer_cast<service::Object>(std::make_shared<introspection::object::Schema>(std::make_shared<introspection::Schema>(_schema))), std::move(params));
 }
 
 service::AwaitableResolver Query::resolve_type(service::ResolverParams&& params) const

--- a/samples/today/schema/QueryObject.h
+++ b/samples/today/schema/QueryObject.h
@@ -233,12 +233,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getNodeWithParams<T>)
 			{
@@ -254,7 +254,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsWithParams<T>)
 			{
@@ -270,7 +270,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksWithParams<T>)
 			{
@@ -286,7 +286,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsWithParams<T>)
 			{
@@ -302,7 +302,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsByIdWithParams<T>)
 			{
@@ -318,7 +318,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksByIdWithParams<T>)
 			{
@@ -334,7 +334,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsByIdWithParams<T>)
 			{
@@ -350,7 +350,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getNestedWithParams<T>)
 			{
@@ -366,7 +366,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getUnimplementedWithParams<T>)
 			{
@@ -382,7 +382,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getExpensiveWithParams<T>)
 			{
@@ -398,7 +398,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getTestTaskStateWithParams<T>)
 			{
@@ -414,7 +414,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAnyTypeWithParams<T>)
 			{
@@ -430,7 +430,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getDefaultWithParams<T>)
 			{
@@ -446,7 +446,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::beginSelectionSet<T>)
 			{
@@ -454,7 +454,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::endSelectionSet<T>)
 			{
@@ -478,7 +478,7 @@ private:
 
 public:
 	template <class T>
-	Query(std::shared_ptr<T> pimpl) noexcept
+	inline Query(std::shared_ptr<T> pimpl) noexcept
 		: Query { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/SubscriptionObject.cpp
+++ b/samples/today/schema/SubscriptionObject.cpp
@@ -77,7 +77,7 @@ service::AwaitableResolver Subscription::resolveNodeChange(service::ResolverPara
 
 service::AwaitableResolver Subscription::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Subscription)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Subscription)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/SubscriptionObject.h
+++ b/samples/today/schema/SubscriptionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNextAppointmentChangeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNodeChangeWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	Subscription(std::shared_ptr<T> pimpl) noexcept
+	inline Subscription(std::shared_ptr<T> pimpl) noexcept
 		: Subscription { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/TaskConnectionObject.cpp
+++ b/samples/today/schema/TaskConnectionObject.cpp
@@ -76,7 +76,7 @@ service::AwaitableResolver TaskConnection::resolveEdges(service::ResolverParams&
 
 service::AwaitableResolver TaskConnection::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(TaskConnection)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(TaskConnection)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/TaskConnectionObject.h
+++ b/samples/today/schema/TaskConnectionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getEdgesWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	TaskConnection(std::shared_ptr<T> pimpl) noexcept
+	inline TaskConnection(std::shared_ptr<T> pimpl) noexcept
 		: TaskConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/TaskEdgeObject.cpp
+++ b/samples/today/schema/TaskEdgeObject.cpp
@@ -75,7 +75,7 @@ service::AwaitableResolver TaskEdge::resolveCursor(service::ResolverParams&& par
 
 service::AwaitableResolver TaskEdge::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(TaskEdge)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(TaskEdge)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/TaskEdgeObject.h
+++ b/samples/today/schema/TaskEdgeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getCursorWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	TaskEdge(std::shared_ptr<T> pimpl) noexcept
+	inline TaskEdge(std::shared_ptr<T> pimpl) noexcept
 		: TaskEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/TaskObject.cpp
+++ b/samples/today/schema/TaskObject.cpp
@@ -87,7 +87,7 @@ service::AwaitableResolver Task::resolveIsComplete(service::ResolverParams&& par
 
 service::AwaitableResolver Task::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Task)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Task)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/today/schema/TaskObject.h
+++ b/samples/today/schema/TaskObject.h
@@ -96,12 +96,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getTitleWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIsCompleteWithParams<T>)
 			{
@@ -149,7 +149,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskHas::beginSelectionSet<T>)
 			{
@@ -157,7 +157,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskHas::endSelectionSet<T>)
 			{
@@ -193,7 +193,7 @@ private:
 
 public:
 	template <class T>
-	Task(std::shared_ptr<T> pimpl) noexcept
+	inline Task(std::shared_ptr<T> pimpl) noexcept
 		: Task { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/TodaySchema.cpp
+++ b/samples/today/schema/TodaySchema.cpp
@@ -29,7 +29,7 @@ static const auto s_namesTaskState = today::getTaskStateNames();
 static const auto s_valuesTaskState = today::getTaskStateValues();
 
 template <>
-today::TaskState ModifiedArgument<today::TaskState>::convert(const response::Value& value)
+today::TaskState Argument<today::TaskState>::convert(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{
@@ -82,7 +82,7 @@ void ModifiedResult<today::TaskState>::validateScalar(const response::Value& val
 }
 
 template <>
-today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(const response::Value& value)
+today::CompleteTaskInput Argument<today::CompleteTaskInput>::convert(const response::Value& value)
 {
 	const auto defaultValue = []()
 	{
@@ -112,7 +112,7 @@ today::CompleteTaskInput ModifiedArgument<today::CompleteTaskInput>::convert(con
 }
 
 template <>
-today::ThirdNestedInput ModifiedArgument<today::ThirdNestedInput>::convert(const response::Value& value)
+today::ThirdNestedInput Argument<today::ThirdNestedInput>::convert(const response::Value& value)
 {
 	auto valueId = service::ModifiedArgument<response::IdType>::require("id", value);
 	auto valueSecond = service::ModifiedArgument<today::SecondNestedInput>::require<service::TypeModifier::Nullable>("second", value);
@@ -124,7 +124,7 @@ today::ThirdNestedInput ModifiedArgument<today::ThirdNestedInput>::convert(const
 }
 
 template <>
-today::FourthNestedInput ModifiedArgument<today::FourthNestedInput>::convert(const response::Value& value)
+today::FourthNestedInput Argument<today::FourthNestedInput>::convert(const response::Value& value)
 {
 	auto valueId = service::ModifiedArgument<response::IdType>::require("id", value);
 
@@ -134,7 +134,7 @@ today::FourthNestedInput ModifiedArgument<today::FourthNestedInput>::convert(con
 }
 
 template <>
-today::IncludeNullableSelfInput ModifiedArgument<today::IncludeNullableSelfInput>::convert(const response::Value& value)
+today::IncludeNullableSelfInput Argument<today::IncludeNullableSelfInput>::convert(const response::Value& value)
 {
 	auto valueSelf = service::ModifiedArgument<today::IncludeNullableSelfInput>::require<service::TypeModifier::Nullable>("self", value);
 
@@ -144,7 +144,7 @@ today::IncludeNullableSelfInput ModifiedArgument<today::IncludeNullableSelfInput
 }
 
 template <>
-today::IncludeNonNullableListSelfInput ModifiedArgument<today::IncludeNonNullableListSelfInput>::convert(const response::Value& value)
+today::IncludeNonNullableListSelfInput Argument<today::IncludeNonNullableListSelfInput>::convert(const response::Value& value)
 {
 	auto valueSelves = service::ModifiedArgument<today::IncludeNonNullableListSelfInput>::require<service::TypeModifier::List>("selves", value);
 
@@ -154,7 +154,7 @@ today::IncludeNonNullableListSelfInput ModifiedArgument<today::IncludeNonNullabl
 }
 
 template <>
-today::StringOperationFilterInput ModifiedArgument<today::StringOperationFilterInput>::convert(const response::Value& value)
+today::StringOperationFilterInput Argument<today::StringOperationFilterInput>::convert(const response::Value& value)
 {
 	auto valueAnd_ = service::ModifiedArgument<today::StringOperationFilterInput>::require<service::TypeModifier::Nullable, service::TypeModifier::List>("and", value);
 	auto valueOr_ = service::ModifiedArgument<today::StringOperationFilterInput>::require<service::TypeModifier::Nullable, service::TypeModifier::List>("or", value);
@@ -186,7 +186,7 @@ today::StringOperationFilterInput ModifiedArgument<today::StringOperationFilterI
 }
 
 template <>
-today::SecondNestedInput ModifiedArgument<today::SecondNestedInput>::convert(const response::Value& value)
+today::SecondNestedInput Argument<today::SecondNestedInput>::convert(const response::Value& value)
 {
 	auto valueId = service::ModifiedArgument<response::IdType>::require("id", value);
 	auto valueThird = service::ModifiedArgument<today::ThirdNestedInput>::require("third", value);
@@ -198,7 +198,7 @@ today::SecondNestedInput ModifiedArgument<today::SecondNestedInput>::convert(con
 }
 
 template <>
-today::ForwardDeclaredInput ModifiedArgument<today::ForwardDeclaredInput>::convert(const response::Value& value)
+today::ForwardDeclaredInput Argument<today::ForwardDeclaredInput>::convert(const response::Value& value)
 {
 	auto valueNullableSelf = service::ModifiedArgument<today::IncludeNullableSelfInput>::require<service::TypeModifier::Nullable>("nullableSelf", value);
 	auto valueListSelves = service::ModifiedArgument<today::IncludeNonNullableListSelfInput>::require("listSelves", value);
@@ -210,7 +210,7 @@ today::ForwardDeclaredInput ModifiedArgument<today::ForwardDeclaredInput>::conve
 }
 
 template <>
-today::FirstNestedInput ModifiedArgument<today::FirstNestedInput>::convert(const response::Value& value)
+today::FirstNestedInput Argument<today::FirstNestedInput>::convert(const response::Value& value)
 {
 	auto valueId = service::ModifiedArgument<response::IdType>::require("id", value);
 	auto valueSecond = service::ModifiedArgument<today::SecondNestedInput>::require("second", value);

--- a/samples/today/schema/TodaySchema.cpp
+++ b/samples/today/schema/TodaySchema.cpp
@@ -49,9 +49,9 @@ today::TaskState Argument<today::TaskState>::convert(const response::Value& valu
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<today::TaskState>::convert(service::AwaitableScalar<today::TaskState> result, ResolverParams params)
+service::AwaitableResolver Result<today::TaskState>::convert(service::AwaitableScalar<today::TaskState> result, ResolverParams params)
 {
-	return resolve(std::move(result), std::move(params),
+	return ModifiedResult<today::TaskState>::resolve(std::move(result), std::move(params),
 		[](today::TaskState value, const ResolverParams&)
 		{
 			response::Value result(response::Type::EnumValue);
@@ -63,7 +63,7 @@ service::AwaitableResolver ModifiedResult<today::TaskState>::convert(service::Aw
 }
 
 template <>
-void ModifiedResult<today::TaskState>::validateScalar(const response::Value& value)
+void Result<today::TaskState>::validateScalar(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{

--- a/samples/today/schema/UnionTypeObject.h
+++ b/samples/today/schema/UnionTypeObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	UnionType(std::shared_ptr<T> pimpl) noexcept
+	inline UnionType(std::shared_ptr<T> pimpl) noexcept
 		: UnionType { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<UnionType>(), "UnionType is not implemented");

--- a/samples/validation/schema/AlienObject.cpp
+++ b/samples/validation/schema/AlienObject.cpp
@@ -76,7 +76,7 @@ service::AwaitableResolver Alien::resolveHomePlanet(service::ResolverParams&& pa
 
 service::AwaitableResolver Alien::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Alien)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Alien)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/validation/schema/AlienObject.h
+++ b/samples/validation/schema/AlienObject.h
@@ -82,12 +82,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AlienHas::getNameWithParams<T>)
 			{
@@ -103,7 +103,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AlienHas::getHomePlanetWithParams<T>)
 			{
@@ -119,7 +119,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AlienHas::beginSelectionSet<T>)
 			{
@@ -127,7 +127,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AlienHas::endSelectionSet<T>)
 			{
@@ -163,7 +163,7 @@ private:
 
 public:
 	template <class T>
-	Alien(std::shared_ptr<T> pimpl) noexcept
+	inline Alien(std::shared_ptr<T> pimpl) noexcept
 		: Alien { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/ArgumentsObject.cpp
+++ b/samples/validation/schema/ArgumentsObject.cpp
@@ -163,7 +163,7 @@ service::AwaitableResolver Arguments::resolveOptionalNonNullBooleanArgField(serv
 
 service::AwaitableResolver Arguments::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Arguments)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Arguments)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/validation/schema/ArgumentsObject.h
+++ b/samples/validation/schema/ArgumentsObject.h
@@ -159,12 +159,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getMultipleReqsWithParams<T>)
 			{
@@ -180,7 +180,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getBooleanArgFieldWithParams<T>)
 			{
@@ -196,7 +196,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getFloatArgFieldWithParams<T>)
 			{
@@ -212,7 +212,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getIntArgFieldWithParams<T>)
 			{
@@ -228,7 +228,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getNonNullBooleanArgFieldWithParams<T>)
 			{
@@ -244,7 +244,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getNonNullBooleanListFieldWithParams<T>)
 			{
@@ -260,7 +260,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getBooleanListArgFieldWithParams<T>)
 			{
@@ -276,7 +276,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getOptionalNonNullBooleanArgFieldWithParams<T>)
 			{
@@ -292,7 +292,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ArgumentsHas::beginSelectionSet<T>)
 			{
@@ -300,7 +300,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ArgumentsHas::endSelectionSet<T>)
 			{
@@ -324,7 +324,7 @@ private:
 
 public:
 	template <class T>
-	Arguments(std::shared_ptr<T> pimpl) noexcept
+	inline Arguments(std::shared_ptr<T> pimpl) noexcept
 		: Arguments { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/CatObject.cpp
+++ b/samples/validation/schema/CatObject.cpp
@@ -99,7 +99,7 @@ service::AwaitableResolver Cat::resolveMeowVolume(service::ResolverParams&& para
 
 service::AwaitableResolver Cat::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Cat)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Cat)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/validation/schema/CatObject.h
+++ b/samples/validation/schema/CatObject.h
@@ -110,12 +110,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CatHas::getNameWithParams<T>)
 			{
@@ -131,7 +131,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CatHas::getNicknameWithParams<T>)
 			{
@@ -147,7 +147,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const final
 		{
 			if constexpr (methods::CatHas::getDoesKnowCommandWithParams<T>)
 			{
@@ -163,7 +163,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CatHas::getMeowVolumeWithParams<T>)
 			{
@@ -179,7 +179,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::CatHas::beginSelectionSet<T>)
 			{
@@ -187,7 +187,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::CatHas::endSelectionSet<T>)
 			{
@@ -223,7 +223,7 @@ private:
 
 public:
 	template <class T>
-	Cat(std::shared_ptr<T> pimpl) noexcept
+	inline Cat(std::shared_ptr<T> pimpl) noexcept
 		: Cat { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/CatOrDogObject.h
+++ b/samples/validation/schema/CatOrDogObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	CatOrDog(std::shared_ptr<T> pimpl) noexcept
+	inline CatOrDog(std::shared_ptr<T> pimpl) noexcept
 		: CatOrDog { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<CatOrDog>(), "CatOrDog is not implemented");

--- a/samples/validation/schema/DogObject.cpp
+++ b/samples/validation/schema/DogObject.cpp
@@ -124,7 +124,7 @@ service::AwaitableResolver Dog::resolveOwner(service::ResolverParams&& params) c
 
 service::AwaitableResolver Dog::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Dog)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Dog)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/validation/schema/DogObject.h
+++ b/samples/validation/schema/DogObject.h
@@ -138,12 +138,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getNameWithParams<T>)
 			{
@@ -159,7 +159,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getNicknameWithParams<T>)
 			{
@@ -175,7 +175,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getBarkVolumeWithParams<T>)
 			{
@@ -191,7 +191,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const final
 		{
 			if constexpr (methods::DogHas::getDoesKnowCommandWithParams<T>)
 			{
@@ -207,7 +207,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const final
 		{
 			if constexpr (methods::DogHas::getIsHousetrainedWithParams<T>)
 			{
@@ -223,7 +223,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getOwnerWithParams<T>)
 			{
@@ -239,7 +239,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::DogHas::beginSelectionSet<T>)
 			{
@@ -247,7 +247,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::DogHas::endSelectionSet<T>)
 			{
@@ -284,7 +284,7 @@ private:
 
 public:
 	template <class T>
-	Dog(std::shared_ptr<T> pimpl) noexcept
+	inline Dog(std::shared_ptr<T> pimpl) noexcept
 		: Dog { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/DogOrHumanObject.h
+++ b/samples/validation/schema/DogOrHumanObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	DogOrHuman(std::shared_ptr<T> pimpl) noexcept
+	inline DogOrHuman(std::shared_ptr<T> pimpl) noexcept
 		: DogOrHuman { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<DogOrHuman>(), "DogOrHuman is not implemented");

--- a/samples/validation/schema/HumanObject.cpp
+++ b/samples/validation/schema/HumanObject.cpp
@@ -78,7 +78,7 @@ service::AwaitableResolver Human::resolvePets(service::ResolverParams&& params) 
 
 service::AwaitableResolver Human::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Human)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Human)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/validation/schema/HumanObject.h
+++ b/samples/validation/schema/HumanObject.h
@@ -82,12 +82,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getNameWithParams<T>)
 			{
@@ -103,7 +103,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getPetsWithParams<T>)
 			{
@@ -119,7 +119,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::HumanHas::beginSelectionSet<T>)
 			{
@@ -127,7 +127,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::HumanHas::endSelectionSet<T>)
 			{
@@ -164,7 +164,7 @@ private:
 
 public:
 	template <class T>
-	Human(std::shared_ptr<T> pimpl) noexcept
+	inline Human(std::shared_ptr<T> pimpl) noexcept
 		: Human { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/HumanOrAlienObject.h
+++ b/samples/validation/schema/HumanOrAlienObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	HumanOrAlien(std::shared_ptr<T> pimpl) noexcept
+	inline HumanOrAlien(std::shared_ptr<T> pimpl) noexcept
 		: HumanOrAlien { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<HumanOrAlien>(), "HumanOrAlien is not implemented");

--- a/samples/validation/schema/MessageObject.cpp
+++ b/samples/validation/schema/MessageObject.cpp
@@ -74,7 +74,7 @@ service::AwaitableResolver Message::resolveSender(service::ResolverParams&& para
 
 service::AwaitableResolver Message::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Message)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Message)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/validation/schema/MessageObject.h
+++ b/samples/validation/schema/MessageObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MessageHas::getBodyWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MessageHas::getSenderWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MessageHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MessageHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	Message(std::shared_ptr<T> pimpl) noexcept
+	inline Message(std::shared_ptr<T> pimpl) noexcept
 		: Message { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/MutateDogResultObject.cpp
+++ b/samples/validation/schema/MutateDogResultObject.cpp
@@ -63,7 +63,7 @@ service::AwaitableResolver MutateDogResult::resolveId(service::ResolverParams&& 
 
 service::AwaitableResolver MutateDogResult::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(MutateDogResult)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(MutateDogResult)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/validation/schema/MutateDogResultObject.h
+++ b/samples/validation/schema/MutateDogResultObject.h
@@ -61,12 +61,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MutateDogResultHas::getIdWithParams<T>)
 			{
@@ -82,7 +82,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutateDogResultHas::beginSelectionSet<T>)
 			{
@@ -90,7 +90,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutateDogResultHas::endSelectionSet<T>)
 			{
@@ -114,7 +114,7 @@ private:
 
 public:
 	template <class T>
-	MutateDogResult(std::shared_ptr<T> pimpl) noexcept
+	inline MutateDogResult(std::shared_ptr<T> pimpl) noexcept
 		: MutateDogResult { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/MutationObject.cpp
+++ b/samples/validation/schema/MutationObject.cpp
@@ -64,7 +64,7 @@ service::AwaitableResolver Mutation::resolveMutateDog(service::ResolverParams&& 
 
 service::AwaitableResolver Mutation::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Mutation)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Mutation)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/validation/schema/MutationObject.h
+++ b/samples/validation/schema/MutationObject.h
@@ -61,12 +61,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MutationHas::applyMutateDogWithParams<T>)
 			{
@@ -82,7 +82,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::beginSelectionSet<T>)
 			{
@@ -90,7 +90,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::endSelectionSet<T>)
 			{
@@ -114,7 +114,7 @@ private:
 
 public:
 	template <class T>
-	Mutation(std::shared_ptr<T> pimpl) noexcept
+	inline Mutation(std::shared_ptr<T> pimpl) noexcept
 		: Mutation { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/NodeObject.h
+++ b/samples/validation/schema/NodeObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	Node(std::shared_ptr<T> pimpl) noexcept
+	inline Node(std::shared_ptr<T> pimpl) noexcept
 		: Node { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Node>(), "Node is not implemented");

--- a/samples/validation/schema/PetObject.h
+++ b/samples/validation/schema/PetObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	Pet(std::shared_ptr<T> pimpl) noexcept
+	inline Pet(std::shared_ptr<T> pimpl) noexcept
 		: Pet { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Pet>(), "Pet is not implemented");

--- a/samples/validation/schema/QueryObject.cpp
+++ b/samples/validation/schema/QueryObject.cpp
@@ -148,7 +148,7 @@ service::AwaitableResolver Query::resolveBooleanList(service::ResolverParams&& p
 
 service::AwaitableResolver Query::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Query)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Query)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/validation/schema/QueryObject.h
+++ b/samples/validation/schema/QueryObject.h
@@ -159,12 +159,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getDogWithParams<T>)
 			{
@@ -180,7 +180,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getHumanWithParams<T>)
 			{
@@ -196,7 +196,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getPetWithParams<T>)
 			{
@@ -212,7 +212,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getCatOrDogWithParams<T>)
 			{
@@ -228,7 +228,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getArgumentsWithParams<T>)
 			{
@@ -244,7 +244,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getResourceWithParams<T>)
 			{
@@ -260,7 +260,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::unique_ptr<ComplexInput>&& complexArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::unique_ptr<ComplexInput>&& complexArg) const final
 		{
 			if constexpr (methods::QueryHas::getFindDogWithParams<T>)
 			{
@@ -276,7 +276,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const final
 		{
 			if constexpr (methods::QueryHas::getBooleanListWithParams<T>)
 			{
@@ -292,7 +292,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::beginSelectionSet<T>)
 			{
@@ -300,7 +300,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::endSelectionSet<T>)
 			{
@@ -324,7 +324,7 @@ private:
 
 public:
 	template <class T>
-	Query(std::shared_ptr<T> pimpl) noexcept
+	inline Query(std::shared_ptr<T> pimpl) noexcept
 		: Query { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/ResourceObject.h
+++ b/samples/validation/schema/ResourceObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	Resource(std::shared_ptr<T> pimpl) noexcept
+	inline Resource(std::shared_ptr<T> pimpl) noexcept
 		: Resource { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Resource>(), "Resource is not implemented");

--- a/samples/validation/schema/SentientObject.h
+++ b/samples/validation/schema/SentientObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	Sentient(std::shared_ptr<T> pimpl) noexcept
+	inline Sentient(std::shared_ptr<T> pimpl) noexcept
 		: Sentient { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Sentient>(), "Sentient is not implemented");

--- a/samples/validation/schema/SubscriptionObject.cpp
+++ b/samples/validation/schema/SubscriptionObject.cpp
@@ -75,7 +75,7 @@ service::AwaitableResolver Subscription::resolveDisallowedSecondRootField(servic
 
 service::AwaitableResolver Subscription::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(Subscription)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(Subscription)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/samples/validation/schema/SubscriptionObject.h
+++ b/samples/validation/schema/SubscriptionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNewMessageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getDisallowedSecondRootFieldWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	Subscription(std::shared_ptr<T> pimpl) noexcept
+	inline Subscription(std::shared_ptr<T> pimpl) noexcept
 		: Subscription { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/ValidationSchema.cpp
+++ b/samples/validation/schema/ValidationSchema.cpp
@@ -49,9 +49,9 @@ validation::DogCommand Argument<validation::DogCommand>::convert(const response:
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<validation::DogCommand>::convert(service::AwaitableScalar<validation::DogCommand> result, ResolverParams params)
+service::AwaitableResolver Result<validation::DogCommand>::convert(service::AwaitableScalar<validation::DogCommand> result, ResolverParams params)
 {
-	return resolve(std::move(result), std::move(params),
+	return ModifiedResult<validation::DogCommand>::resolve(std::move(result), std::move(params),
 		[](validation::DogCommand value, const ResolverParams&)
 		{
 			response::Value result(response::Type::EnumValue);
@@ -63,7 +63,7 @@ service::AwaitableResolver ModifiedResult<validation::DogCommand>::convert(servi
 }
 
 template <>
-void ModifiedResult<validation::DogCommand>::validateScalar(const response::Value& value)
+void Result<validation::DogCommand>::validateScalar(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{
@@ -105,9 +105,9 @@ validation::CatCommand Argument<validation::CatCommand>::convert(const response:
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<validation::CatCommand>::convert(service::AwaitableScalar<validation::CatCommand> result, ResolverParams params)
+service::AwaitableResolver Result<validation::CatCommand>::convert(service::AwaitableScalar<validation::CatCommand> result, ResolverParams params)
 {
-	return resolve(std::move(result), std::move(params),
+	return ModifiedResult<validation::CatCommand>::resolve(std::move(result), std::move(params),
 		[](validation::CatCommand value, const ResolverParams&)
 		{
 			response::Value result(response::Type::EnumValue);
@@ -119,7 +119,7 @@ service::AwaitableResolver ModifiedResult<validation::CatCommand>::convert(servi
 }
 
 template <>
-void ModifiedResult<validation::CatCommand>::validateScalar(const response::Value& value)
+void Result<validation::CatCommand>::validateScalar(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{

--- a/samples/validation/schema/ValidationSchema.cpp
+++ b/samples/validation/schema/ValidationSchema.cpp
@@ -29,7 +29,7 @@ static const auto s_namesDogCommand = validation::getDogCommandNames();
 static const auto s_valuesDogCommand = validation::getDogCommandValues();
 
 template <>
-validation::DogCommand ModifiedArgument<validation::DogCommand>::convert(const response::Value& value)
+validation::DogCommand Argument<validation::DogCommand>::convert(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{
@@ -85,7 +85,7 @@ static const auto s_namesCatCommand = validation::getCatCommandNames();
 static const auto s_valuesCatCommand = validation::getCatCommandValues();
 
 template <>
-validation::CatCommand ModifiedArgument<validation::CatCommand>::convert(const response::Value& value)
+validation::CatCommand Argument<validation::CatCommand>::convert(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{
@@ -138,7 +138,7 @@ void ModifiedResult<validation::CatCommand>::validateScalar(const response::Valu
 }
 
 template <>
-validation::ComplexInput ModifiedArgument<validation::ComplexInput>::convert(const response::Value& value)
+validation::ComplexInput Argument<validation::ComplexInput>::convert(const response::Value& value)
 {
 	auto valueName = service::ModifiedArgument<std::string>::require<service::TypeModifier::Nullable>("name", value);
 	auto valueOwner = service::ModifiedArgument<std::string>::require<service::TypeModifier::Nullable>("owner", value);

--- a/src/ClientGenerator.cpp
+++ b/src/ClientGenerator.cpp
@@ -797,7 +797,7 @@ using namespace )cpp"
 				pendingSeparator.reset();
 
 				sourceFile << R"cpp(template <>
-response::Value ModifiedVariable<)cpp"
+response::Value Variable<)cpp"
 						   << cppType << R"cpp(>::serialize()cpp" << cppType << R"cpp(&& value)
 {
 	response::Value result { response::Type::EnumValue };
@@ -823,7 +823,7 @@ response::Value ModifiedVariable<)cpp"
 				pendingSeparator.reset();
 
 				sourceFile << R"cpp(template <>
-response::Value ModifiedVariable<)cpp"
+response::Value Variable<)cpp"
 						   << cppType << R"cpp(>::serialize()cpp" << cppType
 						   << R"cpp(&& inputValue)
 {
@@ -900,7 +900,7 @@ response::Value ModifiedVariable<)cpp"
 			pendingSeparator.reset();
 
 			sourceFile << R"cpp(template <>
-)cpp" << cppType << R"cpp( ModifiedResponse<)cpp"
+)cpp" << cppType << R"cpp( Response<)cpp"
 					   << cppType << R"cpp(>::parse(response::Value&& value)
 {
 	if (!value.maybe_enum())
@@ -1107,7 +1107,7 @@ bool Generator::outputModifiedResponseImplementation(std::ostream& sourceFile,
 	sourceFile << R"cpp(
 template <>
 )cpp" << cppType
-			   << R"cpp( ModifiedResponse<)cpp" << cppType
+			   << R"cpp( Response<)cpp" << cppType
 			   << R"cpp(>::parse(response::Value&& response)
 {
 	)cpp" << cppType

--- a/src/GraphQLClient.cpp
+++ b/src/GraphQLClient.cpp
@@ -165,43 +165,43 @@ ServiceResponse parseServiceResponse(response::Value response)
 }
 
 template <>
-response::Value ModifiedVariable<int>::serialize(int&& value)
+response::Value Variable<int>::serialize(int&& value)
 {
 	return response::Value { value };
 }
 
 template <>
-response::Value ModifiedVariable<double>::serialize(double&& value)
+response::Value Variable<double>::serialize(double&& value)
 {
 	return response::Value { value };
 }
 
 template <>
-response::Value ModifiedVariable<std::string>::serialize(std::string&& value)
+response::Value Variable<std::string>::serialize(std::string&& value)
 {
 	return response::Value { std::move(value) };
 }
 
 template <>
-response::Value ModifiedVariable<bool>::serialize(bool&& value)
+response::Value Variable<bool>::serialize(bool&& value)
 {
 	return response::Value { value };
 }
 
 template <>
-response::Value ModifiedVariable<response::Value>::serialize(response::Value&& value)
+response::Value Variable<response::Value>::serialize(response::Value&& value)
 {
 	return response::Value { std::move(value) };
 }
 
 template <>
-response::Value ModifiedVariable<response::IdType>::serialize(response::IdType&& value)
+response::Value Variable<response::IdType>::serialize(response::IdType&& value)
 {
 	return response::Value { std::move(value) };
 }
 
 template <>
-int ModifiedResponse<int>::parse(response::Value&& value)
+int Response<int>::parse(response::Value&& value)
 {
 	if (value.type() != response::Type::Int)
 	{
@@ -212,7 +212,7 @@ int ModifiedResponse<int>::parse(response::Value&& value)
 }
 
 template <>
-double ModifiedResponse<double>::parse(response::Value&& value)
+double Response<double>::parse(response::Value&& value)
 {
 	if (value.type() != response::Type::Float && value.type() != response::Type::Int)
 	{
@@ -223,7 +223,7 @@ double ModifiedResponse<double>::parse(response::Value&& value)
 }
 
 template <>
-std::string ModifiedResponse<std::string>::parse(response::Value&& value)
+std::string Response<std::string>::parse(response::Value&& value)
 {
 	if (value.type() != response::Type::String)
 	{
@@ -234,7 +234,7 @@ std::string ModifiedResponse<std::string>::parse(response::Value&& value)
 }
 
 template <>
-bool ModifiedResponse<bool>::parse(response::Value&& value)
+bool Response<bool>::parse(response::Value&& value)
 {
 	if (value.type() != response::Type::Boolean)
 	{
@@ -245,13 +245,13 @@ bool ModifiedResponse<bool>::parse(response::Value&& value)
 }
 
 template <>
-response::Value ModifiedResponse<response::Value>::parse(response::Value&& value)
+response::Value Response<response::Value>::parse(response::Value&& value)
 {
 	return { std::move(value) };
 }
 
 template <>
-response::IdType ModifiedResponse<response::IdType>::parse(response::Value&& value)
+response::IdType Response<response::IdType>::parse(response::Value&& value)
 {
 	if (!value.maybe_id())
 	{

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -694,33 +694,36 @@ void blockSubFields(const ResolverParams& params)
 }
 
 template <>
-AwaitableResolver ModifiedResult<int>::convert(AwaitableScalar<int> result, ResolverParams params)
+AwaitableResolver Result<int>::convert(AwaitableScalar<int> result, ResolverParams params)
 {
 	blockSubFields(params);
 
-	return resolve(std::move(result), std::move(params), [](int&& value, const ResolverParams&) {
-		return response::Value(value);
-	});
+	return ModifiedResult<int>::resolve(std::move(result),
+		std::move(params),
+		[](int&& value, const ResolverParams&) {
+			return response::Value(value);
+		});
 }
 
 template <>
-AwaitableResolver ModifiedResult<double>::convert(
-	AwaitableScalar<double> result, ResolverParams params)
+AwaitableResolver Result<double>::convert(AwaitableScalar<double> result, ResolverParams params)
 {
 	blockSubFields(params);
 
-	return resolve(std::move(result), std::move(params), [](double&& value, const ResolverParams&) {
-		return response::Value(value);
-	});
+	return ModifiedResult<double>::resolve(std::move(result),
+		std::move(params),
+		[](double&& value, const ResolverParams&) {
+			return response::Value(value);
+		});
 }
 
 template <>
-AwaitableResolver ModifiedResult<std::string>::convert(
+AwaitableResolver Result<std::string>::convert(
 	AwaitableScalar<std::string> result, ResolverParams params)
 {
 	blockSubFields(params);
 
-	return resolve(std::move(result),
+	return ModifiedResult<std::string>::resolve(std::move(result),
 		std::move(params),
 		[](std::string&& value, const ResolverParams&) {
 			return response::Value(std::move(value));
@@ -728,22 +731,24 @@ AwaitableResolver ModifiedResult<std::string>::convert(
 }
 
 template <>
-AwaitableResolver ModifiedResult<bool>::convert(AwaitableScalar<bool> result, ResolverParams params)
+AwaitableResolver Result<bool>::convert(AwaitableScalar<bool> result, ResolverParams params)
 {
 	blockSubFields(params);
 
-	return resolve(std::move(result), std::move(params), [](bool&& value, const ResolverParams&) {
-		return response::Value(value);
-	});
+	return ModifiedResult<bool>::resolve(std::move(result),
+		std::move(params),
+		[](bool&& value, const ResolverParams&) {
+			return response::Value(value);
+		});
 }
 
 template <>
-AwaitableResolver ModifiedResult<response::Value>::convert(
+AwaitableResolver Result<response::Value>::convert(
 	AwaitableScalar<response::Value> result, ResolverParams params)
 {
 	blockSubFields(params);
 
-	return resolve(std::move(result),
+	return ModifiedResult<response::Value>::resolve(std::move(result),
 		std::move(params),
 		[](response::Value&& value, const ResolverParams&) {
 			return response::Value(std::move(value));
@@ -751,12 +756,12 @@ AwaitableResolver ModifiedResult<response::Value>::convert(
 }
 
 template <>
-AwaitableResolver ModifiedResult<response::IdType>::convert(
+AwaitableResolver Result<response::IdType>::convert(
 	AwaitableScalar<response::IdType> result, ResolverParams params)
 {
 	blockSubFields(params);
 
-	return resolve(std::move(result),
+	return ModifiedResult<response::IdType>::resolve(std::move(result),
 		std::move(params),
 		[](response::IdType&& value, const ResolverParams&) {
 			return response::Value(std::move(value));
@@ -780,7 +785,7 @@ void requireSubFields(const ResolverParams& params)
 }
 
 template <>
-AwaitableResolver ModifiedResult<Object>::convert(
+AwaitableResolver Result<Object>::convert(
 	AwaitableObject<std::shared_ptr<const Object>> result, ResolverParams params)
 {
 	requireSubFields(params);
@@ -803,7 +808,7 @@ AwaitableResolver ModifiedResult<Object>::convert(
 }
 
 template <>
-void ModifiedResult<int>::validateScalar(const response::Value& value)
+void Result<int>::validateScalar(const response::Value& value)
 {
 	if (value.type() != response::Type::Int)
 	{
@@ -812,7 +817,7 @@ void ModifiedResult<int>::validateScalar(const response::Value& value)
 }
 
 template <>
-void ModifiedResult<double>::validateScalar(const response::Value& value)
+void Result<double>::validateScalar(const response::Value& value)
 {
 	if (value.type() != response::Type::Float)
 	{
@@ -821,7 +826,7 @@ void ModifiedResult<double>::validateScalar(const response::Value& value)
 }
 
 template <>
-void ModifiedResult<std::string>::validateScalar(const response::Value& value)
+void Result<std::string>::validateScalar(const response::Value& value)
 {
 	if (value.type() != response::Type::String)
 	{
@@ -830,7 +835,7 @@ void ModifiedResult<std::string>::validateScalar(const response::Value& value)
 }
 
 template <>
-void ModifiedResult<bool>::validateScalar(const response::Value& value)
+void Result<bool>::validateScalar(const response::Value& value)
 {
 	if (value.type() != response::Type::Boolean)
 	{
@@ -839,7 +844,7 @@ void ModifiedResult<bool>::validateScalar(const response::Value& value)
 }
 
 template <>
-void ModifiedResult<response::IdType>::validateScalar(const response::Value& value)
+void Result<response::IdType>::validateScalar(const response::Value& value)
 {
 	if (!value.maybe_id())
 	{
@@ -848,7 +853,7 @@ void ModifiedResult<response::IdType>::validateScalar(const response::Value& val
 }
 
 template <>
-void ModifiedResult<response::Value>::validateScalar(const response::Value&)
+void Result<response::Value>::validateScalar(const response::Value&)
 {
 	// Any response::Value is valid for a custom scalar type.
 }

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -617,7 +617,7 @@ schema_location ResolverParams::getLocation() const
 }
 
 template <>
-int ModifiedArgument<int>::convert(const response::Value& value)
+int Argument<int>::convert(const response::Value& value)
 {
 	if (value.type() != response::Type::Int)
 	{
@@ -628,7 +628,7 @@ int ModifiedArgument<int>::convert(const response::Value& value)
 }
 
 template <>
-double ModifiedArgument<double>::convert(const response::Value& value)
+double Argument<double>::convert(const response::Value& value)
 {
 	if (value.type() != response::Type::Float && value.type() != response::Type::Int)
 	{
@@ -639,7 +639,7 @@ double ModifiedArgument<double>::convert(const response::Value& value)
 }
 
 template <>
-std::string ModifiedArgument<std::string>::convert(const response::Value& value)
+std::string Argument<std::string>::convert(const response::Value& value)
 {
 	if (value.type() != response::Type::String)
 	{
@@ -650,7 +650,7 @@ std::string ModifiedArgument<std::string>::convert(const response::Value& value)
 }
 
 template <>
-bool ModifiedArgument<bool>::convert(const response::Value& value)
+bool Argument<bool>::convert(const response::Value& value)
 {
 	if (value.type() != response::Type::Boolean)
 	{
@@ -661,13 +661,13 @@ bool ModifiedArgument<bool>::convert(const response::Value& value)
 }
 
 template <>
-response::Value ModifiedArgument<response::Value>::convert(const response::Value& value)
+response::Value Argument<response::Value>::convert(const response::Value& value)
 {
 	return response::Value(value);
 }
 
 template <>
-response::IdType ModifiedArgument<response::IdType>::convert(const response::Value& value)
+response::IdType Argument<response::IdType>::convert(const response::Value& value)
 {
 	if (!value.maybe_id())
 	{

--- a/src/RequestLoader.cpp
+++ b/src/RequestLoader.cpp
@@ -572,7 +572,7 @@ void RequestLoader::addTypesToSchema()
 
 				locationValue.set<std::string>(std::string { locationName });
 
-				return service::ModifiedArgument<introspection::DirectiveLocation>::convert(
+				return service::Argument<introspection::DirectiveLocation>::convert(
 					locationValue);
 			});
 

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -609,14 +609,14 @@ GRAPHQLSERVICE_EXPORT )cpp" << _loader.getSchemaNamespace()
 						   << R"cpp(>::convert(
 	const response::Value& value);
 template <>
-GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<)cpp"
+GRAPHQLSERVICE_EXPORT AwaitableResolver Result<)cpp"
 						   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << enumType.cppType
 						   << R"cpp(>::convert(
 	AwaitableScalar<)cpp" << _loader.getSchemaNamespace()
 						   << R"cpp(::)cpp" << enumType.cppType
 						   << R"cpp(> result, ResolverParams params);
 template <>
-GRAPHQLSERVICE_EXPORT void ModifiedResult<)cpp"
+GRAPHQLSERVICE_EXPORT void Result<)cpp"
 						   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << enumType.cppType
 						   << R"cpp(>::validateScalar(
 	const response::Value& value);
@@ -1133,8 +1133,8 @@ public:
 
 public:
 	template <class T>
-	inline )cpp" << objectType.cppType
-			<< R"cpp((std::shared_ptr<T> pimpl) noexcept
+	inline )cpp"
+			<< objectType.cppType << R"cpp((std::shared_ptr<T> pimpl) noexcept
 		: )cpp"
 			<< objectType.cppType
 			<< R"cpp( { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
@@ -1308,13 +1308,15 @@ template <>
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<)cpp"
+service::AwaitableResolver Result<)cpp"
 					   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << enumType.cppType
 					   << R"cpp(>::convert(service::AwaitableScalar<)cpp"
 					   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << enumType.cppType
 					   << R"cpp(> result, ResolverParams params)
 {
-	return resolve(std::move(result), std::move(params),
+	return ModifiedResult<)cpp"
+					   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << enumType.cppType
+					   << R"cpp(>::resolve(std::move(result), std::move(params),
 		[]()cpp" << _loader.getSchemaNamespace()
 					   << R"cpp(::)cpp" << enumType.cppType << R"cpp( value, const ResolverParams&)
 		{
@@ -1328,8 +1330,8 @@ service::AwaitableResolver ModifiedResult<)cpp"
 }
 
 template <>
-void ModifiedResult<)cpp"
-					   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << enumType.cppType
+void Result<)cpp" << _loader.getSchemaNamespace()
+					   << R"cpp(::)cpp" << enumType.cppType
 					   << R"cpp(>::validateScalar(const response::Value& value)
 {
 	if (!value.maybe_enum())
@@ -2419,7 +2421,7 @@ service::AwaitableResolver )cpp"
 			   << objectType.cppType
 			   << R"cpp(::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql()cpp"
+	return service::Result<std::string>::convert(std::string{ R"gql()cpp"
 			   << objectType.type << R"cpp()gql" }, std::move(params));
 }
 )cpp";
@@ -2431,7 +2433,7 @@ service::AwaitableResolver )cpp"
 service::AwaitableResolver )cpp"
 			<< objectType.cppType << R"cpp(::resolve_schema(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<service::Object>::convert(std::static_pointer_cast<service::Object>(std::make_shared<)cpp"
+	return service::Result<service::Object>::convert(std::static_pointer_cast<service::Object>(std::make_shared<)cpp"
 			<< SchemaLoader::getIntrospectionNamespace()
 			<< R"cpp(::object::Schema>(std::make_shared<)cpp"
 			<< SchemaLoader::getIntrospectionNamespace()

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -670,27 +670,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -709,7 +709,7 @@ private:
 
 public:
 	template <class T>
-	)cpp"
+	inline )cpp"
 		<< cppType << R"cpp((std::shared_ptr<T> pimpl) noexcept
 		: )cpp"
 		<< cppType
@@ -898,7 +898,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -909,7 +909,7 @@ private:
 		const auto accessorName = SchemaLoader::getOutputCppAccessor(outputField);
 
 		headerFile << R"cpp(
-		[[nodiscard]] )cpp"
+		[[nodiscard]] inline )cpp"
 				   << _loader.getOutputCppType(outputField) << R"cpp( )cpp" << accessorName
 				   << R"cpp(()cpp";
 
@@ -1028,7 +1028,7 @@ private:
 	if (!_loader.isIntrospection())
 	{
 		headerFile << R"cpp(
-		void beginSelectionSet(const service::SelectionSetParams& params) const final
+		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::)cpp"
 				   << objectType.cppType << R"cpp(Has::beginSelectionSet<T>)
@@ -1037,7 +1037,7 @@ private:
 			}
 		}
 
-		void endSelectionSet(const service::SelectionSetParams& params) const final
+		inline void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::)cpp"
 				   << objectType.cppType << R"cpp(Has::endSelectionSet<T>)
@@ -1133,7 +1133,7 @@ public:
 
 public:
 	template <class T>
-	)cpp" << objectType.cppType
+	inline )cpp" << objectType.cppType
 			<< R"cpp((std::shared_ptr<T> pimpl) noexcept
 		: )cpp"
 			<< objectType.cppType

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -604,7 +604,7 @@ private:
 			{
 				headerFile << R"cpp(template <>
 GRAPHQLSERVICE_EXPORT )cpp" << _loader.getSchemaNamespace()
-						   << R"cpp(::)cpp" << enumType.cppType << R"cpp( ModifiedArgument<)cpp"
+						   << R"cpp(::)cpp" << enumType.cppType << R"cpp( Argument<)cpp"
 						   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << enumType.cppType
 						   << R"cpp(>::convert(
 	const response::Value& value);
@@ -627,7 +627,7 @@ GRAPHQLSERVICE_EXPORT void ModifiedResult<)cpp"
 			{
 				headerFile << R"cpp(template <>
 GRAPHQLSERVICE_EXPORT )cpp" << _loader.getSchemaNamespace()
-						   << R"cpp(::)cpp" << inputType.cppType << R"cpp( ModifiedArgument<)cpp"
+						   << R"cpp(::)cpp" << inputType.cppType << R"cpp( Argument<)cpp"
 						   << inputType.cppType << R"cpp(>::convert(
 	const response::Value& value);
 )cpp";
@@ -1283,7 +1283,7 @@ static const auto s_values)cpp"
 
 template <>
 )cpp" << _loader.getSchemaNamespace()
-					   << R"cpp(::)cpp" << enumType.cppType << R"cpp( ModifiedArgument<)cpp"
+					   << R"cpp(::)cpp" << enumType.cppType << R"cpp( Argument<)cpp"
 					   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << enumType.cppType
 					   << R"cpp(>::convert(const response::Value& value)
 {
@@ -1361,7 +1361,7 @@ void ModifiedResult<)cpp"
 
 			sourceFile << R"cpp(template <>
 )cpp" << _loader.getSchemaNamespace()
-					   << R"cpp(::)cpp" << inputType.cppType << R"cpp( ModifiedArgument<)cpp"
+					   << R"cpp(::)cpp" << inputType.cppType << R"cpp( Argument<)cpp"
 					   << _loader.getSchemaNamespace() << R"cpp(::)cpp" << inputType.cppType
 					   << R"cpp(>::convert(const response::Value& value)
 {

--- a/src/introspection/DirectiveObject.cpp
+++ b/src/introspection/DirectiveObject.cpp
@@ -97,7 +97,7 @@ service::AwaitableResolver Directive::resolveIsRepeatable(service::ResolverParam
 
 service::AwaitableResolver Directive::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(__Directive)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(__Directive)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/src/introspection/DirectiveObject.h
+++ b/src/introspection/DirectiveObject.h
@@ -39,32 +39,32 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
 		{
 			return { _pimpl->getLocations() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsRepeatable() const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getIsRepeatable() const final
 		{
 			return { _pimpl->getIsRepeatable() };
 		}

--- a/src/introspection/EnumValueObject.cpp
+++ b/src/introspection/EnumValueObject.cpp
@@ -86,7 +86,7 @@ service::AwaitableResolver EnumValue::resolveDeprecationReason(service::Resolver
 
 service::AwaitableResolver EnumValue::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(__EnumValue)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(__EnumValue)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/src/introspection/EnumValueObject.h
+++ b/src/introspection/EnumValueObject.h
@@ -37,27 +37,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}

--- a/src/introspection/FieldObject.cpp
+++ b/src/introspection/FieldObject.cpp
@@ -108,7 +108,7 @@ service::AwaitableResolver Field::resolveDeprecationReason(service::ResolverPara
 
 service::AwaitableResolver Field::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(__Field)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(__Field)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/src/introspection/FieldObject.h
+++ b/src/introspection/FieldObject.h
@@ -41,37 +41,37 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const final
+		[[nodiscard]] inline service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}

--- a/src/introspection/InputValueObject.cpp
+++ b/src/introspection/InputValueObject.cpp
@@ -87,7 +87,7 @@ service::AwaitableResolver InputValue::resolveDefaultValue(service::ResolverPara
 
 service::AwaitableResolver InputValue::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(__InputValue)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(__InputValue)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/src/introspection/InputValueObject.h
+++ b/src/introspection/InputValueObject.h
@@ -37,27 +37,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
 		{
 			return { _pimpl->getDefaultValue() };
 		}

--- a/src/introspection/IntrospectionSchema.cpp
+++ b/src/introspection/IntrospectionSchema.cpp
@@ -23,7 +23,7 @@ static const auto s_namesTypeKind = introspection::getTypeKindNames();
 static const auto s_valuesTypeKind = introspection::getTypeKindValues();
 
 template <>
-introspection::TypeKind ModifiedArgument<introspection::TypeKind>::convert(const response::Value& value)
+introspection::TypeKind Argument<introspection::TypeKind>::convert(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{
@@ -79,7 +79,7 @@ static const auto s_namesDirectiveLocation = introspection::getDirectiveLocation
 static const auto s_valuesDirectiveLocation = introspection::getDirectiveLocationValues();
 
 template <>
-introspection::DirectiveLocation ModifiedArgument<introspection::DirectiveLocation>::convert(const response::Value& value)
+introspection::DirectiveLocation Argument<introspection::DirectiveLocation>::convert(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{

--- a/src/introspection/IntrospectionSchema.cpp
+++ b/src/introspection/IntrospectionSchema.cpp
@@ -43,9 +43,9 @@ introspection::TypeKind Argument<introspection::TypeKind>::convert(const respons
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<introspection::TypeKind>::convert(service::AwaitableScalar<introspection::TypeKind> result, ResolverParams params)
+service::AwaitableResolver Result<introspection::TypeKind>::convert(service::AwaitableScalar<introspection::TypeKind> result, ResolverParams params)
 {
-	return resolve(std::move(result), std::move(params),
+	return ModifiedResult<introspection::TypeKind>::resolve(std::move(result), std::move(params),
 		[](introspection::TypeKind value, const ResolverParams&)
 		{
 			response::Value result(response::Type::EnumValue);
@@ -57,7 +57,7 @@ service::AwaitableResolver ModifiedResult<introspection::TypeKind>::convert(serv
 }
 
 template <>
-void ModifiedResult<introspection::TypeKind>::validateScalar(const response::Value& value)
+void Result<introspection::TypeKind>::validateScalar(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{
@@ -99,9 +99,9 @@ introspection::DirectiveLocation Argument<introspection::DirectiveLocation>::con
 }
 
 template <>
-service::AwaitableResolver ModifiedResult<introspection::DirectiveLocation>::convert(service::AwaitableScalar<introspection::DirectiveLocation> result, ResolverParams params)
+service::AwaitableResolver Result<introspection::DirectiveLocation>::convert(service::AwaitableScalar<introspection::DirectiveLocation> result, ResolverParams params)
 {
-	return resolve(std::move(result), std::move(params),
+	return ModifiedResult<introspection::DirectiveLocation>::resolve(std::move(result), std::move(params),
 		[](introspection::DirectiveLocation value, const ResolverParams&)
 		{
 			response::Value result(response::Type::EnumValue);
@@ -113,7 +113,7 @@ service::AwaitableResolver ModifiedResult<introspection::DirectiveLocation>::con
 }
 
 template <>
-void ModifiedResult<introspection::DirectiveLocation>::validateScalar(const response::Value& value)
+void Result<introspection::DirectiveLocation>::validateScalar(const response::Value& value)
 {
 	if (!value.maybe_enum())
 	{

--- a/src/introspection/IntrospectionSchema.h
+++ b/src/introspection/IntrospectionSchema.h
@@ -177,7 +177,7 @@ namespace service {
 #ifdef GRAPHQL_DLLEXPORTS
 // Export all of the built-in converters
 template <>
-GRAPHQLSERVICE_EXPORT introspection::TypeKind ModifiedArgument<introspection::TypeKind>::convert(
+GRAPHQLSERVICE_EXPORT introspection::TypeKind Argument<introspection::TypeKind>::convert(
 	const response::Value& value);
 template <>
 GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<introspection::TypeKind>::convert(
@@ -186,7 +186,7 @@ template <>
 GRAPHQLSERVICE_EXPORT void ModifiedResult<introspection::TypeKind>::validateScalar(
 	const response::Value& value);
 template <>
-GRAPHQLSERVICE_EXPORT introspection::DirectiveLocation ModifiedArgument<introspection::DirectiveLocation>::convert(
+GRAPHQLSERVICE_EXPORT introspection::DirectiveLocation Argument<introspection::DirectiveLocation>::convert(
 	const response::Value& value);
 template <>
 GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<introspection::DirectiveLocation>::convert(

--- a/src/introspection/IntrospectionSchema.h
+++ b/src/introspection/IntrospectionSchema.h
@@ -180,19 +180,19 @@ template <>
 GRAPHQLSERVICE_EXPORT introspection::TypeKind Argument<introspection::TypeKind>::convert(
 	const response::Value& value);
 template <>
-GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<introspection::TypeKind>::convert(
+GRAPHQLSERVICE_EXPORT AwaitableResolver Result<introspection::TypeKind>::convert(
 	AwaitableScalar<introspection::TypeKind> result, ResolverParams params);
 template <>
-GRAPHQLSERVICE_EXPORT void ModifiedResult<introspection::TypeKind>::validateScalar(
+GRAPHQLSERVICE_EXPORT void Result<introspection::TypeKind>::validateScalar(
 	const response::Value& value);
 template <>
 GRAPHQLSERVICE_EXPORT introspection::DirectiveLocation Argument<introspection::DirectiveLocation>::convert(
 	const response::Value& value);
 template <>
-GRAPHQLSERVICE_EXPORT AwaitableResolver ModifiedResult<introspection::DirectiveLocation>::convert(
+GRAPHQLSERVICE_EXPORT AwaitableResolver Result<introspection::DirectiveLocation>::convert(
 	AwaitableScalar<introspection::DirectiveLocation> result, ResolverParams params);
 template <>
-GRAPHQLSERVICE_EXPORT void ModifiedResult<introspection::DirectiveLocation>::validateScalar(
+GRAPHQLSERVICE_EXPORT void Result<introspection::DirectiveLocation>::validateScalar(
 	const response::Value& value);
 #endif // GRAPHQL_DLLEXPORTS
 

--- a/src/introspection/SchemaObject.cpp
+++ b/src/introspection/SchemaObject.cpp
@@ -108,7 +108,7 @@ service::AwaitableResolver Schema::resolveDirectives(service::ResolverParams&& p
 
 service::AwaitableResolver Schema::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(__Schema)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(__Schema)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/src/introspection/SchemaObject.h
+++ b/src/introspection/SchemaObject.h
@@ -41,37 +41,37 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
 		{
 			return { _pimpl->getTypes() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
 		{
 			return { _pimpl->getQueryType() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
 		{
 			return { _pimpl->getMutationType() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
 		{
 			return { _pimpl->getSubscriptionType() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
+		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
 		{
 			return { _pimpl->getDirectives() };
 		}

--- a/src/introspection/TypeObject.cpp
+++ b/src/introspection/TypeObject.cpp
@@ -180,7 +180,7 @@ service::AwaitableResolver Type::resolveSpecifiedByURL(service::ResolverParams&&
 
 service::AwaitableResolver Type::resolve_typename(service::ResolverParams&& params) const
 {
-	return service::ModifiedResult<std::string>::convert(std::string{ R"gql(__Type)gql" }, std::move(params));
+	return service::Result<std::string>::convert(std::string{ R"gql(__Type)gql" }, std::move(params));
 }
 
 } // namespace object

--- a/src/introspection/TypeObject.h
+++ b/src/introspection/TypeObject.h
@@ -49,57 +49,57 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		inline Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<TypeKind> getKind() const final
+		[[nodiscard]] inline service::AwaitableScalar<TypeKind> getKind() const final
 		{
 			return { _pimpl->getKind() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getFields(std::move(includeDeprecatedArg)) };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
 		{
 			return { _pimpl->getInterfaces() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
 		{
 			return { _pimpl->getPossibleTypes() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getEnumValues(std::move(includeDeprecatedArg)) };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
+		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
 		{
 			return { _pimpl->getInputFields() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
+		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
 		{
 			return { _pimpl->getOfType() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
+		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
 		{
 			return { _pimpl->getSpecifiedByURL() };
 		}

--- a/test/ResponseTests.cpp
+++ b/test/ResponseTests.cpp
@@ -19,7 +19,7 @@ TEST(ResponseCase, ValueConstructorFromStringLiteral)
 TEST(ResponseCase, IdTypeCompareEqual)
 {
 	const auto fakeId = []() noexcept {
-		std::string fakeIdString("fakeId");
+		std::string_view fakeIdString { "fakeId" };
 		response::IdType result(fakeIdString.size());
 
 		std::copy(fakeIdString.cbegin(), fakeIdString.cend(), result.begin());


### PR DESCRIPTION
Fix #255 

At least, I think this will fix that issue, as originally reported. I have not been able to reproduce the original linker error, but by enabling LTO and testing with both GCC 10 and GCC 12 (after an Ubuntu upgrade), I flushed out a lot of ODR (one definition rule) warnings where template methods were specialized the same way in multiple translation units.

To fix the ODR warnings, and hopefully the original linker issue, I added `inline` specifiers to every non-`constexpr` inline method I could find in the headers. I also separated the template methods from the static methods in the `Modified...` template `structs` and put the template methods in an anonymous namespace. That makes their linkage private to each translation unit which instantiates them, so the linker cannot treat them as the same symbol (although it may still monomorphize them to remove duplicate code).

While I was tracking that down, I decided to simplify the SFINAE template logic in the `Modified...` template `structs`. I replaced/consolidated pretty much every reference to the `std::is_same_v<>` or `std::is_base_of_v<>` `type_traits` with concepts and and `std::enable_if_t` with `requires` clauses on the template methods. They're all much easier to read now.

Last of all, GCC 12 seems to have added some potential memory safety warnings which it evaluates at compile time. I found that it wanted me to pass keys (which are pretty much always `std::string_view`) by value rather than `const` reference in `SortedMap.h`. In a few tests where I copy strings into a byte vector to make a Base64 `response::IdType`, I needed to use `std::string_view` instead of `std::string` to avoid hitting the small-string optimization and confusing the compile-time bounds checks.