### PR TITLE
Cleanup redundant inline specifiers

### DIFF
--- a/include/graphqlservice/GraphQLClient.h
+++ b/include/graphqlservice/GraphQLClient.h
@@ -146,7 +146,7 @@ struct ModifiedVariable
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static inline response::Value serialize(
+	[[nodiscard]] static response::Value serialize(
 		Type&& value) requires OnlyNoneModifiers<Modifier, Other...>
 	{
 		// Just call through to the non-template method without the modifiers.
@@ -155,7 +155,7 @@ struct ModifiedVariable
 
 	// Peel off nullable modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static inline response::Value serialize(
+	[[nodiscard]] static response::Value serialize(
 		typename VariableTraits<Type, Modifier, Other...>::type&& nullableValue) requires
 		NullableModifier<Modifier>
 	{
@@ -172,7 +172,7 @@ struct ModifiedVariable
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static inline response::Value serialize(
+	[[nodiscard]] static response::Value serialize(
 		typename VariableTraits<Type, Modifier, Other...>::type&& listValue) requires
 		ListModifier<Modifier>
 	{
@@ -189,7 +189,7 @@ struct ModifiedVariable
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static inline Type duplicate(
+	[[nodiscard]] static Type duplicate(
 		const Type& value) requires OnlyNoneModifiers<Modifier, Other...>
 	{
 		// Just copy the value.
@@ -198,7 +198,7 @@ struct ModifiedVariable
 
 	// Peel off nullable modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static inline typename VariableTraits<Type, Modifier, Other...>::type duplicate(
+	[[nodiscard]] static typename VariableTraits<Type, Modifier, Other...>::type duplicate(
 		const typename VariableTraits<Type, Modifier, Other...>::type& nullableValue) requires
 		NullableModifier<Modifier>
 	{
@@ -222,7 +222,7 @@ struct ModifiedVariable
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static inline typename VariableTraits<Type, Modifier, Other...>::type duplicate(
+	[[nodiscard]] static typename VariableTraits<Type, Modifier, Other...>::type duplicate(
 		const typename VariableTraits<Type, Modifier, Other...>::type& listValue) requires
 		ListModifier<Modifier>
 	{
@@ -296,7 +296,7 @@ struct ModifiedResponse
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static inline Type parse(
+	[[nodiscard]] static Type parse(
 		response::Value&& response) requires OnlyNoneModifiers<Modifier, Other...>
 	{
 		return Response<Type>::parse(std::move(response));
@@ -304,7 +304,7 @@ struct ModifiedResponse
 
 	// Peel off nullable modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static inline std::optional<typename ResponseTraits<Type, Other...>::type> parse(
+	[[nodiscard]] static std::optional<typename ResponseTraits<Type, Other...>::type> parse(
 		response::Value&& response) requires NullableModifier<Modifier>
 	{
 		if (response.type() == response::Type::Null)
@@ -318,7 +318,7 @@ struct ModifiedResponse
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static inline std::vector<typename ResponseTraits<Type, Other...>::type> parse(
+	[[nodiscard]] static std::vector<typename ResponseTraits<Type, Other...>::type> parse(
 		response::Value&& response) requires ListModifier<Modifier>
 	{
 		std::vector<typename ResponseTraits<Type, Other...>::type> result;

--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -392,42 +392,42 @@ private:
 	template <class T>
 	struct Model : Concept
 	{
-		inline Model(std::unique_ptr<T>&& pimpl)
+		Model(std::unique_ptr<T>&& pimpl)
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		inline void start_object() const final
+		void start_object() const final
 		{
 			_pimpl->start_object();
 		}
 
-		inline void add_member(const std::string& key) const final
+		void add_member(const std::string& key) const final
 		{
 			_pimpl->add_member(key);
 		}
 
-		inline void end_object() const final
+		void end_object() const final
 		{
 			_pimpl->end_object();
 		}
 
-		inline void start_array() const final
+		void start_array() const final
 		{
 			_pimpl->start_array();
 		}
 
-		inline void end_arrary() const final
+		void end_arrary() const final
 		{
 			_pimpl->end_arrary();
 		}
 
-		inline void write_null() const final
+		void write_null() const final
 		{
 			_pimpl->write_null();
 		}
 
-		inline void write_string(const std::string& value) const final
+		void write_string(const std::string& value) const final
 		{
 			_pimpl->write_string(value);
 		}
@@ -437,12 +437,12 @@ private:
 			_pimpl->write_bool(value);
 		}
 
-		inline void write_int(int value) const final
+		void write_int(int value) const final
 		{
 			_pimpl->write_int(value);
 		}
 
-		inline void write_float(double value) const final
+		void write_float(double value) const final
 		{
 			_pimpl->write_float(value);
 		}
@@ -455,7 +455,7 @@ private:
 
 public:
 	template <class T>
-	inline Writer(std::unique_ptr<T> writer)
+	Writer(std::unique_ptr<T> writer)
 		: _concept { std::static_pointer_cast<const Concept>(
 			std::make_shared<Model<T>>(std::move(writer))) }
 	{

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -197,22 +197,22 @@ private:
 	template <class T>
 	struct [[nodiscard]] Model : Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl)
+		Model(std::shared_ptr<T>&& pimpl)
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline bool await_ready() const final
+		[[nodiscard]] bool await_ready() const final
 		{
 			return _pimpl->await_ready();
 		}
 
-		inline void await_suspend(coro::coroutine_handle<> h) const final
+		void await_suspend(coro::coroutine_handle<> h) const final
 		{
 			_pimpl->await_suspend(std::move(h));
 		}
 
-		inline void await_resume() const final
+		void await_resume() const final
 		{
 			_pimpl->await_resume();
 		}
@@ -226,7 +226,7 @@ private:
 public:
 	// Type-erased explicit constructor for a custom awaitable.
 	template <class T>
-	inline explicit await_async(std::shared_ptr<T> pimpl)
+	explicit await_async(std::shared_ptr<T> pimpl)
 		: _pimpl { std::make_shared<Model<T>>(std::move(pimpl)) }
 	{
 	}
@@ -300,39 +300,39 @@ class [[nodiscard]] AwaitableScalar
 {
 public:
 	template <typename U>
-	inline AwaitableScalar(U&& value)
+	AwaitableScalar(U&& value)
 		: _value { std::forward<U>(value) }
 	{
 	}
 
 	struct promise_type
 	{
-		[[nodiscard]] inline AwaitableScalar<T> get_return_object() noexcept
+		[[nodiscard]] AwaitableScalar<T> get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
 
-		inline coro::suspend_never initial_suspend() const noexcept
+		coro::suspend_never initial_suspend() const noexcept
 		{
 			return {};
 		}
 
-		inline coro::suspend_never final_suspend() const noexcept
+		coro::suspend_never final_suspend() const noexcept
 		{
 			return {};
 		}
 
-		inline void return_value(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
+		void return_value(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
 		{
 			_promise.set_value(value);
 		}
 
-		inline void return_value(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
+		void return_value(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
 		{
 			_promise.set_value(std::move(value));
 		}
 
-		inline void unhandled_exception() noexcept
+		void unhandled_exception() noexcept
 		{
 			_promise.set_exception(std::current_exception());
 		}
@@ -341,7 +341,7 @@ public:
 		std::promise<T> _promise;
 	};
 
-	[[nodiscard]] inline bool await_ready() const noexcept
+	[[nodiscard]] bool await_ready() const noexcept
 	{
 		return std::visit(
 			[](const auto& value) noexcept {
@@ -366,7 +366,7 @@ public:
 			_value);
 	}
 
-	inline void await_suspend(coro::coroutine_handle<> h) const
+	void await_suspend(coro::coroutine_handle<> h) const
 	{
 		std::thread(
 			[this](coro::coroutine_handle<> h) noexcept {
@@ -377,7 +377,7 @@ public:
 			.detach();
 	}
 
-	[[nodiscard]] inline T await_resume()
+	[[nodiscard]] T await_resume()
 	{
 		return std::visit(
 			[](auto&& value) -> T {
@@ -400,7 +400,7 @@ public:
 			std::move(_value));
 	}
 
-	[[nodiscard]] inline std::shared_ptr<const response::Value> get_value() noexcept
+	[[nodiscard]] std::shared_ptr<const response::Value> get_value() noexcept
 	{
 		return std::visit(
 			[](auto&& value) noexcept {
@@ -429,39 +429,39 @@ class [[nodiscard]] AwaitableObject
 {
 public:
 	template <typename U>
-	inline AwaitableObject(U&& value)
+	AwaitableObject(U&& value)
 		: _value { std::forward<U>(value) }
 	{
 	}
 
 	struct promise_type
 	{
-		[[nodiscard]] inline AwaitableObject<T> get_return_object() noexcept
+		[[nodiscard]] AwaitableObject<T> get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
 
-		inline coro::suspend_never initial_suspend() const noexcept
+		coro::suspend_never initial_suspend() const noexcept
 		{
 			return {};
 		}
 
-		inline coro::suspend_never final_suspend() const noexcept
+		coro::suspend_never final_suspend() const noexcept
 		{
 			return {};
 		}
 
-		inline void return_value(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
+		void return_value(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
 		{
 			_promise.set_value(value);
 		}
 
-		inline void return_value(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
+		void return_value(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
 		{
 			_promise.set_value(std::move(value));
 		}
 
-		inline void unhandled_exception() noexcept
+		void unhandled_exception() noexcept
 		{
 			_promise.set_exception(std::current_exception());
 		}
@@ -470,7 +470,7 @@ public:
 		std::promise<T> _promise;
 	};
 
-	[[nodiscard]] inline bool await_ready() const noexcept
+	[[nodiscard]] bool await_ready() const noexcept
 	{
 		return std::visit(
 			[](const auto& value) noexcept {
@@ -490,7 +490,7 @@ public:
 			_value);
 	}
 
-	inline void await_suspend(coro::coroutine_handle<> h) const
+	void await_suspend(coro::coroutine_handle<> h) const
 	{
 		std::thread(
 			[this](coro::coroutine_handle<> h) noexcept {
@@ -501,7 +501,7 @@ public:
 			.detach();
 	}
 
-	[[nodiscard]] inline T await_resume()
+	[[nodiscard]] T await_resume()
 	{
 		return std::visit(
 			[](auto&& value) -> T {
@@ -671,8 +671,7 @@ struct ModifiedArgument
 	};
 
 	// Call convert on this type without any modifiers.
-	[[nodiscard]] static inline Type require(
-		std::string_view name, const response::Value& arguments)
+	[[nodiscard]] static Type require(std::string_view name, const response::Value& arguments)
 	{
 		try
 		{
@@ -696,7 +695,7 @@ struct ModifiedArgument
 	}
 
 	// Wrap require in a try/catch block.
-	[[nodiscard]] static inline std::pair<Type, bool> find(
+	[[nodiscard]] static std::pair<Type, bool> find(
 		const std::string& name, const response::Value& arguments) noexcept
 	{
 		try
@@ -711,7 +710,7 @@ struct ModifiedArgument
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static inline Type require(std::string_view name,
+	[[nodiscard]] static Type require(std::string_view name,
 		const response::Value& arguments) requires OnlyNoneModifiers<Modifier, Other...>
 	{
 		static_assert(sizeof...(Other) == 0, "None modifier should always be last");
@@ -722,7 +721,7 @@ struct ModifiedArgument
 
 	// Peel off nullable modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static inline typename ArgumentTraits<Type, Modifier, Other...>::type require(
+	[[nodiscard]] static typename ArgumentTraits<Type, Modifier, Other...>::type require(
 		std::string_view name, const response::Value& arguments) requires NullableModifier<Modifier>
 	{
 		const auto& valueItr = arguments.find(name);
@@ -747,7 +746,7 @@ struct ModifiedArgument
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static inline typename ArgumentTraits<Type, Modifier, Other...>::type require(
+	[[nodiscard]] static typename ArgumentTraits<Type, Modifier, Other...>::type require(
 		std::string_view name, const response::Value& arguments) requires ListModifier<Modifier>
 	{
 		const auto& values = arguments[name];
@@ -770,8 +769,7 @@ struct ModifiedArgument
 
 	// Wrap require with modifiers in a try/catch block.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static inline std::pair<typename ArgumentTraits<Type, Modifier, Other...>::type,
-		bool>
+	[[nodiscard]] static std::pair<typename ArgumentTraits<Type, Modifier, Other...>::type, bool>
 	find(std::string_view name, const response::Value& arguments) noexcept
 	{
 		try
@@ -786,7 +784,7 @@ struct ModifiedArgument
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static inline Type duplicate(
+	[[nodiscard]] static Type duplicate(
 		const Type& value) requires OnlyNoneModifiers<Modifier, Other...>
 	{
 		// Just copy the value.
@@ -795,7 +793,7 @@ struct ModifiedArgument
 
 	// Peel off nullable modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static inline typename ArgumentTraits<Type, Modifier, Other...>::type duplicate(
+	[[nodiscard]] static typename ArgumentTraits<Type, Modifier, Other...>::type duplicate(
 		const typename ArgumentTraits<Type, Modifier, Other...>::type& nullableValue) requires
 		NullableModifier<Modifier>
 	{
@@ -819,7 +817,7 @@ struct ModifiedArgument
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static inline typename ArgumentTraits<Type, Modifier, Other...>::type duplicate(
+	[[nodiscard]] static typename ArgumentTraits<Type, Modifier, Other...>::type duplicate(
 		const typename ArgumentTraits<Type, Modifier, Other...>::type& listValue) requires
 		ListModifier<Modifier>
 	{
@@ -1002,7 +1000,7 @@ struct ModifiedResult
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static inline AwaitableResolver convert(
+	[[nodiscard]] static AwaitableResolver convert(
 		AwaitableObject<typename ResultTraits<Type>::type> result,
 		ResolverParams params) requires NoneObjectDerivedType<Type, Modifier>
 	{
@@ -1023,8 +1021,7 @@ struct ModifiedResult
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	[[nodiscard]] static inline AwaitableResolver convert(
-		typename ResultTraits<Type>::future_type result,
+	[[nodiscard]] static AwaitableResolver convert(typename ResultTraits<Type>::future_type result,
 		ResolverParams params) requires NoneScalarOrObjectType<Type, Modifier>
 	{
 		static_assert(sizeof...(Other) == 0, "None modifier should always be last");
@@ -1035,7 +1032,7 @@ struct ModifiedResult
 
 	// Peel off final nullable modifiers for std::shared_ptr of Object and subclasses of Object.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static inline AwaitableResolver convert(
+	[[nodiscard]] static AwaitableResolver convert(
 		typename ResultTraits<Type, Modifier, Other...>::future_type result,
 		ResolverParams params) requires NullableResultSharedPtr<Type, Modifier, Other...>
 	{
@@ -1056,7 +1053,7 @@ struct ModifiedResult
 
 	// Peel off nullable modifiers for anything else, which should all be std::optional.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static inline AwaitableResolver convert(
+	[[nodiscard]] static AwaitableResolver convert(
 		typename ResultTraits<Type, Modifier, Other...>::future_type result,
 		ResolverParams params) requires NullableResultOptional<Type, Modifier, Other...>
 	{
@@ -1093,7 +1090,7 @@ struct ModifiedResult
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	[[nodiscard]] static inline AwaitableResolver convert(
+	[[nodiscard]] static AwaitableResolver convert(
 		typename ResultTraits<Type, Modifier, Other...>::future_type result,
 		ResolverParams params) requires ListModifier<Modifier>
 	{
@@ -1195,7 +1192,7 @@ struct ModifiedResult
 
 	// Peel off the none modifier. If it's included, it should always be last in the list.
 	template <TypeModifier Modifier = TypeModifier::None, TypeModifier... Other>
-	static inline void validateScalar(
+	static void validateScalar(
 		const response::Value& value) requires OnlyNoneModifiers<Modifier, Other...>
 	{
 		static_assert(sizeof...(Other) == 0, "None modifier should always be last");
@@ -1206,8 +1203,7 @@ struct ModifiedResult
 
 	// Peel off nullable modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	static inline void validateScalar(
-		const response::Value& value) requires NullableModifier<Modifier>
+	static void validateScalar(const response::Value& value) requires NullableModifier<Modifier>
 	{
 		if (value.type() != response::Type::Null)
 		{
@@ -1217,7 +1213,7 @@ struct ModifiedResult
 
 	// Peel off list modifiers.
 	template <TypeModifier Modifier, TypeModifier... Other>
-	static inline void validateScalar(const response::Value& value) requires ListModifier<Modifier>
+	static void validateScalar(const response::Value& value) requires ListModifier<Modifier>
 	{
 		if (value.type() != response::Type::List)
 		{
@@ -1233,9 +1229,8 @@ struct ModifiedResult
 	using ResolverCallback =
 		std::function<response::Value(typename ResultTraits<Type>::type, const ResolverParams&)>;
 
-	[[nodiscard]] static inline AwaitableResolver resolve(
-		typename ResultTraits<Type>::future_type result, ResolverParams params,
-		ResolverCallback&& resolver)
+	[[nodiscard]] static AwaitableResolver resolve(typename ResultTraits<Type>::future_type result,
+		ResolverParams params, ResolverCallback&& resolver)
 	{
 		static_assert(!ObjectBaseType<Type>, "ModfiedResult<Object> needs special handling");
 

--- a/include/graphqlservice/internal/Awaitable.h
+++ b/include/graphqlservice/internal/Awaitable.h
@@ -28,39 +28,39 @@ template <>
 class [[nodiscard]] Awaitable<void>
 {
 public:
-	inline Awaitable(std::future<void> value)
+	Awaitable(std::future<void> value)
 		: _value { std::move(value) }
 	{
 	}
 
-	inline void get()
+	void get()
 	{
 		_value.get();
 	}
 
 	struct promise_type
 	{
-		[[nodiscard]] inline Awaitable get_return_object() noexcept
+		[[nodiscard]] Awaitable get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
 
-		inline coro::suspend_never initial_suspend() const noexcept
+		coro::suspend_never initial_suspend() const noexcept
 		{
 			return {};
 		}
 
-		inline coro::suspend_never final_suspend() const noexcept
+		coro::suspend_never final_suspend() const noexcept
 		{
 			return {};
 		}
 
-		inline void return_void() noexcept
+		void return_void() noexcept
 		{
 			_promise.set_value();
 		}
 
-		inline void unhandled_exception() noexcept
+		void unhandled_exception() noexcept
 		{
 			_promise.set_exception(std::current_exception());
 		}
@@ -74,12 +74,12 @@ public:
 		return true;
 	}
 
-	inline void await_suspend(coro::coroutine_handle<> h) const
+	void await_suspend(coro::coroutine_handle<> h) const
 	{
 		h.resume();
 	}
 
-	inline void await_resume()
+	void await_resume()
 	{
 		_value.get();
 	}
@@ -92,44 +92,44 @@ template <typename T>
 class [[nodiscard]] Awaitable
 {
 public:
-	inline Awaitable(std::future<T> value)
+	Awaitable(std::future<T> value)
 		: _value { std::move(value) }
 	{
 	}
 
-	[[nodiscard]] inline T get()
+	[[nodiscard]] T get()
 	{
 		return _value.get();
 	}
 
 	struct promise_type
 	{
-		[[nodiscard]] inline Awaitable get_return_object() noexcept
+		[[nodiscard]] Awaitable get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
 
-		inline coro::suspend_never initial_suspend() const noexcept
+		coro::suspend_never initial_suspend() const noexcept
 		{
 			return {};
 		}
 
-		inline coro::suspend_never final_suspend() const noexcept
+		coro::suspend_never final_suspend() const noexcept
 		{
 			return {};
 		}
 
-		inline void return_value(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
+		void return_value(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
 		{
 			_promise.set_value(value);
 		}
 
-		inline void return_value(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
+		void return_value(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
 		{
 			_promise.set_value(std::move(value));
 		}
 
-		inline void unhandled_exception() noexcept
+		void unhandled_exception() noexcept
 		{
 			_promise.set_exception(std::current_exception());
 		}
@@ -143,12 +143,12 @@ public:
 		return true;
 	}
 
-	inline void await_suspend(coro::coroutine_handle<> h) const
+	void await_suspend(coro::coroutine_handle<> h) const
 	{
 		h.resume();
 	}
 
-	[[nodiscard]] inline T await_resume()
+	[[nodiscard]] T await_resume()
 	{
 		return _value.get();
 	}

--- a/include/graphqlservice/internal/SortedMap.h
+++ b/include/graphqlservice/internal/SortedMap.h
@@ -86,7 +86,7 @@ public:
 		return _data == rhs._data;
 	}
 
-	inline void reserve(size_t size)
+	void reserve(size_t size)
 	{
 		_data.reserve(size);
 	}
@@ -96,7 +96,7 @@ public:
 		return _data.capacity();
 	}
 
-	inline void clear() noexcept
+	void clear() noexcept
 	{
 		_data.clear();
 	}
@@ -147,7 +147,7 @@ public:
 	}
 
 	template <typename KeyArg, typename... ValueArgs>
-	inline std::pair<const_iterator, bool> emplace(KeyArg&& keyArg, ValueArgs&&... args) noexcept
+	std::pair<const_iterator, bool> emplace(KeyArg&& keyArg, ValueArgs&&... args) noexcept
 	{
 		K key { std::forward<KeyArg>(keyArg) };
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
@@ -161,7 +161,7 @@ public:
 			true };
 	}
 
-	inline const_iterator erase(K key) noexcept
+	const_iterator erase(K key) noexcept
 	{
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
 
@@ -174,20 +174,20 @@ public:
 	}
 
 	template <typename KeyArg>
-	inline const_iterator erase(KeyArg&& keyArg) noexcept
+	const_iterator erase(KeyArg&& keyArg) noexcept
 	{
 		const K key { std::forward<KeyArg>(keyArg) };
 
 		return erase(key);
 	}
 
-	inline const_iterator erase(const_iterator itr) noexcept
+	const_iterator erase(const_iterator itr) noexcept
 	{
 		return _data.erase(itr);
 	}
 
 	template <typename KeyArg>
-	[[nodiscard]] inline V& operator[](KeyArg&& keyArg) noexcept
+	[[nodiscard]] V& operator[](KeyArg&& keyArg) noexcept
 	{
 		K key { std::forward<KeyArg>(keyArg) };
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
@@ -201,7 +201,7 @@ public:
 	}
 
 	template <typename KeyArg>
-	[[nodiscard]] inline V& at(KeyArg&& keyArg)
+	[[nodiscard]] V& at(KeyArg&& keyArg)
 	{
 		const K key { std::forward<KeyArg>(keyArg) };
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
@@ -246,7 +246,7 @@ public:
 		return _data == rhs._data;
 	}
 
-	inline void reserve(size_t size)
+	void reserve(size_t size)
 	{
 		_data.reserve(size);
 	}
@@ -256,7 +256,7 @@ public:
 		return _data.capacity();
 	}
 
-	inline void clear() noexcept
+	void clear() noexcept
 	{
 		_data.clear();
 	}
@@ -309,7 +309,7 @@ public:
 	}
 
 	template <typename Arg>
-	inline std::pair<const_iterator, bool> emplace(Arg&& key) noexcept
+	std::pair<const_iterator, bool> emplace(Arg&& key) noexcept
 	{
 		const auto [itr, itrEnd] =
 			std::equal_range(_data.begin(), _data.end(), key, [](K lhs, K rhs) noexcept {
@@ -324,7 +324,7 @@ public:
 		return { _data.emplace(itrEnd, std::forward<Arg>(key)), true };
 	}
 
-	inline const_iterator erase(K key) noexcept
+	const_iterator erase(K key) noexcept
 	{
 		const auto [itr, itrEnd] =
 			std::equal_range(_data.begin(), _data.end(), key, [](K lhs, K rhs) noexcept {
@@ -340,14 +340,14 @@ public:
 	}
 
 	template <typename Arg>
-	inline const_iterator erase(Arg&& arg) noexcept
+	const_iterator erase(Arg&& arg) noexcept
 	{
 		const K key { std::forward<Arg>(arg) };
 
 		return erase(key);
 	}
 
-	inline const_iterator erase(const_iterator itr) noexcept
+	const_iterator erase(const_iterator itr) noexcept
 	{
 		return _data.erase(itr);
 	}

--- a/include/graphqlservice/internal/SyntaxTree.h
+++ b/include/graphqlservice/internal/SyntaxTree.h
@@ -32,7 +32,7 @@ public:
 	[[nodiscard]] GRAPHQLPEG_EXPORT std::string_view unescaped_view() const;
 
 	template <typename U>
-	[[nodiscard]] inline bool is_type() const noexcept
+	[[nodiscard]] bool is_type() const noexcept
 	{
 		const auto u = type_name<U>();
 
@@ -48,7 +48,7 @@ public:
 	using basic_node_t = parse_tree::basic_node<ast_node>;
 
 	template <typename Rule, typename ParseInput>
-	inline void success(const ParseInput& in)
+	void success(const ParseInput& in)
 	{
 		basic_node_t::template success<Rule>(in);
 		_type_name = type_name<Rule>();
@@ -57,7 +57,7 @@ public:
 
 private:
 	template <typename U>
-	[[nodiscard]] static inline std::string_view type_name() noexcept
+	[[nodiscard]] static std::string_view type_name() noexcept
 	{
 		// This is cached in a static local variable per-specialization, but each module may have
 		// its own instance of the specialization and the local variable. Within a single module,
@@ -69,7 +69,7 @@ private:
 	}
 
 	template <typename U>
-	[[nodiscard]] static inline size_t type_hash() noexcept
+	[[nodiscard]] static size_t type_hash() noexcept
 	{
 		// This is cached in a static local variable per-specialization, but each module may have
 		// its own instance of the specialization and the local variable.

--- a/include/graphqlservice/introspection/DirectiveObject.h
+++ b/include/graphqlservice/introspection/DirectiveObject.h
@@ -39,32 +39,32 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
+		[[nodiscard]] service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
 		{
 			return { _pimpl->getLocations() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getIsRepeatable() const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsRepeatable() const final
 		{
 			return { _pimpl->getIsRepeatable() };
 		}

--- a/include/graphqlservice/introspection/EnumValueObject.h
+++ b/include/graphqlservice/introspection/EnumValueObject.h
@@ -37,27 +37,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getIsDeprecated() const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}

--- a/include/graphqlservice/introspection/FieldObject.h
+++ b/include/graphqlservice/introspection/FieldObject.h
@@ -41,37 +41,37 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getIsDeprecated() const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}

--- a/include/graphqlservice/introspection/InputValueObject.h
+++ b/include/graphqlservice/introspection/InputValueObject.h
@@ -37,27 +37,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
 		{
 			return { _pimpl->getDefaultValue() };
 		}

--- a/include/graphqlservice/introspection/SchemaObject.h
+++ b/include/graphqlservice/introspection/SchemaObject.h
@@ -41,37 +41,37 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
 		{
 			return { _pimpl->getTypes() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
 		{
 			return { _pimpl->getQueryType() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
 		{
 			return { _pimpl->getMutationType() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
 		{
 			return { _pimpl->getSubscriptionType() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
 		{
 			return { _pimpl->getDirectives() };
 		}

--- a/include/graphqlservice/introspection/TypeObject.h
+++ b/include/graphqlservice/introspection/TypeObject.h
@@ -49,57 +49,57 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<TypeKind> getKind() const final
+		[[nodiscard]] service::AwaitableScalar<TypeKind> getKind() const final
 		{
 			return { _pimpl->getKind() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getFields(std::move(includeDeprecatedArg)) };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
 		{
 			return { _pimpl->getInterfaces() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
 		{
 			return { _pimpl->getPossibleTypes() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getEnumValues(std::move(includeDeprecatedArg)) };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
 		{
 			return { _pimpl->getInputFields() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
 		{
 			return { _pimpl->getOfType() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
 		{
 			return { _pimpl->getSpecifiedByURL() };
 		}

--- a/samples/learn/schema/CharacterObject.h
+++ b/samples/learn/schema/CharacterObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	inline Character(std::shared_ptr<T> pimpl) noexcept
+	Character(std::shared_ptr<T> pimpl) noexcept
 		: Character { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Character>(), "Character is not implemented");

--- a/samples/learn/schema/DroidObject.h
+++ b/samples/learn/schema/DroidObject.h
@@ -124,12 +124,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getIdWithParams<T>)
 			{
@@ -142,7 +142,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getNameWithParams<T>)
 			{
@@ -155,7 +155,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getFriendsWithParams<T>)
 			{
@@ -168,7 +168,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getAppearsInWithParams<T>)
 			{
@@ -181,7 +181,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DroidHas::getPrimaryFunctionWithParams<T>)
 			{
@@ -194,7 +194,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::DroidHas::beginSelectionSet<T>)
 			{
@@ -202,7 +202,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::DroidHas::endSelectionSet<T>)
 			{
@@ -235,7 +235,7 @@ private:
 
 public:
 	template <class T>
-	inline Droid(std::shared_ptr<T> pimpl) noexcept
+	Droid(std::shared_ptr<T> pimpl) noexcept
 		: Droid { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/learn/schema/HumanObject.h
+++ b/samples/learn/schema/HumanObject.h
@@ -124,12 +124,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getIdWithParams<T>)
 			{
@@ -142,7 +142,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getNameWithParams<T>)
 			{
@@ -155,7 +155,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getFriendsWithParams<T>)
 			{
@@ -168,7 +168,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getAppearsInWithParams<T>)
 			{
@@ -181,7 +181,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getHomePlanetWithParams<T>)
 			{
@@ -194,7 +194,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::HumanHas::beginSelectionSet<T>)
 			{
@@ -202,7 +202,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::HumanHas::endSelectionSet<T>)
 			{
@@ -235,7 +235,7 @@ private:
 
 public:
 	template <class T>
-	inline Human(std::shared_ptr<T> pimpl) noexcept
+	Human(std::shared_ptr<T> pimpl) noexcept
 		: Human { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/learn/schema/MutationObject.h
+++ b/samples/learn/schema/MutationObject.h
@@ -61,12 +61,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const final
 		{
 			if constexpr (methods::MutationHas::applyCreateReviewWithParams<T>)
 			{
@@ -79,7 +79,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::beginSelectionSet<T>)
 			{
@@ -87,7 +87,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::endSelectionSet<T>)
 			{
@@ -111,7 +111,7 @@ private:
 
 public:
 	template <class T>
-	inline Mutation(std::shared_ptr<T> pimpl) noexcept
+	Mutation(std::shared_ptr<T> pimpl) noexcept
 		: Mutation { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/learn/schema/QueryObject.h
+++ b/samples/learn/schema/QueryObject.h
@@ -93,12 +93,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const final
 		{
 			if constexpr (methods::QueryHas::getHeroWithParams<T>)
 			{
@@ -111,7 +111,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getHumanWithParams<T>)
 			{
@@ -124,7 +124,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getDroidWithParams<T>)
 			{
@@ -137,7 +137,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::beginSelectionSet<T>)
 			{
@@ -145,7 +145,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::endSelectionSet<T>)
 			{
@@ -169,7 +169,7 @@ private:
 
 public:
 	template <class T>
-	inline Query(std::shared_ptr<T> pimpl) noexcept
+	Query(std::shared_ptr<T> pimpl) noexcept
 		: Query { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/learn/schema/ReviewObject.h
+++ b/samples/learn/schema/ReviewObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<int> getStars(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getStars(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ReviewHas::getStarsWithParams<T>)
 			{
@@ -93,7 +93,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ReviewHas::getCommentaryWithParams<T>)
 			{
@@ -106,7 +106,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ReviewHas::beginSelectionSet<T>)
 			{
@@ -114,7 +114,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ReviewHas::endSelectionSet<T>)
 			{
@@ -138,7 +138,7 @@ private:
 
 public:
 	template <class T>
-	inline Review(std::shared_ptr<T> pimpl) noexcept
+	Review(std::shared_ptr<T> pimpl) noexcept
 		: Review { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/AppointmentConnectionObject.h
+++ b/samples/today/nointrospection/AppointmentConnectionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getEdgesWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline AppointmentConnection(std::shared_ptr<T> pimpl) noexcept
+	AppointmentConnection(std::shared_ptr<T> pimpl) noexcept
 		: AppointmentConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/AppointmentEdgeObject.h
+++ b/samples/today/nointrospection/AppointmentEdgeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getCursorWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline AppointmentEdge(std::shared_ptr<T> pimpl) noexcept
+	AppointmentEdge(std::shared_ptr<T> pimpl) noexcept
 		: AppointmentEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/AppointmentObject.h
+++ b/samples/today/nointrospection/AppointmentObject.h
@@ -124,12 +124,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIdWithParams<T>)
 			{
@@ -145,7 +145,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getWhenWithParams<T>)
 			{
@@ -161,7 +161,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getSubjectWithParams<T>)
 			{
@@ -177,7 +177,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIsNowWithParams<T>)
 			{
@@ -193,7 +193,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getForceErrorWithParams<T>)
 			{
@@ -209,7 +209,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentHas::beginSelectionSet<T>)
 			{
@@ -217,7 +217,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentHas::endSelectionSet<T>)
 			{
@@ -253,7 +253,7 @@ private:
 
 public:
 	template <class T>
-	inline Appointment(std::shared_ptr<T> pimpl) noexcept
+	Appointment(std::shared_ptr<T> pimpl) noexcept
 		: Appointment { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/CompleteTaskPayloadObject.h
+++ b/samples/today/nointrospection/CompleteTaskPayloadObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getClientMutationIdWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline CompleteTaskPayload(std::shared_ptr<T> pimpl) noexcept
+	CompleteTaskPayload(std::shared_ptr<T> pimpl) noexcept
 		: CompleteTaskPayload { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/ExpensiveObject.h
+++ b/samples/today/nointrospection/ExpensiveObject.h
@@ -61,12 +61,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::getOrderWithParams<T>)
 			{
@@ -82,7 +82,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::beginSelectionSet<T>)
 			{
@@ -90,7 +90,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::endSelectionSet<T>)
 			{
@@ -114,7 +114,7 @@ private:
 
 public:
 	template <class T>
-	inline Expensive(std::shared_ptr<T> pimpl) noexcept
+	Expensive(std::shared_ptr<T> pimpl) noexcept
 		: Expensive { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/FolderConnectionObject.h
+++ b/samples/today/nointrospection/FolderConnectionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getEdgesWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline FolderConnection(std::shared_ptr<T> pimpl) noexcept
+	FolderConnection(std::shared_ptr<T> pimpl) noexcept
 		: FolderConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/FolderEdgeObject.h
+++ b/samples/today/nointrospection/FolderEdgeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getCursorWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline FolderEdge(std::shared_ptr<T> pimpl) noexcept
+	FolderEdge(std::shared_ptr<T> pimpl) noexcept
 		: FolderEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/FolderObject.h
+++ b/samples/today/nointrospection/FolderObject.h
@@ -96,12 +96,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getNameWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getUnreadCountWithParams<T>)
 			{
@@ -149,7 +149,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderHas::beginSelectionSet<T>)
 			{
@@ -157,7 +157,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderHas::endSelectionSet<T>)
 			{
@@ -193,7 +193,7 @@ private:
 
 public:
 	template <class T>
-	inline Folder(std::shared_ptr<T> pimpl) noexcept
+	Folder(std::shared_ptr<T> pimpl) noexcept
 		: Folder { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/MutationObject.h
+++ b/samples/today/nointrospection/MutationObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
 		{
 			if constexpr (methods::MutationHas::applyCompleteTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
+		[[nodiscard]] service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
 		{
 			if constexpr (methods::MutationHas::applySetFloatWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline Mutation(std::shared_ptr<T> pimpl) noexcept
+	Mutation(std::shared_ptr<T> pimpl) noexcept
 		: Mutation { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/NestedTypeObject.h
+++ b/samples/today/nointrospection/NestedTypeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getDepthWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getNestedWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline NestedType(std::shared_ptr<T> pimpl) noexcept
+	NestedType(std::shared_ptr<T> pimpl) noexcept
 		: NestedType { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/NodeObject.h
+++ b/samples/today/nointrospection/NodeObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	inline Node(std::shared_ptr<T> pimpl) noexcept
+	Node(std::shared_ptr<T> pimpl) noexcept
 		: Node { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Node>(), "Node is not implemented");

--- a/samples/today/nointrospection/PageInfoObject.h
+++ b/samples/today/nointrospection/PageInfoObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasNextPageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasPreviousPageWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::PageInfoHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::PageInfoHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline PageInfo(std::shared_ptr<T> pimpl) noexcept
+	PageInfo(std::shared_ptr<T> pimpl) noexcept
 		: PageInfo { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/QueryObject.h
+++ b/samples/today/nointrospection/QueryObject.h
@@ -229,12 +229,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getNodeWithParams<T>)
 			{
@@ -250,7 +250,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsWithParams<T>)
 			{
@@ -266,7 +266,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksWithParams<T>)
 			{
@@ -282,7 +282,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsWithParams<T>)
 			{
@@ -298,7 +298,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsByIdWithParams<T>)
 			{
@@ -314,7 +314,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksByIdWithParams<T>)
 			{
@@ -330,7 +330,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsByIdWithParams<T>)
 			{
@@ -346,7 +346,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getNestedWithParams<T>)
 			{
@@ -362,7 +362,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getUnimplementedWithParams<T>)
 			{
@@ -378,7 +378,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getExpensiveWithParams<T>)
 			{
@@ -394,7 +394,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getTestTaskStateWithParams<T>)
 			{
@@ -410,7 +410,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAnyTypeWithParams<T>)
 			{
@@ -426,7 +426,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getDefaultWithParams<T>)
 			{
@@ -442,7 +442,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::beginSelectionSet<T>)
 			{
@@ -450,7 +450,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::endSelectionSet<T>)
 			{
@@ -474,7 +474,7 @@ private:
 
 public:
 	template <class T>
-	inline Query(std::shared_ptr<T> pimpl) noexcept
+	Query(std::shared_ptr<T> pimpl) noexcept
 		: Query { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/SubscriptionObject.h
+++ b/samples/today/nointrospection/SubscriptionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNextAppointmentChangeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNodeChangeWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline Subscription(std::shared_ptr<T> pimpl) noexcept
+	Subscription(std::shared_ptr<T> pimpl) noexcept
 		: Subscription { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/TaskConnectionObject.h
+++ b/samples/today/nointrospection/TaskConnectionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getEdgesWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline TaskConnection(std::shared_ptr<T> pimpl) noexcept
+	TaskConnection(std::shared_ptr<T> pimpl) noexcept
 		: TaskConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/TaskEdgeObject.h
+++ b/samples/today/nointrospection/TaskEdgeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getCursorWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline TaskEdge(std::shared_ptr<T> pimpl) noexcept
+	TaskEdge(std::shared_ptr<T> pimpl) noexcept
 		: TaskEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/TaskObject.h
+++ b/samples/today/nointrospection/TaskObject.h
@@ -96,12 +96,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getTitleWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIsCompleteWithParams<T>)
 			{
@@ -149,7 +149,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskHas::beginSelectionSet<T>)
 			{
@@ -157,7 +157,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskHas::endSelectionSet<T>)
 			{
@@ -193,7 +193,7 @@ private:
 
 public:
 	template <class T>
-	inline Task(std::shared_ptr<T> pimpl) noexcept
+	Task(std::shared_ptr<T> pimpl) noexcept
 		: Task { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/nointrospection/UnionTypeObject.h
+++ b/samples/today/nointrospection/UnionTypeObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	inline UnionType(std::shared_ptr<T> pimpl) noexcept
+	UnionType(std::shared_ptr<T> pimpl) noexcept
 		: UnionType { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<UnionType>(), "UnionType is not implemented");

--- a/samples/today/schema/AppointmentConnectionObject.h
+++ b/samples/today/schema/AppointmentConnectionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::getEdgesWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentConnectionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline AppointmentConnection(std::shared_ptr<T> pimpl) noexcept
+	AppointmentConnection(std::shared_ptr<T> pimpl) noexcept
 		: AppointmentConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/AppointmentEdgeObject.h
+++ b/samples/today/schema/AppointmentEdgeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::getCursorWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentEdgeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline AppointmentEdge(std::shared_ptr<T> pimpl) noexcept
+	AppointmentEdge(std::shared_ptr<T> pimpl) noexcept
 		: AppointmentEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/AppointmentObject.h
+++ b/samples/today/schema/AppointmentObject.h
@@ -124,12 +124,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIdWithParams<T>)
 			{
@@ -145,7 +145,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getWhenWithParams<T>)
 			{
@@ -161,7 +161,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getSubjectWithParams<T>)
 			{
@@ -177,7 +177,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getIsNowWithParams<T>)
 			{
@@ -193,7 +193,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AppointmentHas::getForceErrorWithParams<T>)
 			{
@@ -209,7 +209,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentHas::beginSelectionSet<T>)
 			{
@@ -217,7 +217,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AppointmentHas::endSelectionSet<T>)
 			{
@@ -253,7 +253,7 @@ private:
 
 public:
 	template <class T>
-	inline Appointment(std::shared_ptr<T> pimpl) noexcept
+	Appointment(std::shared_ptr<T> pimpl) noexcept
 		: Appointment { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/CompleteTaskPayloadObject.h
+++ b/samples/today/schema/CompleteTaskPayloadObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getClientMutationIdWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline CompleteTaskPayload(std::shared_ptr<T> pimpl) noexcept
+	CompleteTaskPayload(std::shared_ptr<T> pimpl) noexcept
 		: CompleteTaskPayload { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/ExpensiveObject.h
+++ b/samples/today/schema/ExpensiveObject.h
@@ -61,12 +61,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::getOrderWithParams<T>)
 			{
@@ -82,7 +82,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::beginSelectionSet<T>)
 			{
@@ -90,7 +90,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ExpensiveHas::endSelectionSet<T>)
 			{
@@ -114,7 +114,7 @@ private:
 
 public:
 	template <class T>
-	inline Expensive(std::shared_ptr<T> pimpl) noexcept
+	Expensive(std::shared_ptr<T> pimpl) noexcept
 		: Expensive { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/FolderConnectionObject.h
+++ b/samples/today/schema/FolderConnectionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::getEdgesWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderConnectionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline FolderConnection(std::shared_ptr<T> pimpl) noexcept
+	FolderConnection(std::shared_ptr<T> pimpl) noexcept
 		: FolderConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/FolderEdgeObject.h
+++ b/samples/today/schema/FolderEdgeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::getCursorWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderEdgeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline FolderEdge(std::shared_ptr<T> pimpl) noexcept
+	FolderEdge(std::shared_ptr<T> pimpl) noexcept
 		: FolderEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/FolderObject.h
+++ b/samples/today/schema/FolderObject.h
@@ -96,12 +96,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getNameWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::FolderHas::getUnreadCountWithParams<T>)
 			{
@@ -149,7 +149,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderHas::beginSelectionSet<T>)
 			{
@@ -157,7 +157,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::FolderHas::endSelectionSet<T>)
 			{
@@ -193,7 +193,7 @@ private:
 
 public:
 	template <class T>
-	inline Folder(std::shared_ptr<T> pimpl) noexcept
+	Folder(std::shared_ptr<T> pimpl) noexcept
 		: Folder { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/MutationObject.h
+++ b/samples/today/schema/MutationObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const final
 		{
 			if constexpr (methods::MutationHas::applyCompleteTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
+		[[nodiscard]] service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const final
 		{
 			if constexpr (methods::MutationHas::applySetFloatWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline Mutation(std::shared_ptr<T> pimpl) noexcept
+	Mutation(std::shared_ptr<T> pimpl) noexcept
 		: Mutation { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/NestedTypeObject.h
+++ b/samples/today/schema/NestedTypeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getDepthWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::getNestedWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::NestedTypeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline NestedType(std::shared_ptr<T> pimpl) noexcept
+	NestedType(std::shared_ptr<T> pimpl) noexcept
 		: NestedType { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/NodeObject.h
+++ b/samples/today/schema/NodeObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	inline Node(std::shared_ptr<T> pimpl) noexcept
+	Node(std::shared_ptr<T> pimpl) noexcept
 		: Node { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Node>(), "Node is not implemented");

--- a/samples/today/schema/PageInfoObject.h
+++ b/samples/today/schema/PageInfoObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasNextPageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::PageInfoHas::getHasPreviousPageWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::PageInfoHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::PageInfoHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline PageInfo(std::shared_ptr<T> pimpl) noexcept
+	PageInfo(std::shared_ptr<T> pimpl) noexcept
 		: PageInfo { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/QueryObject.h
+++ b/samples/today/schema/QueryObject.h
@@ -233,12 +233,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::QueryHas::getNodeWithParams<T>)
 			{
@@ -254,7 +254,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsWithParams<T>)
 			{
@@ -270,7 +270,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksWithParams<T>)
 			{
@@ -286,7 +286,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsWithParams<T>)
 			{
@@ -302,7 +302,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAppointmentsByIdWithParams<T>)
 			{
@@ -318,7 +318,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getTasksByIdWithParams<T>)
 			{
@@ -334,7 +334,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsByIdWithParams<T>)
 			{
@@ -350,7 +350,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getNestedWithParams<T>)
 			{
@@ -366,7 +366,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getUnimplementedWithParams<T>)
 			{
@@ -382,7 +382,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getExpensiveWithParams<T>)
 			{
@@ -398,7 +398,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getTestTaskStateWithParams<T>)
 			{
@@ -414,7 +414,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const final
 		{
 			if constexpr (methods::QueryHas::getAnyTypeWithParams<T>)
 			{
@@ -430,7 +430,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getDefaultWithParams<T>)
 			{
@@ -446,7 +446,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::beginSelectionSet<T>)
 			{
@@ -454,7 +454,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::endSelectionSet<T>)
 			{
@@ -478,7 +478,7 @@ private:
 
 public:
 	template <class T>
-	inline Query(std::shared_ptr<T> pimpl) noexcept
+	Query(std::shared_ptr<T> pimpl) noexcept
 		: Query { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/SubscriptionObject.h
+++ b/samples/today/schema/SubscriptionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNextAppointmentChangeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNodeChangeWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline Subscription(std::shared_ptr<T> pimpl) noexcept
+	Subscription(std::shared_ptr<T> pimpl) noexcept
 		: Subscription { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/TaskConnectionObject.h
+++ b/samples/today/schema/TaskConnectionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::getEdgesWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskConnectionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline TaskConnection(std::shared_ptr<T> pimpl) noexcept
+	TaskConnection(std::shared_ptr<T> pimpl) noexcept
 		: TaskConnection { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/TaskEdgeObject.h
+++ b/samples/today/schema/TaskEdgeObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::getCursorWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskEdgeHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline TaskEdge(std::shared_ptr<T> pimpl) noexcept
+	TaskEdge(std::shared_ptr<T> pimpl) noexcept
 		: TaskEdge { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/TaskObject.h
+++ b/samples/today/schema/TaskObject.h
@@ -96,12 +96,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getTitleWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::TaskHas::getIsCompleteWithParams<T>)
 			{
@@ -149,7 +149,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskHas::beginSelectionSet<T>)
 			{
@@ -157,7 +157,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::TaskHas::endSelectionSet<T>)
 			{
@@ -193,7 +193,7 @@ private:
 
 public:
 	template <class T>
-	inline Task(std::shared_ptr<T> pimpl) noexcept
+	Task(std::shared_ptr<T> pimpl) noexcept
 		: Task { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/today/schema/UnionTypeObject.h
+++ b/samples/today/schema/UnionTypeObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	inline UnionType(std::shared_ptr<T> pimpl) noexcept
+	UnionType(std::shared_ptr<T> pimpl) noexcept
 		: UnionType { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<UnionType>(), "UnionType is not implemented");

--- a/samples/validation/schema/AlienObject.h
+++ b/samples/validation/schema/AlienObject.h
@@ -82,12 +82,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AlienHas::getNameWithParams<T>)
 			{
@@ -103,7 +103,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::AlienHas::getHomePlanetWithParams<T>)
 			{
@@ -119,7 +119,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AlienHas::beginSelectionSet<T>)
 			{
@@ -127,7 +127,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::AlienHas::endSelectionSet<T>)
 			{
@@ -163,7 +163,7 @@ private:
 
 public:
 	template <class T>
-	inline Alien(std::shared_ptr<T> pimpl) noexcept
+	Alien(std::shared_ptr<T> pimpl) noexcept
 		: Alien { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/ArgumentsObject.h
+++ b/samples/validation/schema/ArgumentsObject.h
@@ -159,12 +159,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const final
+		[[nodiscard]] service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getMultipleReqsWithParams<T>)
 			{
@@ -180,7 +180,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getBooleanArgFieldWithParams<T>)
 			{
@@ -196,7 +196,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getFloatArgFieldWithParams<T>)
 			{
@@ -212,7 +212,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getIntArgFieldWithParams<T>)
 			{
@@ -228,7 +228,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getNonNullBooleanArgFieldWithParams<T>)
 			{
@@ -244,7 +244,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getNonNullBooleanListFieldWithParams<T>)
 			{
@@ -260,7 +260,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getBooleanListArgFieldWithParams<T>)
 			{
@@ -276,7 +276,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const final
 		{
 			if constexpr (methods::ArgumentsHas::getOptionalNonNullBooleanArgFieldWithParams<T>)
 			{
@@ -292,7 +292,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ArgumentsHas::beginSelectionSet<T>)
 			{
@@ -300,7 +300,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::ArgumentsHas::endSelectionSet<T>)
 			{
@@ -324,7 +324,7 @@ private:
 
 public:
 	template <class T>
-	inline Arguments(std::shared_ptr<T> pimpl) noexcept
+	Arguments(std::shared_ptr<T> pimpl) noexcept
 		: Arguments { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/CatObject.h
+++ b/samples/validation/schema/CatObject.h
@@ -110,12 +110,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CatHas::getNameWithParams<T>)
 			{
@@ -131,7 +131,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CatHas::getNicknameWithParams<T>)
 			{
@@ -147,7 +147,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const final
 		{
 			if constexpr (methods::CatHas::getDoesKnowCommandWithParams<T>)
 			{
@@ -163,7 +163,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::CatHas::getMeowVolumeWithParams<T>)
 			{
@@ -179,7 +179,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::CatHas::beginSelectionSet<T>)
 			{
@@ -187,7 +187,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::CatHas::endSelectionSet<T>)
 			{
@@ -223,7 +223,7 @@ private:
 
 public:
 	template <class T>
-	inline Cat(std::shared_ptr<T> pimpl) noexcept
+	Cat(std::shared_ptr<T> pimpl) noexcept
 		: Cat { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/CatOrDogObject.h
+++ b/samples/validation/schema/CatOrDogObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	inline CatOrDog(std::shared_ptr<T> pimpl) noexcept
+	CatOrDog(std::shared_ptr<T> pimpl) noexcept
 		: CatOrDog { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<CatOrDog>(), "CatOrDog is not implemented");

--- a/samples/validation/schema/DogObject.h
+++ b/samples/validation/schema/DogObject.h
@@ -138,12 +138,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getNameWithParams<T>)
 			{
@@ -159,7 +159,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getNicknameWithParams<T>)
 			{
@@ -175,7 +175,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getBarkVolumeWithParams<T>)
 			{
@@ -191,7 +191,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const final
 		{
 			if constexpr (methods::DogHas::getDoesKnowCommandWithParams<T>)
 			{
@@ -207,7 +207,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const final
 		{
 			if constexpr (methods::DogHas::getIsHousetrainedWithParams<T>)
 			{
@@ -223,7 +223,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::DogHas::getOwnerWithParams<T>)
 			{
@@ -239,7 +239,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::DogHas::beginSelectionSet<T>)
 			{
@@ -247,7 +247,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::DogHas::endSelectionSet<T>)
 			{
@@ -284,7 +284,7 @@ private:
 
 public:
 	template <class T>
-	inline Dog(std::shared_ptr<T> pimpl) noexcept
+	Dog(std::shared_ptr<T> pimpl) noexcept
 		: Dog { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/DogOrHumanObject.h
+++ b/samples/validation/schema/DogOrHumanObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	inline DogOrHuman(std::shared_ptr<T> pimpl) noexcept
+	DogOrHuman(std::shared_ptr<T> pimpl) noexcept
 		: DogOrHuman { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<DogOrHuman>(), "DogOrHuman is not implemented");

--- a/samples/validation/schema/HumanObject.h
+++ b/samples/validation/schema/HumanObject.h
@@ -82,12 +82,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getNameWithParams<T>)
 			{
@@ -103,7 +103,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::HumanHas::getPetsWithParams<T>)
 			{
@@ -119,7 +119,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::HumanHas::beginSelectionSet<T>)
 			{
@@ -127,7 +127,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::HumanHas::endSelectionSet<T>)
 			{
@@ -164,7 +164,7 @@ private:
 
 public:
 	template <class T>
-	inline Human(std::shared_ptr<T> pimpl) noexcept
+	Human(std::shared_ptr<T> pimpl) noexcept
 		: Human { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/HumanOrAlienObject.h
+++ b/samples/validation/schema/HumanOrAlienObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	inline HumanOrAlien(std::shared_ptr<T> pimpl) noexcept
+	HumanOrAlien(std::shared_ptr<T> pimpl) noexcept
 		: HumanOrAlien { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<HumanOrAlien>(), "HumanOrAlien is not implemented");

--- a/samples/validation/schema/MessageObject.h
+++ b/samples/validation/schema/MessageObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MessageHas::getBodyWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MessageHas::getSenderWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MessageHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MessageHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline Message(std::shared_ptr<T> pimpl) noexcept
+	Message(std::shared_ptr<T> pimpl) noexcept
 		: Message { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/MutateDogResultObject.h
+++ b/samples/validation/schema/MutateDogResultObject.h
@@ -61,12 +61,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MutateDogResultHas::getIdWithParams<T>)
 			{
@@ -82,7 +82,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutateDogResultHas::beginSelectionSet<T>)
 			{
@@ -90,7 +90,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutateDogResultHas::endSelectionSet<T>)
 			{
@@ -114,7 +114,7 @@ private:
 
 public:
 	template <class T>
-	inline MutateDogResult(std::shared_ptr<T> pimpl) noexcept
+	MutateDogResult(std::shared_ptr<T> pimpl) noexcept
 		: MutateDogResult { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/MutationObject.h
+++ b/samples/validation/schema/MutationObject.h
@@ -61,12 +61,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::MutationHas::applyMutateDogWithParams<T>)
 			{
@@ -82,7 +82,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::beginSelectionSet<T>)
 			{
@@ -90,7 +90,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::MutationHas::endSelectionSet<T>)
 			{
@@ -114,7 +114,7 @@ private:
 
 public:
 	template <class T>
-	inline Mutation(std::shared_ptr<T> pimpl) noexcept
+	Mutation(std::shared_ptr<T> pimpl) noexcept
 		: Mutation { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/NodeObject.h
+++ b/samples/validation/schema/NodeObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	inline Node(std::shared_ptr<T> pimpl) noexcept
+	Node(std::shared_ptr<T> pimpl) noexcept
 		: Node { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Node>(), "Node is not implemented");

--- a/samples/validation/schema/PetObject.h
+++ b/samples/validation/schema/PetObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	inline Pet(std::shared_ptr<T> pimpl) noexcept
+	Pet(std::shared_ptr<T> pimpl) noexcept
 		: Pet { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Pet>(), "Pet is not implemented");

--- a/samples/validation/schema/QueryObject.h
+++ b/samples/validation/schema/QueryObject.h
@@ -159,12 +159,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getDogWithParams<T>)
 			{
@@ -180,7 +180,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getHumanWithParams<T>)
 			{
@@ -196,7 +196,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getPetWithParams<T>)
 			{
@@ -212,7 +212,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getCatOrDogWithParams<T>)
 			{
@@ -228,7 +228,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getArgumentsWithParams<T>)
 			{
@@ -244,7 +244,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::QueryHas::getResourceWithParams<T>)
 			{
@@ -260,7 +260,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::unique_ptr<ComplexInput>&& complexArg) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::unique_ptr<ComplexInput>&& complexArg) const final
 		{
 			if constexpr (methods::QueryHas::getFindDogWithParams<T>)
 			{
@@ -276,7 +276,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const final
 		{
 			if constexpr (methods::QueryHas::getBooleanListWithParams<T>)
 			{
@@ -292,7 +292,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::beginSelectionSet<T>)
 			{
@@ -300,7 +300,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::QueryHas::endSelectionSet<T>)
 			{
@@ -324,7 +324,7 @@ private:
 
 public:
 	template <class T>
-	inline Query(std::shared_ptr<T> pimpl) noexcept
+	Query(std::shared_ptr<T> pimpl) noexcept
 		: Query { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/samples/validation/schema/ResourceObject.h
+++ b/samples/validation/schema/ResourceObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	inline Resource(std::shared_ptr<T> pimpl) noexcept
+	Resource(std::shared_ptr<T> pimpl) noexcept
 		: Resource { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Resource>(), "Resource is not implemented");

--- a/samples/validation/schema/SentientObject.h
+++ b/samples/validation/schema/SentientObject.h
@@ -31,27 +31,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -69,7 +69,7 @@ private:
 
 public:
 	template <class T>
-	inline Sentient(std::shared_ptr<T> pimpl) noexcept
+	Sentient(std::shared_ptr<T> pimpl) noexcept
 		: Sentient { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 		static_assert(T::template implements<Sentient>(), "Sentient is not implemented");

--- a/samples/validation/schema/SubscriptionObject.h
+++ b/samples/validation/schema/SubscriptionObject.h
@@ -75,12 +75,12 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getNewMessageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const final
+		[[nodiscard]] service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::getDisallowedSecondRootFieldWithParams<T>)
 			{
@@ -112,7 +112,7 @@ private:
 			}
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::beginSelectionSet<T>)
 			{
@@ -120,7 +120,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::SubscriptionHas::endSelectionSet<T>)
 			{
@@ -144,7 +144,7 @@ private:
 
 public:
 	template <class T>
-	inline Subscription(std::shared_ptr<T> pimpl) noexcept
+	Subscription(std::shared_ptr<T> pimpl) noexcept
 		: Subscription { std::unique_ptr<const Concept> { std::make_unique<Model<T>>(std::move(pimpl)) } }
 	{
 	}

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -670,27 +670,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::TypeNames getTypeNames() const noexcept final
+		[[nodiscard]] service::TypeNames getTypeNames() const noexcept final
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] inline service::ResolverMap getResolvers() const noexcept final
+		[[nodiscard]] service::ResolverMap getResolvers() const noexcept final
 		{
 			return _pimpl->getResolvers();
 		}
 
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->beginSelectionSet(params);
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			_pimpl->endSelectionSet(params);
 		}
@@ -709,7 +709,7 @@ private:
 
 public:
 	template <class T>
-	inline )cpp"
+	)cpp"
 		<< cppType << R"cpp((std::shared_ptr<T> pimpl) noexcept
 		: )cpp"
 		<< cppType
@@ -898,7 +898,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -909,7 +909,7 @@ private:
 		const auto accessorName = SchemaLoader::getOutputCppAccessor(outputField);
 
 		headerFile << R"cpp(
-		[[nodiscard]] inline )cpp"
+		[[nodiscard]] )cpp"
 				   << _loader.getOutputCppType(outputField) << R"cpp( )cpp" << accessorName
 				   << R"cpp(()cpp";
 
@@ -1028,7 +1028,7 @@ private:
 	if (!_loader.isIntrospection())
 	{
 		headerFile << R"cpp(
-		inline void beginSelectionSet(const service::SelectionSetParams& params) const final
+		void beginSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::)cpp"
 				   << objectType.cppType << R"cpp(Has::beginSelectionSet<T>)
@@ -1037,7 +1037,7 @@ private:
 			}
 		}
 
-		inline void endSelectionSet(const service::SelectionSetParams& params) const final
+		void endSelectionSet(const service::SelectionSetParams& params) const final
 		{
 			if constexpr (methods::)cpp"
 				   << objectType.cppType << R"cpp(Has::endSelectionSet<T>)
@@ -1133,7 +1133,7 @@ public:
 
 public:
 	template <class T>
-	inline )cpp"
+	)cpp"
 			<< objectType.cppType << R"cpp((std::shared_ptr<T> pimpl) noexcept
 		: )cpp"
 			<< objectType.cppType

--- a/src/introspection/DirectiveObject.h
+++ b/src/introspection/DirectiveObject.h
@@ -39,32 +39,32 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
+		[[nodiscard]] service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const final
 		{
 			return { _pimpl->getLocations() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getIsRepeatable() const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsRepeatable() const final
 		{
 			return { _pimpl->getIsRepeatable() };
 		}

--- a/src/introspection/EnumValueObject.h
+++ b/src/introspection/EnumValueObject.h
@@ -37,27 +37,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getIsDeprecated() const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}

--- a/src/introspection/FieldObject.h
+++ b/src/introspection/FieldObject.h
@@ -41,37 +41,37 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const final
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<bool> getIsDeprecated() const final
+		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const final
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const final
 		{
 			return { _pimpl->getDeprecationReason() };
 		}

--- a/src/introspection/InputValueObject.h
+++ b/src/introspection/InputValueObject.h
@@ -37,27 +37,27 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::string> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::string> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const final
 		{
 			return { _pimpl->getType() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const final
 		{
 			return { _pimpl->getDefaultValue() };
 		}

--- a/src/introspection/SchemaObject.h
+++ b/src/introspection/SchemaObject.h
@@ -41,37 +41,37 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const final
 		{
 			return { _pimpl->getTypes() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const final
 		{
 			return { _pimpl->getQueryType() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const final
 		{
 			return { _pimpl->getMutationType() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const final
 		{
 			return { _pimpl->getSubscriptionType() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
+		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const final
 		{
 			return { _pimpl->getDirectives() };
 		}

--- a/src/introspection/TypeObject.h
+++ b/src/introspection/TypeObject.h
@@ -49,57 +49,57 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		inline Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T>&& pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<TypeKind> getKind() const final
+		[[nodiscard]] service::AwaitableScalar<TypeKind> getKind() const final
 		{
 			return { _pimpl->getKind() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getName() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName() const final
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getDescription() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const final
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getFields(std::move(includeDeprecatedArg)) };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const final
 		{
 			return { _pimpl->getInterfaces() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const final
 		{
 			return { _pimpl->getPossibleTypes() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const final
 		{
 			return { _pimpl->getEnumValues(std::move(includeDeprecatedArg)) };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
+		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const final
 		{
 			return { _pimpl->getInputFields() };
 		}
 
-		[[nodiscard]] inline service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
+		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getOfType() const final
 		{
 			return { _pimpl->getOfType() };
 		}
 
-		[[nodiscard]] inline service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const final
 		{
 			return { _pimpl->getSpecifiedByURL() };
 		}


### PR DESCRIPTION
As part of the fix for #255, I tried adding `inline` to any function or method that was defined in a header. However, that's not what ultimately fixed it, as far as I can tell. I think moving the template methods of the `Modified...` template structs to an anonymous namespace is what deduplicated their symbols and let `-flto=auto` work again in GCC 12.

I've tested with and without this in GCC 12 and it looks like it does not change the size of the binary or the benchmark speed. It's just removing some redundant and potentially misleading `inline` specifiers, since it's implied anytime a method is defined in the body of the class/struct declaration, and it's impossible for any of the type-erased wrappers to call a virtual method on the `Model<T>` type as an inline method because the whole point of type erasure is that it doesn't know the concrete type.