### PR TITLE
Expose a Traits struct for each client operation for easier templating

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,27 +20,18 @@ jobs:
       uses: actions/cache@v2
       id: cache-vcpkg
       with:
-        path: vcpkg/
+        path: build/vcpkg_installed/
         key: vcpkg-x64-osx
 
-    - name: Install Dependencies
-      if: ${{ !steps.cache-vcpkg.outputs.cache-hit }}
-      shell: pwsh
-      run: |
-        git clone https://github.com/microsoft/vcpkg
-        cd vcpkg
-        ./bootstrap-vcpkg.sh -allowAppleClang
-        ./vcpkg integrate install
-        ./vcpkg install boost-program-options rapidjson gtest
-
     - name: Create Build Environment
+      if: ${{ !steps.cache-vcpkg.outputs.cache-hit }}
       run: cmake -E make_directory build
 
     - name: Configure
       shell: pwsh
       working-directory: build/
       run: |
-        $vcpkgToolchain = Join-Path '../vcpkg' './scripts/buildsystems/vcpkg.cmake' -Resolve
+        $vcpkgToolchain = Join-Path $env:VCPKG_ROOT './scripts/buildsystems/vcpkg.cmake' -Resolve
         $cmakeBuildType = '${{ matrix.config }}'
 
         cmake "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" "-DCMAKE_BUILD_TYPE=$cmakeBuildType" ${{ github.workspace }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,27 +27,18 @@ jobs:
       uses: actions/cache@v2
       id: cache-vcpkg
       with:
-        path: vcpkg/
+        path: build/vcpkg_installed/
         key: vcpkg-${{ steps.set-variables.outputs.vcpkg_triplet }}
 
-    - name: Install Dependencies
-      if: ${{ !steps.cache-vcpkg.outputs.cache-hit }}
-      shell: pwsh
-      run: |
-        git clone https://github.com/microsoft/vcpkg
-        cd vcpkg
-        .\bootstrap-vcpkg.bat
-        .\vcpkg integrate install
-        .\vcpkg install boost-program-options rapidjson gtest --triplet ${{ steps.set-variables.outputs.vcpkg_triplet }}
-
     - name: Create Build Environment
+      if: ${{ !steps.cache-vcpkg.outputs.cache-hit }}
       run: cmake -E make_directory build
 
     - name: Configure
       shell: pwsh
       working-directory: build/
       run: |
-        $vcpkgToolchain = Join-Path '..\vcpkg' '.\scripts\buildsystems\vcpkg.cmake' -Resolve
+        $vcpkgToolchain = Join-Path $env:VCPKG_ROOT '.\scripts\buildsystems\vcpkg.cmake' -Resolve
         $vcpkgTriplet = '${{ steps.set-variables.outputs.vcpkg_triplet }}'
         $cmakeSharedLibs = $(if ('${{ matrix.libs }}' -eq 'shared') { 'ON' } else { 'OFF' })
         $msbuildArch = $(if ('${{ matrix.arch }}' -eq 'x64') { 'X64' } else { 'Win32' })

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,32 @@ if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   endif()
 endif()
 
+option(GRAPHQL_BUILD_SCHEMAGEN "Build the schemagen tool." ON)
+option(GRAPHQL_BUILD_CLIENTGEN "Build the clientgen tool." ON)
+option(GRAPHQL_BUILD_TESTS "Build the tests and sample schema library." ON)
+
+if(GRAPHQL_BUILD_SCHEMAGEN)
+  list(APPEND VCPKG_MANIFEST_FEATURES "schemagen")
+endif()
+
+if(GRAPHQL_BUILD_CLIENTGEN)
+  list(APPEND VCPKG_MANIFEST_FEATURES "clientgen")
+endif()
+
+if(GRAPHQL_BUILD_TESTS)
+  list(APPEND VCPKG_MANIFEST_FEATURES "tests")
+endif()
+
+if(GRAPHQL_BUILD_SCHEMAGEN AND GRAPHQL_BUILD_CLIENTGEN)
+  option(GRAPHQL_UPDATE_SAMPLES "Regenerate the sample schema sources whether or not we're building the tests." ON)
+
+  if(GRAPHQL_UPDATE_SAMPLES)
+    list(APPEND VCPKG_MANIFEST_FEATURES "update-samples")
+  endif()
+else()
+  set(GRAPHQL_UPDATE_SAMPLES OFF CACHE BOOL "Disable regenerating samples." FORCE)
+endif()
+
 project(cppgraphqlgen VERSION ${LATEST_VERSION})
 
 set(GRAPHQL_INSTALL_INCLUDE_DIR include CACHE PATH "Header file install directory")
@@ -80,16 +106,6 @@ if(NOT pegtl_FOUND)
   set(PEGTL_INSTALL_CMAKE_DIR ${GRAPHQL_INSTALL_CMAKE_DIR}/pegtl CACHE STRING "Override PEGTL cmake install directory")
   add_subdirectory(PEGTL)
 endif()
-
-option(GRAPHQL_BUILD_SCHEMAGEN "Build the schemagen tool." ON)
-
-if(GRAPHQL_BUILD_SCHEMAGEN)
-  option(GRAPHQL_UPDATE_SAMPLES "Regenerate the sample schema sources whether or not we're building the tests." ON)
-else()
-  set(GRAPHQL_UPDATE_SAMPLES OFF CACHE BOOL "Disable regenerating samples." FORCE)
-endif()
-
-option(GRAPHQL_BUILD_CLIENTGEN "Build the clientgen tool." ON)
 
 option(GRAPHQL_UPDATE_VERSION "Regenerate graphqlservice/internal/Version.h and all of the version info rc files for Windows." ON)
 

--- a/samples/client/benchmark/BenchmarkClient.cpp
+++ b/samples/client/benchmark/BenchmarkClient.cpp
@@ -201,5 +201,25 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
+[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+{
+	return benchmark::GetRequestText();
+}
+
+[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+{
+	return benchmark::GetRequestObject();
+}
+
+[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+{
+	return Query::GetOperationName();
+}
+
+[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+{
+	return Query::parseResponse(std::move(response));
+}
+
 } // namespace query::Query
 } // namespace graphql::client

--- a/samples/client/benchmark/BenchmarkClient.h
+++ b/samples/client/benchmark/BenchmarkClient.h
@@ -98,27 +98,13 @@ struct [[nodiscard]] Response
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept
-	{
-		return benchmark::GetRequestText();
-	}
-
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
-	{
-		return benchmark::GetRequestObject();
-	}
-
-	[[nodiscard]] static const std::string& GetOperationName() noexcept
-	{
-		return Query::GetOperationName();
-	}
+	[[nodiscard]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard]] static const std::string& GetOperationName() noexcept;
 
 	using Response = Query::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response)
-	{
-		return Query::parseResponse(std::move(response));
-	}
+	[[nodiscard]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::Query

--- a/samples/client/benchmark/BenchmarkClient.h
+++ b/samples/client/benchmark/BenchmarkClient.h
@@ -96,6 +96,31 @@ struct [[nodiscard]] Response
 
 [[nodiscard]] Response parseResponse(response::Value&& response);
 
+struct Traits
+{
+	[[nodiscard]] static const std::string& GetRequestText() noexcept
+	{
+		return benchmark::GetRequestText();
+	}
+
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
+	{
+		return benchmark::GetRequestObject();
+	}
+
+	[[nodiscard]] static const std::string& GetOperationName() noexcept
+	{
+		return Query::GetOperationName();
+	}
+
+	using Response = Query::Response;
+
+	[[nodiscard]] static Response parseResponse(response::Value&& response)
+	{
+		return Query::parseResponse(std::move(response));
+	}
+};
+
 } // namespace query::Query
 } // namespace graphql::client
 

--- a/samples/client/multiple/MultipleQueriesClient.cpp
+++ b/samples/client/multiple/MultipleQueriesClient.cpp
@@ -288,6 +288,26 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
+[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+{
+	return multiple::GetRequestText();
+}
+
+[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+{
+	return multiple::GetRequestObject();
+}
+
+[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+{
+	return Appointments::GetOperationName();
+}
+
+[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+{
+	return Appointments::parseResponse(std::move(response));
+}
+
 } // namespace query::Appointments
 
 template <>
@@ -401,6 +421,26 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
+[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+{
+	return multiple::GetRequestText();
+}
+
+[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+{
+	return multiple::GetRequestObject();
+}
+
+[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+{
+	return Tasks::GetOperationName();
+}
+
+[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+{
+	return Tasks::parseResponse(std::move(response));
+}
+
 } // namespace query::Tasks
 
 template <>
@@ -512,6 +552,26 @@ Response parseResponse(response::Value&& response)
 	}
 
 	return result;
+}
+
+[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+{
+	return multiple::GetRequestText();
+}
+
+[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+{
+	return multiple::GetRequestObject();
+}
+
+[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+{
+	return UnreadCounts::GetOperationName();
+}
+
+[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+{
+	return UnreadCounts::parseResponse(std::move(response));
 }
 
 } // namespace query::UnreadCounts
@@ -633,6 +693,26 @@ Response parseResponse(response::Value&& response)
 	}
 
 	return result;
+}
+
+[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+{
+	return multiple::GetRequestText();
+}
+
+[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+{
+	return multiple::GetRequestObject();
+}
+
+[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+{
+	return Miscellaneous::GetOperationName();
+}
+
+[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+{
+	return Miscellaneous::parseResponse(std::move(response));
 }
 
 } // namespace query::Miscellaneous
@@ -764,6 +844,31 @@ Response parseResponse(response::Value&& response)
 	}
 
 	return result;
+}
+
+[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+{
+	return multiple::GetRequestText();
+}
+
+[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+{
+	return multiple::GetRequestObject();
+}
+
+[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+{
+	return CompleteTaskMutation::GetOperationName();
+}
+
+[[nodiscard]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
+{
+	return CompleteTaskMutation::serializeVariables(std::move(variables));
+}
+
+[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+{
+	return CompleteTaskMutation::parseResponse(std::move(response));
 }
 
 } // namespace mutation::CompleteTaskMutation

--- a/samples/client/multiple/MultipleQueriesClient.h
+++ b/samples/client/multiple/MultipleQueriesClient.h
@@ -182,27 +182,13 @@ struct [[nodiscard]] Response
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept
-	{
-		return multiple::GetRequestText();
-	}
-
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
-	{
-		return multiple::GetRequestObject();
-	}
-
-	[[nodiscard]] static const std::string& GetOperationName() noexcept
-	{
-		return Appointments::GetOperationName();
-	}
+	[[nodiscard]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard]] static const std::string& GetOperationName() noexcept;
 
 	using Response = Appointments::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response)
-	{
-		return Appointments::parseResponse(std::move(response));
-	}
+	[[nodiscard]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::Appointments
@@ -242,27 +228,13 @@ struct [[nodiscard]] Response
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept
-	{
-		return multiple::GetRequestText();
-	}
-
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
-	{
-		return multiple::GetRequestObject();
-	}
-
-	[[nodiscard]] static const std::string& GetOperationName() noexcept
-	{
-		return Tasks::GetOperationName();
-	}
+	[[nodiscard]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard]] static const std::string& GetOperationName() noexcept;
 
 	using Response = Tasks::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response)
-	{
-		return Tasks::parseResponse(std::move(response));
-	}
+	[[nodiscard]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::Tasks
@@ -302,27 +274,13 @@ struct [[nodiscard]] Response
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept
-	{
-		return multiple::GetRequestText();
-	}
-
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
-	{
-		return multiple::GetRequestObject();
-	}
-
-	[[nodiscard]] static const std::string& GetOperationName() noexcept
-	{
-		return UnreadCounts::GetOperationName();
-	}
+	[[nodiscard]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard]] static const std::string& GetOperationName() noexcept;
 
 	using Response = UnreadCounts::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response)
-	{
-		return UnreadCounts::parseResponse(std::move(response));
-	}
+	[[nodiscard]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::UnreadCounts
@@ -359,27 +317,13 @@ struct [[nodiscard]] Response
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept
-	{
-		return multiple::GetRequestText();
-	}
-
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
-	{
-		return multiple::GetRequestObject();
-	}
-
-	[[nodiscard]] static const std::string& GetOperationName() noexcept
-	{
-		return Miscellaneous::GetOperationName();
-	}
+	[[nodiscard]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard]] static const std::string& GetOperationName() noexcept;
 
 	using Response = Miscellaneous::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response)
-	{
-		return Miscellaneous::parseResponse(std::move(response));
-	}
+	[[nodiscard]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::Miscellaneous
@@ -426,34 +370,17 @@ struct [[nodiscard]] Response
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept
-	{
-		return multiple::GetRequestText();
-	}
-
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
-	{
-		return multiple::GetRequestObject();
-	}
-
-	[[nodiscard]] static const std::string& GetOperationName() noexcept
-	{
-		return CompleteTaskMutation::GetOperationName();
-	}
+	[[nodiscard]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard]] static const std::string& GetOperationName() noexcept;
 
 	using Variables = CompleteTaskMutation::Variables;
 
-	[[nodiscard]] static response::Value serializeVariables(Variables&& variables)
-	{
-		return CompleteTaskMutation::serializeVariables(std::move(variables));
-	}
+	[[nodiscard]] static response::Value serializeVariables(Variables&& variables);
 
 	using Response = CompleteTaskMutation::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response)
-	{
-		return CompleteTaskMutation::parseResponse(std::move(response));
-	}
+	[[nodiscard]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace mutation::CompleteTaskMutation

--- a/samples/client/multiple/MultipleQueriesClient.h
+++ b/samples/client/multiple/MultipleQueriesClient.h
@@ -180,6 +180,31 @@ struct [[nodiscard]] Response
 
 [[nodiscard]] Response parseResponse(response::Value&& response);
 
+struct Traits
+{
+	[[nodiscard]] static const std::string& GetRequestText() noexcept
+	{
+		return multiple::GetRequestText();
+	}
+
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
+	{
+		return multiple::GetRequestObject();
+	}
+
+	[[nodiscard]] static const std::string& GetOperationName() noexcept
+	{
+		return Appointments::GetOperationName();
+	}
+
+	using Response = Appointments::Response;
+
+	[[nodiscard]] static Response parseResponse(response::Value&& response)
+	{
+		return Appointments::parseResponse(std::move(response));
+	}
+};
+
 } // namespace query::Appointments
 
 namespace query::Tasks {
@@ -214,6 +239,31 @@ struct [[nodiscard]] Response
 };
 
 [[nodiscard]] Response parseResponse(response::Value&& response);
+
+struct Traits
+{
+	[[nodiscard]] static const std::string& GetRequestText() noexcept
+	{
+		return multiple::GetRequestText();
+	}
+
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
+	{
+		return multiple::GetRequestObject();
+	}
+
+	[[nodiscard]] static const std::string& GetOperationName() noexcept
+	{
+		return Tasks::GetOperationName();
+	}
+
+	using Response = Tasks::Response;
+
+	[[nodiscard]] static Response parseResponse(response::Value&& response)
+	{
+		return Tasks::parseResponse(std::move(response));
+	}
+};
 
 } // namespace query::Tasks
 
@@ -250,6 +300,31 @@ struct [[nodiscard]] Response
 
 [[nodiscard]] Response parseResponse(response::Value&& response);
 
+struct Traits
+{
+	[[nodiscard]] static const std::string& GetRequestText() noexcept
+	{
+		return multiple::GetRequestText();
+	}
+
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
+	{
+		return multiple::GetRequestObject();
+	}
+
+	[[nodiscard]] static const std::string& GetOperationName() noexcept
+	{
+		return UnreadCounts::GetOperationName();
+	}
+
+	using Response = UnreadCounts::Response;
+
+	[[nodiscard]] static Response parseResponse(response::Value&& response)
+	{
+		return UnreadCounts::parseResponse(std::move(response));
+	}
+};
+
 } // namespace query::UnreadCounts
 
 namespace query::Miscellaneous {
@@ -281,6 +356,31 @@ struct [[nodiscard]] Response
 };
 
 [[nodiscard]] Response parseResponse(response::Value&& response);
+
+struct Traits
+{
+	[[nodiscard]] static const std::string& GetRequestText() noexcept
+	{
+		return multiple::GetRequestText();
+	}
+
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
+	{
+		return multiple::GetRequestObject();
+	}
+
+	[[nodiscard]] static const std::string& GetOperationName() noexcept
+	{
+		return Miscellaneous::GetOperationName();
+	}
+
+	using Response = Miscellaneous::Response;
+
+	[[nodiscard]] static Response parseResponse(response::Value&& response)
+	{
+		return Miscellaneous::parseResponse(std::move(response));
+	}
+};
 
 } // namespace query::Miscellaneous
 
@@ -323,6 +423,38 @@ struct [[nodiscard]] Response
 };
 
 [[nodiscard]] Response parseResponse(response::Value&& response);
+
+struct Traits
+{
+	[[nodiscard]] static const std::string& GetRequestText() noexcept
+	{
+		return multiple::GetRequestText();
+	}
+
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
+	{
+		return multiple::GetRequestObject();
+	}
+
+	[[nodiscard]] static const std::string& GetOperationName() noexcept
+	{
+		return CompleteTaskMutation::GetOperationName();
+	}
+
+	using Variables = CompleteTaskMutation::Variables;
+
+	[[nodiscard]] static response::Value serializeVariables(Variables&& variables)
+	{
+		return CompleteTaskMutation::serializeVariables(std::move(variables));
+	}
+
+	using Response = CompleteTaskMutation::Response;
+
+	[[nodiscard]] static Response parseResponse(response::Value&& response)
+	{
+		return CompleteTaskMutation::parseResponse(std::move(response));
+	}
+};
 
 } // namespace mutation::CompleteTaskMutation
 } // namespace graphql::client

--- a/samples/client/mutate/MutateClient.cpp
+++ b/samples/client/mutate/MutateClient.cpp
@@ -261,5 +261,30 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
+[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+{
+	return mutate::GetRequestText();
+}
+
+[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+{
+	return mutate::GetRequestObject();
+}
+
+[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+{
+	return CompleteTaskMutation::GetOperationName();
+}
+
+[[nodiscard]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
+{
+	return CompleteTaskMutation::serializeVariables(std::move(variables));
+}
+
+[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+{
+	return CompleteTaskMutation::parseResponse(std::move(response));
+}
+
 } // namespace mutation::CompleteTaskMutation
 } // namespace graphql::client

--- a/samples/client/mutate/MutateClient.h
+++ b/samples/client/mutate/MutateClient.h
@@ -119,6 +119,38 @@ struct [[nodiscard]] Response
 
 [[nodiscard]] Response parseResponse(response::Value&& response);
 
+struct Traits
+{
+	[[nodiscard]] static const std::string& GetRequestText() noexcept
+	{
+		return mutate::GetRequestText();
+	}
+
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
+	{
+		return mutate::GetRequestObject();
+	}
+
+	[[nodiscard]] static const std::string& GetOperationName() noexcept
+	{
+		return CompleteTaskMutation::GetOperationName();
+	}
+
+	using Variables = CompleteTaskMutation::Variables;
+
+	[[nodiscard]] static response::Value serializeVariables(Variables&& variables)
+	{
+		return CompleteTaskMutation::serializeVariables(std::move(variables));
+	}
+
+	using Response = CompleteTaskMutation::Response;
+
+	[[nodiscard]] static Response parseResponse(response::Value&& response)
+	{
+		return CompleteTaskMutation::parseResponse(std::move(response));
+	}
+};
+
 } // namespace mutation::CompleteTaskMutation
 } // namespace graphql::client
 

--- a/samples/client/mutate/MutateClient.h
+++ b/samples/client/mutate/MutateClient.h
@@ -121,34 +121,17 @@ struct [[nodiscard]] Response
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept
-	{
-		return mutate::GetRequestText();
-	}
-
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
-	{
-		return mutate::GetRequestObject();
-	}
-
-	[[nodiscard]] static const std::string& GetOperationName() noexcept
-	{
-		return CompleteTaskMutation::GetOperationName();
-	}
+	[[nodiscard]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard]] static const std::string& GetOperationName() noexcept;
 
 	using Variables = CompleteTaskMutation::Variables;
 
-	[[nodiscard]] static response::Value serializeVariables(Variables&& variables)
-	{
-		return CompleteTaskMutation::serializeVariables(std::move(variables));
-	}
+	[[nodiscard]] static response::Value serializeVariables(Variables&& variables);
 
 	using Response = CompleteTaskMutation::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response)
-	{
-		return CompleteTaskMutation::parseResponse(std::move(response));
-	}
+	[[nodiscard]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace mutation::CompleteTaskMutation

--- a/samples/client/nestedinput/NestedInputClient.cpp
+++ b/samples/client/nestedinput/NestedInputClient.cpp
@@ -327,5 +327,30 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
+[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+{
+	return nestedinput::GetRequestText();
+}
+
+[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+{
+	return nestedinput::GetRequestObject();
+}
+
+[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+{
+	return testQuery::GetOperationName();
+}
+
+[[nodiscard]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
+{
+	return testQuery::serializeVariables(std::move(variables));
+}
+
+[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+{
+	return testQuery::parseResponse(std::move(response));
+}
+
 } // namespace query::testQuery
 } // namespace graphql::client

--- a/samples/client/nestedinput/NestedInputClient.h
+++ b/samples/client/nestedinput/NestedInputClient.h
@@ -145,6 +145,38 @@ struct [[nodiscard]] Response
 
 [[nodiscard]] Response parseResponse(response::Value&& response);
 
+struct Traits
+{
+	[[nodiscard]] static const std::string& GetRequestText() noexcept
+	{
+		return nestedinput::GetRequestText();
+	}
+
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
+	{
+		return nestedinput::GetRequestObject();
+	}
+
+	[[nodiscard]] static const std::string& GetOperationName() noexcept
+	{
+		return testQuery::GetOperationName();
+	}
+
+	using Variables = testQuery::Variables;
+
+	[[nodiscard]] static response::Value serializeVariables(Variables&& variables)
+	{
+		return testQuery::serializeVariables(std::move(variables));
+	}
+
+	using Response = testQuery::Response;
+
+	[[nodiscard]] static Response parseResponse(response::Value&& response)
+	{
+		return testQuery::parseResponse(std::move(response));
+	}
+};
+
 } // namespace query::testQuery
 } // namespace graphql::client
 

--- a/samples/client/nestedinput/NestedInputClient.h
+++ b/samples/client/nestedinput/NestedInputClient.h
@@ -147,34 +147,17 @@ struct [[nodiscard]] Response
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept
-	{
-		return nestedinput::GetRequestText();
-	}
-
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
-	{
-		return nestedinput::GetRequestObject();
-	}
-
-	[[nodiscard]] static const std::string& GetOperationName() noexcept
-	{
-		return testQuery::GetOperationName();
-	}
+	[[nodiscard]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard]] static const std::string& GetOperationName() noexcept;
 
 	using Variables = testQuery::Variables;
 
-	[[nodiscard]] static response::Value serializeVariables(Variables&& variables)
-	{
-		return testQuery::serializeVariables(std::move(variables));
-	}
+	[[nodiscard]] static response::Value serializeVariables(Variables&& variables);
 
 	using Response = testQuery::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response)
-	{
-		return testQuery::parseResponse(std::move(response));
-	}
+	[[nodiscard]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::testQuery

--- a/samples/client/query/QueryClient.cpp
+++ b/samples/client/query/QueryClient.cpp
@@ -488,5 +488,25 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
+[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+{
+	return query::GetRequestText();
+}
+
+[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+{
+	return query::GetRequestObject();
+}
+
+[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+{
+	return Query::GetOperationName();
+}
+
+[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+{
+	return Query::parseResponse(std::move(response));
+}
+
 } // namespace query::Query
 } // namespace graphql::client

--- a/samples/client/query/QueryClient.h
+++ b/samples/client/query/QueryClient.h
@@ -198,27 +198,13 @@ struct [[nodiscard]] Response
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept
-	{
-		return query::GetRequestText();
-	}
-
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
-	{
-		return query::GetRequestObject();
-	}
-
-	[[nodiscard]] static const std::string& GetOperationName() noexcept
-	{
-		return Query::GetOperationName();
-	}
+	[[nodiscard]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard]] static const std::string& GetOperationName() noexcept;
 
 	using Response = Query::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response)
-	{
-		return Query::parseResponse(std::move(response));
-	}
+	[[nodiscard]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::Query

--- a/samples/client/query/QueryClient.h
+++ b/samples/client/query/QueryClient.h
@@ -196,6 +196,31 @@ struct [[nodiscard]] Response
 
 [[nodiscard]] Response parseResponse(response::Value&& response);
 
+struct Traits
+{
+	[[nodiscard]] static const std::string& GetRequestText() noexcept
+	{
+		return query::GetRequestText();
+	}
+
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
+	{
+		return query::GetRequestObject();
+	}
+
+	[[nodiscard]] static const std::string& GetOperationName() noexcept
+	{
+		return Query::GetOperationName();
+	}
+
+	using Response = Query::Response;
+
+	[[nodiscard]] static Response parseResponse(response::Value&& response)
+	{
+		return Query::parseResponse(std::move(response));
+	}
+};
+
 } // namespace query::Query
 } // namespace graphql::client
 

--- a/samples/client/subscribe/SubscribeClient.cpp
+++ b/samples/client/subscribe/SubscribeClient.cpp
@@ -123,5 +123,25 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
+[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+{
+	return subscribe::GetRequestText();
+}
+
+[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+{
+	return subscribe::GetRequestObject();
+}
+
+[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+{
+	return TestSubscription::GetOperationName();
+}
+
+[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+{
+	return TestSubscription::parseResponse(std::move(response));
+}
+
 } // namespace subscription::TestSubscription
 } // namespace graphql::client

--- a/samples/client/subscribe/SubscribeClient.h
+++ b/samples/client/subscribe/SubscribeClient.h
@@ -73,6 +73,31 @@ struct [[nodiscard]] Response
 
 [[nodiscard]] Response parseResponse(response::Value&& response);
 
+struct Traits
+{
+	[[nodiscard]] static const std::string& GetRequestText() noexcept
+	{
+		return subscribe::GetRequestText();
+	}
+
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
+	{
+		return subscribe::GetRequestObject();
+	}
+
+	[[nodiscard]] static const std::string& GetOperationName() noexcept
+	{
+		return TestSubscription::GetOperationName();
+	}
+
+	using Response = TestSubscription::Response;
+
+	[[nodiscard]] static Response parseResponse(response::Value&& response)
+	{
+		return TestSubscription::parseResponse(std::move(response));
+	}
+};
+
 } // namespace subscription::TestSubscription
 } // namespace graphql::client
 

--- a/samples/client/subscribe/SubscribeClient.h
+++ b/samples/client/subscribe/SubscribeClient.h
@@ -75,27 +75,13 @@ struct [[nodiscard]] Response
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept
-	{
-		return subscribe::GetRequestText();
-	}
-
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
-	{
-		return subscribe::GetRequestObject();
-	}
-
-	[[nodiscard]] static const std::string& GetOperationName() noexcept
-	{
-		return TestSubscription::GetOperationName();
-	}
+	[[nodiscard]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard]] static const std::string& GetOperationName() noexcept;
 
 	using Response = TestSubscription::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response)
-	{
-		return TestSubscription::parseResponse(std::move(response));
-	}
+	[[nodiscard]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace subscription::TestSubscription

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -406,8 +406,6 @@ install(FILES
 
 # graphqljson
 if(BUILD_GRAPHQLJSON)
-  option(GRAPHQL_BUILD_TESTS "Build the tests and sample schema library." ON)
-
   target_link_libraries(graphqljson PUBLIC graphqlresponse)
 
   install(TARGETS graphqljson

--- a/src/ClientGenerator.cpp
+++ b/src/ClientGenerator.cpp
@@ -424,6 +424,56 @@ using )cpp" << _schemaLoader.getSchemaNamespace()
 
 [[nodiscard]] Response parseResponse(response::Value&& response);
 
+struct Traits
+{
+	[[nodiscard]] static const std::string& GetRequestText() noexcept
+	{
+		return )cpp"
+				   << _schemaLoader.getSchemaNamespace() << R"cpp(::GetRequestText();
+	}
+
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
+	{
+		return )cpp"
+				   << _schemaLoader.getSchemaNamespace() << R"cpp(::GetRequestObject();
+	}
+
+	[[nodiscard]] static const std::string& GetOperationName() noexcept
+	{
+		return )cpp"
+				   << _requestLoader.getOperationNamespace(operation)
+				   << R"cpp(::GetOperationName();
+	}
+)cpp";
+
+		if (!variables.empty())
+		{
+			headerFile << R"cpp(
+	using Variables = )cpp"
+					   << _requestLoader.getOperationNamespace(operation) << R"cpp(::Variables;
+
+	[[nodiscard]] static response::Value serializeVariables(Variables&& variables)
+	{
+		return )cpp" << _requestLoader.getOperationNamespace(operation)
+					   << R"cpp(::serializeVariables(std::move(variables));
+	}
+)cpp";
+
+			pendingSeparator.add();
+		}
+
+		headerFile << R"cpp(
+	using Response = )cpp"
+				   << _requestLoader.getOperationNamespace(operation) << R"cpp(::Response;
+
+	[[nodiscard]] static Response parseResponse(response::Value&& response)
+	{
+		return )cpp"
+				   << _requestLoader.getOperationNamespace(operation)
+				   << R"cpp(::parseResponse(std::move(response));
+	}
+};
+
 )cpp";
 
 		pendingSeparator.add();
@@ -813,7 +863,8 @@ response::Value Variable<)cpp"
 
 				sourceFile << R"cpp(template <>
 response::Value Variable<)cpp"
-						   << cppType << R"cpp(>::serialize()cpp" << cppType << R"cpp(&& inputValue)
+						   << cppType << R"cpp(>::serialize()cpp" << cppType
+						   << R"cpp(&& inputValue)
 {
 	response::Value result { response::Type::Map };
 

--- a/src/ClientGenerator.cpp
+++ b/src/ClientGenerator.cpp
@@ -426,24 +426,9 @@ using )cpp" << _schemaLoader.getSchemaNamespace()
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept
-	{
-		return )cpp"
-				   << _schemaLoader.getSchemaNamespace() << R"cpp(::GetRequestText();
-	}
-
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept
-	{
-		return )cpp"
-				   << _schemaLoader.getSchemaNamespace() << R"cpp(::GetRequestObject();
-	}
-
-	[[nodiscard]] static const std::string& GetOperationName() noexcept
-	{
-		return )cpp"
-				   << _requestLoader.getOperationNamespace(operation)
-				   << R"cpp(::GetOperationName();
-	}
+	[[nodiscard]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard]] static const std::string& GetOperationName() noexcept;
 )cpp";
 
 		if (!variables.empty())
@@ -452,26 +437,15 @@ struct Traits
 	using Variables = )cpp"
 					   << _requestLoader.getOperationNamespace(operation) << R"cpp(::Variables;
 
-	[[nodiscard]] static response::Value serializeVariables(Variables&& variables)
-	{
-		return )cpp" << _requestLoader.getOperationNamespace(operation)
-					   << R"cpp(::serializeVariables(std::move(variables));
-	}
+	[[nodiscard]] static response::Value serializeVariables(Variables&& variables);
 )cpp";
-
-			pendingSeparator.add();
 		}
 
 		headerFile << R"cpp(
 	using Response = )cpp"
 				   << _requestLoader.getOperationNamespace(operation) << R"cpp(::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response)
-	{
-		return )cpp"
-				   << _requestLoader.getOperationNamespace(operation)
-				   << R"cpp(::parseResponse(std::move(response));
-	}
+	[[nodiscard]] static Response parseResponse(response::Value&& response);
 };
 
 )cpp";
@@ -1056,6 +1030,45 @@ Response parseResponse(response::Value&& response)
 	}
 
 	return result;
+}
+
+[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+{
+	return )cpp"
+				<< _schemaLoader.getSchemaNamespace() << R"cpp(::GetRequestText();
+}
+
+[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+{
+	return )cpp"
+				<< _schemaLoader.getSchemaNamespace() << R"cpp(::GetRequestObject();
+}
+
+[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+{
+	return )cpp"
+				<< _requestLoader.getOperationNamespace(operation)
+				<< R"cpp(::GetOperationName();
+}
+)cpp";
+
+		if (!variables.empty())
+		{
+			sourceFile << R"cpp(
+[[nodiscard]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
+{
+	return )cpp" << _requestLoader.getOperationNamespace(operation)
+					<< R"cpp(::serializeVariables(std::move(variables));
+}
+)cpp";
+		}
+
+		sourceFile << R"cpp(
+[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+{
+	return )cpp"
+				<< _requestLoader.getOperationNamespace(operation)
+				<< R"cpp(::parseResponse(std::move(response));
 }
 
 )cpp";

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,41 @@
+{
+  "name": "current-cppgraphqlgen",
+  "version-string": "current",
+  "features": {
+    "schemagen": {
+      "description": "Build the schemagen tool.",
+      "dependencies": [
+        "boost-program-options"
+      ]
+    },
+    "clientgen": {
+      "description": "Build the clientgen tool.",
+      "dependencies": [
+        "boost-program-options"
+      ]
+    },
+    "tests": {
+      "description": "Build tests.",
+      "dependencies": [
+        "gtest"
+      ]
+    },
+    "update-samples": {
+      "description": "Regenerate the sample schema sources whether or not we're building the tests.",
+      "dependencies": [
+        {
+          "name": "current-cppgraphqlgen",
+          "default-features": false,
+          "features": [
+            "schemagen",
+            "clientgen"
+          ]
+        }
+      ]
+    }
+  },
+  "dependencies": [
+    "pegtl",
+    "rapidjson"
+  ]
+}


### PR DESCRIPTION
This is a partial fix for #264, it adds a `Traits` type in each client operation namespace which make it easier to use in a template.

The rest of it still requires some more thought. Rather than adding explicit template constructors or factory functions, it should be more efficient to optionally include the corresponding schema header and import the identical types into the client namespace. OTOH, that increases complexity and risks pulling a lot more code into clients which don't need to interop with the service code.