### PR TITLE
Pass smart pointers by value

### DIFF
--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -392,7 +392,7 @@ private:
 	template <class T>
 	struct Model : Concept
 	{
-		Model(std::unique_ptr<T>&& pimpl)
+		Model(std::unique_ptr<T> pimpl)
 			: _pimpl { std::move(pimpl) }
 		{
 		}

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -197,7 +197,7 @@ private:
 	template <class T>
 	struct [[nodiscard]] Model : Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl)
+		Model(std::shared_ptr<T> pimpl)
 			: _pimpl { std::move(pimpl) }
 		{
 		}

--- a/include/graphqlservice/introspection/DirectiveObject.h
+++ b/include/graphqlservice/introspection/DirectiveObject.h
@@ -39,7 +39,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}

--- a/include/graphqlservice/introspection/EnumValueObject.h
+++ b/include/graphqlservice/introspection/EnumValueObject.h
@@ -37,7 +37,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}

--- a/include/graphqlservice/introspection/FieldObject.h
+++ b/include/graphqlservice/introspection/FieldObject.h
@@ -41,7 +41,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}

--- a/include/graphqlservice/introspection/InputValueObject.h
+++ b/include/graphqlservice/introspection/InputValueObject.h
@@ -37,7 +37,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}

--- a/include/graphqlservice/introspection/SchemaObject.h
+++ b/include/graphqlservice/introspection/SchemaObject.h
@@ -41,7 +41,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}

--- a/include/graphqlservice/introspection/TypeObject.h
+++ b/include/graphqlservice/introspection/TypeObject.h
@@ -49,7 +49,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}

--- a/samples/learn/schema/CharacterObject.cpp
+++ b/samples/learn/schema/CharacterObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::learn {
 namespace object {
 
-Character::Character(std::unique_ptr<const Concept>&& pimpl) noexcept
+Character::Character(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/learn/schema/CharacterObject.h
+++ b/samples/learn/schema/CharacterObject.h
@@ -31,7 +31,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -60,7 +60,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Character(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Character(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;

--- a/samples/learn/schema/DroidObject.cpp
+++ b/samples/learn/schema/DroidObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::learn {
 namespace object {
 
-Droid::Droid(std::unique_ptr<const Concept>&& pimpl) noexcept
+Droid::Droid(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/learn/schema/DroidObject.h
+++ b/samples/learn/schema/DroidObject.h
@@ -124,7 +124,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -214,7 +214,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Droid(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Droid(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Character;

--- a/samples/learn/schema/HumanObject.cpp
+++ b/samples/learn/schema/HumanObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::learn {
 namespace object {
 
-Human::Human(std::unique_ptr<const Concept>&& pimpl) noexcept
+Human::Human(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/learn/schema/HumanObject.h
+++ b/samples/learn/schema/HumanObject.h
@@ -124,7 +124,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -214,7 +214,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Human(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Human(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Character;

--- a/samples/learn/schema/MutationObject.cpp
+++ b/samples/learn/schema/MutationObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::learn {
 namespace object {
 
-Mutation::Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept
+Mutation::Mutation(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/learn/schema/MutationObject.h
+++ b/samples/learn/schema/MutationObject.h
@@ -61,7 +61,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -99,7 +99,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Mutation(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/learn/schema/QueryObject.cpp
+++ b/samples/learn/schema/QueryObject.cpp
@@ -24,7 +24,7 @@ using namespace std::literals;
 namespace graphql::learn {
 namespace object {
 
-Query::Query(std::unique_ptr<const Concept>&& pimpl) noexcept
+Query::Query(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _schema { GetSchema() }
 	, _pimpl { std::move(pimpl) }

--- a/samples/learn/schema/QueryObject.h
+++ b/samples/learn/schema/QueryObject.h
@@ -93,7 +93,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -157,7 +157,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Query(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Query(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/learn/schema/ReviewObject.cpp
+++ b/samples/learn/schema/ReviewObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::learn {
 namespace object {
 
-Review::Review(std::unique_ptr<const Concept>&& pimpl) noexcept
+Review::Review(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/learn/schema/ReviewObject.h
+++ b/samples/learn/schema/ReviewObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -126,7 +126,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Review(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Review(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/AppointmentConnectionObject.cpp
+++ b/samples/today/nointrospection/AppointmentConnectionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-AppointmentConnection::AppointmentConnection(std::unique_ptr<const Concept>&& pimpl) noexcept
+AppointmentConnection::AppointmentConnection(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/AppointmentConnectionObject.h
+++ b/samples/today/nointrospection/AppointmentConnectionObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	AppointmentConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	AppointmentConnection(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/AppointmentEdgeObject.cpp
+++ b/samples/today/nointrospection/AppointmentEdgeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-AppointmentEdge::AppointmentEdge(std::unique_ptr<const Concept>&& pimpl) noexcept
+AppointmentEdge::AppointmentEdge(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/AppointmentEdgeObject.h
+++ b/samples/today/nointrospection/AppointmentEdgeObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	AppointmentEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	AppointmentEdge(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/AppointmentObject.cpp
+++ b/samples/today/nointrospection/AppointmentObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Appointment::Appointment(std::unique_ptr<const Concept>&& pimpl) noexcept
+Appointment::Appointment(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/AppointmentObject.h
+++ b/samples/today/nointrospection/AppointmentObject.h
@@ -124,7 +124,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -229,7 +229,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Appointment(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Appointment(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Node;

--- a/samples/today/nointrospection/CompleteTaskPayloadObject.cpp
+++ b/samples/today/nointrospection/CompleteTaskPayloadObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-CompleteTaskPayload::CompleteTaskPayload(std::unique_ptr<const Concept>&& pimpl) noexcept
+CompleteTaskPayload::CompleteTaskPayload(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/CompleteTaskPayloadObject.h
+++ b/samples/today/nointrospection/CompleteTaskPayloadObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	CompleteTaskPayload(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	CompleteTaskPayload(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/ExpensiveObject.cpp
+++ b/samples/today/nointrospection/ExpensiveObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Expensive::Expensive(std::unique_ptr<const Concept>&& pimpl) noexcept
+Expensive::Expensive(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/ExpensiveObject.h
+++ b/samples/today/nointrospection/ExpensiveObject.h
@@ -61,7 +61,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -102,7 +102,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Expensive(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Expensive(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/FolderConnectionObject.cpp
+++ b/samples/today/nointrospection/FolderConnectionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-FolderConnection::FolderConnection(std::unique_ptr<const Concept>&& pimpl) noexcept
+FolderConnection::FolderConnection(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/FolderConnectionObject.h
+++ b/samples/today/nointrospection/FolderConnectionObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	FolderConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	FolderConnection(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/FolderEdgeObject.cpp
+++ b/samples/today/nointrospection/FolderEdgeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-FolderEdge::FolderEdge(std::unique_ptr<const Concept>&& pimpl) noexcept
+FolderEdge::FolderEdge(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/FolderEdgeObject.h
+++ b/samples/today/nointrospection/FolderEdgeObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	FolderEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	FolderEdge(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/FolderObject.cpp
+++ b/samples/today/nointrospection/FolderObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Folder::Folder(std::unique_ptr<const Concept>&& pimpl) noexcept
+Folder::Folder(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/FolderObject.h
+++ b/samples/today/nointrospection/FolderObject.h
@@ -96,7 +96,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -169,7 +169,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Folder(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Folder(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Node;

--- a/samples/today/nointrospection/MutationObject.cpp
+++ b/samples/today/nointrospection/MutationObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Mutation::Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept
+Mutation::Mutation(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/MutationObject.h
+++ b/samples/today/nointrospection/MutationObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Mutation(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/NestedTypeObject.cpp
+++ b/samples/today/nointrospection/NestedTypeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-NestedType::NestedType(std::unique_ptr<const Concept>&& pimpl) noexcept
+NestedType::NestedType(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/NestedTypeObject.h
+++ b/samples/today/nointrospection/NestedTypeObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	NestedType(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	NestedType(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/NodeObject.cpp
+++ b/samples/today/nointrospection/NodeObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Node::Node(std::unique_ptr<const Concept>&& pimpl) noexcept
+Node::Node(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/NodeObject.h
+++ b/samples/today/nointrospection/NodeObject.h
@@ -31,7 +31,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -60,7 +60,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Node(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Node(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;

--- a/samples/today/nointrospection/PageInfoObject.cpp
+++ b/samples/today/nointrospection/PageInfoObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-PageInfo::PageInfo(std::unique_ptr<const Concept>&& pimpl) noexcept
+PageInfo::PageInfo(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/PageInfoObject.h
+++ b/samples/today/nointrospection/PageInfoObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	PageInfo(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	PageInfo(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/QueryObject.cpp
+++ b/samples/today/nointrospection/QueryObject.cpp
@@ -30,7 +30,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Query::Query(std::unique_ptr<const Concept>&& pimpl) noexcept
+Query::Query(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/QueryObject.h
+++ b/samples/today/nointrospection/QueryObject.h
@@ -229,7 +229,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -462,7 +462,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Query(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Query(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/SubscriptionObject.cpp
+++ b/samples/today/nointrospection/SubscriptionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Subscription::Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept
+Subscription::Subscription(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/SubscriptionObject.h
+++ b/samples/today/nointrospection/SubscriptionObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Subscription(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/TaskConnectionObject.cpp
+++ b/samples/today/nointrospection/TaskConnectionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-TaskConnection::TaskConnection(std::unique_ptr<const Concept>&& pimpl) noexcept
+TaskConnection::TaskConnection(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/TaskConnectionObject.h
+++ b/samples/today/nointrospection/TaskConnectionObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	TaskConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	TaskConnection(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/TaskEdgeObject.cpp
+++ b/samples/today/nointrospection/TaskEdgeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-TaskEdge::TaskEdge(std::unique_ptr<const Concept>&& pimpl) noexcept
+TaskEdge::TaskEdge(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/TaskEdgeObject.h
+++ b/samples/today/nointrospection/TaskEdgeObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	TaskEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	TaskEdge(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/nointrospection/TaskObject.cpp
+++ b/samples/today/nointrospection/TaskObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Task::Task(std::unique_ptr<const Concept>&& pimpl) noexcept
+Task::Task(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/TaskObject.h
+++ b/samples/today/nointrospection/TaskObject.h
@@ -96,7 +96,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -169,7 +169,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Task(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Task(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Node;

--- a/samples/today/nointrospection/UnionTypeObject.cpp
+++ b/samples/today/nointrospection/UnionTypeObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-UnionType::UnionType(std::unique_ptr<const Concept>&& pimpl) noexcept
+UnionType::UnionType(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/nointrospection/UnionTypeObject.h
+++ b/samples/today/nointrospection/UnionTypeObject.h
@@ -31,7 +31,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -60,7 +60,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	UnionType(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	UnionType(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;

--- a/samples/today/schema/AppointmentConnectionObject.cpp
+++ b/samples/today/schema/AppointmentConnectionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-AppointmentConnection::AppointmentConnection(std::unique_ptr<const Concept>&& pimpl) noexcept
+AppointmentConnection::AppointmentConnection(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/AppointmentConnectionObject.h
+++ b/samples/today/schema/AppointmentConnectionObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	AppointmentConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	AppointmentConnection(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/schema/AppointmentEdgeObject.cpp
+++ b/samples/today/schema/AppointmentEdgeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-AppointmentEdge::AppointmentEdge(std::unique_ptr<const Concept>&& pimpl) noexcept
+AppointmentEdge::AppointmentEdge(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/AppointmentEdgeObject.h
+++ b/samples/today/schema/AppointmentEdgeObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	AppointmentEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	AppointmentEdge(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/schema/AppointmentObject.cpp
+++ b/samples/today/schema/AppointmentObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Appointment::Appointment(std::unique_ptr<const Concept>&& pimpl) noexcept
+Appointment::Appointment(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/AppointmentObject.h
+++ b/samples/today/schema/AppointmentObject.h
@@ -124,7 +124,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -229,7 +229,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Appointment(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Appointment(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Node;

--- a/samples/today/schema/CompleteTaskPayloadObject.cpp
+++ b/samples/today/schema/CompleteTaskPayloadObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-CompleteTaskPayload::CompleteTaskPayload(std::unique_ptr<const Concept>&& pimpl) noexcept
+CompleteTaskPayload::CompleteTaskPayload(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/CompleteTaskPayloadObject.h
+++ b/samples/today/schema/CompleteTaskPayloadObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	CompleteTaskPayload(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	CompleteTaskPayload(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/schema/ExpensiveObject.cpp
+++ b/samples/today/schema/ExpensiveObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Expensive::Expensive(std::unique_ptr<const Concept>&& pimpl) noexcept
+Expensive::Expensive(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/ExpensiveObject.h
+++ b/samples/today/schema/ExpensiveObject.h
@@ -61,7 +61,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -102,7 +102,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Expensive(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Expensive(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/schema/FolderConnectionObject.cpp
+++ b/samples/today/schema/FolderConnectionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-FolderConnection::FolderConnection(std::unique_ptr<const Concept>&& pimpl) noexcept
+FolderConnection::FolderConnection(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/FolderConnectionObject.h
+++ b/samples/today/schema/FolderConnectionObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	FolderConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	FolderConnection(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/schema/FolderEdgeObject.cpp
+++ b/samples/today/schema/FolderEdgeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-FolderEdge::FolderEdge(std::unique_ptr<const Concept>&& pimpl) noexcept
+FolderEdge::FolderEdge(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/FolderEdgeObject.h
+++ b/samples/today/schema/FolderEdgeObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	FolderEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	FolderEdge(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/schema/FolderObject.cpp
+++ b/samples/today/schema/FolderObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Folder::Folder(std::unique_ptr<const Concept>&& pimpl) noexcept
+Folder::Folder(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/FolderObject.h
+++ b/samples/today/schema/FolderObject.h
@@ -96,7 +96,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -169,7 +169,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Folder(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Folder(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Node;

--- a/samples/today/schema/MutationObject.cpp
+++ b/samples/today/schema/MutationObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Mutation::Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept
+Mutation::Mutation(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/MutationObject.h
+++ b/samples/today/schema/MutationObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Mutation(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/schema/NestedTypeObject.cpp
+++ b/samples/today/schema/NestedTypeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-NestedType::NestedType(std::unique_ptr<const Concept>&& pimpl) noexcept
+NestedType::NestedType(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/NestedTypeObject.h
+++ b/samples/today/schema/NestedTypeObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	NestedType(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	NestedType(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/schema/NodeObject.cpp
+++ b/samples/today/schema/NodeObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Node::Node(std::unique_ptr<const Concept>&& pimpl) noexcept
+Node::Node(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/NodeObject.h
+++ b/samples/today/schema/NodeObject.h
@@ -31,7 +31,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -60,7 +60,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Node(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Node(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;

--- a/samples/today/schema/PageInfoObject.cpp
+++ b/samples/today/schema/PageInfoObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-PageInfo::PageInfo(std::unique_ptr<const Concept>&& pimpl) noexcept
+PageInfo::PageInfo(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/PageInfoObject.h
+++ b/samples/today/schema/PageInfoObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	PageInfo(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	PageInfo(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/schema/QueryObject.cpp
+++ b/samples/today/schema/QueryObject.cpp
@@ -31,7 +31,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Query::Query(std::unique_ptr<const Concept>&& pimpl) noexcept
+Query::Query(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _schema { GetSchema() }
 	, _pimpl { std::move(pimpl) }

--- a/samples/today/schema/QueryObject.h
+++ b/samples/today/schema/QueryObject.h
@@ -233,7 +233,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -466,7 +466,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Query(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Query(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/schema/SubscriptionObject.cpp
+++ b/samples/today/schema/SubscriptionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Subscription::Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept
+Subscription::Subscription(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/SubscriptionObject.h
+++ b/samples/today/schema/SubscriptionObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Subscription(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/schema/TaskConnectionObject.cpp
+++ b/samples/today/schema/TaskConnectionObject.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-TaskConnection::TaskConnection(std::unique_ptr<const Concept>&& pimpl) noexcept
+TaskConnection::TaskConnection(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/TaskConnectionObject.h
+++ b/samples/today/schema/TaskConnectionObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	TaskConnection(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	TaskConnection(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/schema/TaskEdgeObject.cpp
+++ b/samples/today/schema/TaskEdgeObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-TaskEdge::TaskEdge(std::unique_ptr<const Concept>&& pimpl) noexcept
+TaskEdge::TaskEdge(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/TaskEdgeObject.h
+++ b/samples/today/schema/TaskEdgeObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	TaskEdge(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	TaskEdge(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/today/schema/TaskObject.cpp
+++ b/samples/today/schema/TaskObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-Task::Task(std::unique_ptr<const Concept>&& pimpl) noexcept
+Task::Task(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/TaskObject.h
+++ b/samples/today/schema/TaskObject.h
@@ -96,7 +96,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -169,7 +169,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Task(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Task(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Node;

--- a/samples/today/schema/UnionTypeObject.cpp
+++ b/samples/today/schema/UnionTypeObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::today {
 namespace object {
 
-UnionType::UnionType(std::unique_ptr<const Concept>&& pimpl) noexcept
+UnionType::UnionType(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/today/schema/UnionTypeObject.h
+++ b/samples/today/schema/UnionTypeObject.h
@@ -31,7 +31,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -60,7 +60,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	UnionType(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	UnionType(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;

--- a/samples/validation/schema/AlienObject.cpp
+++ b/samples/validation/schema/AlienObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Alien::Alien(std::unique_ptr<const Concept>&& pimpl) noexcept
+Alien::Alien(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/AlienObject.h
+++ b/samples/validation/schema/AlienObject.h
@@ -82,7 +82,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -139,7 +139,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Alien(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Alien(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Sentient;

--- a/samples/validation/schema/ArgumentsObject.cpp
+++ b/samples/validation/schema/ArgumentsObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Arguments::Arguments(std::unique_ptr<const Concept>&& pimpl) noexcept
+Arguments::Arguments(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/ArgumentsObject.h
+++ b/samples/validation/schema/ArgumentsObject.h
@@ -159,7 +159,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -312,7 +312,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Arguments(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Arguments(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/validation/schema/CatObject.cpp
+++ b/samples/validation/schema/CatObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Cat::Cat(std::unique_ptr<const Concept>&& pimpl) noexcept
+Cat::Cat(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/CatObject.h
+++ b/samples/validation/schema/CatObject.h
@@ -110,7 +110,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -199,7 +199,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Cat(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Cat(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Pet;

--- a/samples/validation/schema/CatOrDogObject.cpp
+++ b/samples/validation/schema/CatOrDogObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-CatOrDog::CatOrDog(std::unique_ptr<const Concept>&& pimpl) noexcept
+CatOrDog::CatOrDog(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/CatOrDogObject.h
+++ b/samples/validation/schema/CatOrDogObject.h
@@ -31,7 +31,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -60,7 +60,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	CatOrDog(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	CatOrDog(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;

--- a/samples/validation/schema/DogObject.cpp
+++ b/samples/validation/schema/DogObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Dog::Dog(std::unique_ptr<const Concept>&& pimpl) noexcept
+Dog::Dog(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/DogObject.h
+++ b/samples/validation/schema/DogObject.h
@@ -138,7 +138,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -259,7 +259,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Dog(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Dog(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Pet;

--- a/samples/validation/schema/DogOrHumanObject.cpp
+++ b/samples/validation/schema/DogOrHumanObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-DogOrHuman::DogOrHuman(std::unique_ptr<const Concept>&& pimpl) noexcept
+DogOrHuman::DogOrHuman(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/DogOrHumanObject.h
+++ b/samples/validation/schema/DogOrHumanObject.h
@@ -31,7 +31,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -60,7 +60,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	DogOrHuman(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	DogOrHuman(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;

--- a/samples/validation/schema/HumanObject.cpp
+++ b/samples/validation/schema/HumanObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Human::Human(std::unique_ptr<const Concept>&& pimpl) noexcept
+Human::Human(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/HumanObject.h
+++ b/samples/validation/schema/HumanObject.h
@@ -82,7 +82,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -139,7 +139,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Human(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Human(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	// Interfaces which this type implements
 	friend Sentient;

--- a/samples/validation/schema/HumanOrAlienObject.cpp
+++ b/samples/validation/schema/HumanOrAlienObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-HumanOrAlien::HumanOrAlien(std::unique_ptr<const Concept>&& pimpl) noexcept
+HumanOrAlien::HumanOrAlien(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/HumanOrAlienObject.h
+++ b/samples/validation/schema/HumanOrAlienObject.h
@@ -31,7 +31,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -60,7 +60,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	HumanOrAlien(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	HumanOrAlien(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;

--- a/samples/validation/schema/MessageObject.cpp
+++ b/samples/validation/schema/MessageObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Message::Message(std::unique_ptr<const Concept>&& pimpl) noexcept
+Message::Message(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/MessageObject.h
+++ b/samples/validation/schema/MessageObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Message(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Message(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/validation/schema/MutateDogResultObject.cpp
+++ b/samples/validation/schema/MutateDogResultObject.cpp
@@ -20,7 +20,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-MutateDogResult::MutateDogResult(std::unique_ptr<const Concept>&& pimpl) noexcept
+MutateDogResult::MutateDogResult(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/MutateDogResultObject.h
+++ b/samples/validation/schema/MutateDogResultObject.h
@@ -61,7 +61,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -102,7 +102,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	MutateDogResult(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	MutateDogResult(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/validation/schema/MutationObject.cpp
+++ b/samples/validation/schema/MutationObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Mutation::Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept
+Mutation::Mutation(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/MutationObject.h
+++ b/samples/validation/schema/MutationObject.h
@@ -61,7 +61,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -102,7 +102,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Mutation(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Mutation(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/validation/schema/NodeObject.cpp
+++ b/samples/validation/schema/NodeObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Node::Node(std::unique_ptr<const Concept>&& pimpl) noexcept
+Node::Node(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/NodeObject.h
+++ b/samples/validation/schema/NodeObject.h
@@ -31,7 +31,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -60,7 +60,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Node(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Node(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;

--- a/samples/validation/schema/PetObject.cpp
+++ b/samples/validation/schema/PetObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Pet::Pet(std::unique_ptr<const Concept>&& pimpl) noexcept
+Pet::Pet(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/PetObject.h
+++ b/samples/validation/schema/PetObject.h
@@ -31,7 +31,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -60,7 +60,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Pet(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Pet(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;

--- a/samples/validation/schema/QueryObject.cpp
+++ b/samples/validation/schema/QueryObject.cpp
@@ -26,7 +26,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Query::Query(std::unique_ptr<const Concept>&& pimpl) noexcept
+Query::Query(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/QueryObject.h
+++ b/samples/validation/schema/QueryObject.h
@@ -159,7 +159,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -312,7 +312,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Query(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Query(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/samples/validation/schema/ResourceObject.cpp
+++ b/samples/validation/schema/ResourceObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Resource::Resource(std::unique_ptr<const Concept>&& pimpl) noexcept
+Resource::Resource(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/ResourceObject.h
+++ b/samples/validation/schema/ResourceObject.h
@@ -31,7 +31,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -60,7 +60,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Resource(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Resource(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;

--- a/samples/validation/schema/SentientObject.cpp
+++ b/samples/validation/schema/SentientObject.cpp
@@ -14,7 +14,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Sentient::Sentient(std::unique_ptr<const Concept>&& pimpl) noexcept
+Sentient::Sentient(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/SentientObject.h
+++ b/samples/validation/schema/SentientObject.h
@@ -31,7 +31,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -60,7 +60,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Sentient(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Sentient(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;

--- a/samples/validation/schema/SubscriptionObject.cpp
+++ b/samples/validation/schema/SubscriptionObject.cpp
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace graphql::validation {
 namespace object {
 
-Subscription::Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept
+Subscription::Subscription(std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object{ getTypeNames(), getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {

--- a/samples/validation/schema/SubscriptionObject.h
+++ b/samples/validation/schema/SubscriptionObject.h
@@ -75,7 +75,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -132,7 +132,7 @@ private:
 		const std::shared_ptr<T> _pimpl;
 	};
 
-	Subscription(std::unique_ptr<const Concept>&& pimpl) noexcept;
+	Subscription(std::unique_ptr<const Concept> pimpl) noexcept;
 
 	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
 	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -670,7 +670,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -700,7 +700,7 @@ private:
 	};
 
 	)cpp"
-		<< cppType << R"cpp((std::unique_ptr<const Concept>&& pimpl) noexcept;
+		<< cppType << R"cpp((std::unique_ptr<const Concept> pimpl) noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const final;
 	void endSelectionSet(const service::SelectionSetParams& params) const final;
@@ -898,7 +898,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}
@@ -1075,7 +1075,7 @@ public:
 	else
 	{
 		headerFile << R"cpp(	)cpp" << objectType.cppType
-				   << R"cpp((std::unique_ptr<const Concept>&& pimpl) noexcept;
+				   << R"cpp((std::unique_ptr<const Concept> pimpl) noexcept;
 
 )cpp";
 
@@ -2096,7 +2096,7 @@ void Generator::outputInterfaceImplementation(
 	// with arguments that declare the set of types it implements and bind the fields to the
 	// resolver methods.
 	sourceFile << cppType << R"cpp(::)cpp" << cppType
-			   << R"cpp((std::unique_ptr<const Concept>&& pimpl) noexcept
+			   << R"cpp((std::unique_ptr<const Concept> pimpl) noexcept
 	: service::Object { pimpl->getTypeNames(), pimpl->getResolvers() }
 	, _pimpl { std::move(pimpl) }
 {
@@ -2175,7 +2175,7 @@ void Generator::outputObjectImplementation(
 		// with arguments that declare the set of types it implements and bind the fields to the
 		// resolver methods.
 		sourceFile << objectType.cppType << R"cpp(::)cpp" << objectType.cppType
-				   << R"cpp((std::unique_ptr<const Concept>&& pimpl))cpp";
+				   << R"cpp((std::unique_ptr<const Concept> pimpl))cpp";
 	}
 
 	sourceFile << R"cpp( noexcept

--- a/src/introspection/DirectiveObject.h
+++ b/src/introspection/DirectiveObject.h
@@ -39,7 +39,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}

--- a/src/introspection/EnumValueObject.h
+++ b/src/introspection/EnumValueObject.h
@@ -37,7 +37,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}

--- a/src/introspection/FieldObject.h
+++ b/src/introspection/FieldObject.h
@@ -41,7 +41,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}

--- a/src/introspection/InputValueObject.h
+++ b/src/introspection/InputValueObject.h
@@ -37,7 +37,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}

--- a/src/introspection/SchemaObject.h
+++ b/src/introspection/SchemaObject.h
@@ -41,7 +41,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}

--- a/src/introspection/TypeObject.h
+++ b/src/introspection/TypeObject.h
@@ -49,7 +49,7 @@ private:
 	struct [[nodiscard]] Model
 		: Concept
 	{
-		Model(std::shared_ptr<T>&& pimpl) noexcept
+		Model(std::shared_ptr<T> pimpl) noexcept
 			: _pimpl { std::move(pimpl) }
 		{
 		}


### PR DESCRIPTION
We have gotten some code smells reported by SonarQube regarding these smart pointer rvalue references,
so I thought I could maybe contribute and suggest passing these smart pointers by value instead.

Maybe there is a reason they should be rvalue references?


This is the kind of code smell we got:
https://rules.sonarsource.com/cpp/tag/confusing/RSPEC-5954