### PR TITLE
Improve awaitable errors

### DIFF
--- a/samples/proxy/query/ProxyClient.cpp
+++ b/samples/proxy/query/ProxyClient.cpp
@@ -83,7 +83,7 @@ Response parseResponse(response::Value&& response)
 		{
 			if (member.first == R"js(relay)js"sv)
 			{
-				result.relay = ModifiedResponse<std::string>::parse(std::move(member.second));
+				result.relay = ModifiedResponse<std::string>::parse<TypeModifier::Nullable>(std::move(member.second));
 				continue;
 			}
 		}

--- a/samples/proxy/query/ProxyClient.h
+++ b/samples/proxy/query/ProxyClient.h
@@ -64,7 +64,7 @@ struct [[nodiscard]] Variables
 
 struct [[nodiscard]] Response
 {
-	std::string relay {};
+	std::optional<std::string> relay {};
 };
 
 [[nodiscard]] Response parseResponse(response::Value&& response);

--- a/samples/proxy/schema/QueryObject.cpp
+++ b/samples/proxy/schema/QueryObject.cpp
@@ -65,7 +65,7 @@ service::AwaitableResolver Query::resolveRelay(service::ResolverParams&& params)
 	auto result = _pimpl->getRelay(service::FieldParams(service::SelectionSetParams{ params }, std::move(directives)), std::move(argQuery), std::move(argOperationName), std::move(argVariables));
 	resolverLock.unlock();
 
-	return service::ModifiedResult<std::string>::convert(std::move(result), std::move(params));
+	return service::ModifiedResult<std::string>::convert<service::TypeModifier::Nullable>(std::move(result), std::move(params));
 }
 
 service::AwaitableResolver Query::resolve_typename(service::ResolverParams&& params) const
@@ -92,7 +92,7 @@ service::AwaitableResolver Query::resolve_type(service::ResolverParams&& params)
 void AddQueryDetails(const std::shared_ptr<schema::ObjectType>& typeQuery, const std::shared_ptr<schema::Schema>& schema)
 {
 	typeQuery->AddFields({
-		schema::Field::Make(R"gql(relay)gql"sv, R"md()md"sv, std::nullopt, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType(R"gql(String)gql"sv)), {
+		schema::Field::Make(R"gql(relay)gql"sv, R"md()md"sv, std::nullopt, schema->LookupType(R"gql(String)gql"sv), {
 			schema::InputValue::Make(R"gql(query)gql"sv, R"md()md"sv, schema->WrapType(introspection::TypeKind::NON_NULL, schema->LookupType(R"gql(String)gql"sv)), R"gql()gql"sv),
 			schema::InputValue::Make(R"gql(operationName)gql"sv, R"md()md"sv, schema->LookupType(R"gql(String)gql"sv), R"gql()gql"sv),
 			schema::InputValue::Make(R"gql(variables)gql"sv, R"md()md"sv, schema->LookupType(R"gql(String)gql"sv), R"gql()gql"sv)

--- a/samples/proxy/schema/QueryObject.h
+++ b/samples/proxy/schema/QueryObject.h
@@ -16,13 +16,13 @@ namespace methods::QueryHas {
 template <class TImpl>
 concept getRelayWithParams = requires (TImpl impl, service::FieldParams params, std::string queryArg, std::optional<std::string> operationNameArg, std::optional<std::string> variablesArg)
 {
-	{ service::AwaitableScalar<std::string> { impl.getRelay(std::move(params), std::move(queryArg), std::move(operationNameArg), std::move(variablesArg)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getRelay(std::move(params), std::move(queryArg), std::move(operationNameArg), std::move(variablesArg)) } };
 };
 
 template <class TImpl>
 concept getRelay = requires (TImpl impl, std::string queryArg, std::optional<std::string> operationNameArg, std::optional<std::string> variablesArg)
 {
-	{ service::AwaitableScalar<std::string> { impl.getRelay(std::move(queryArg), std::move(operationNameArg), std::move(variablesArg)) } };
+	{ service::AwaitableScalar<std::optional<std::string>> { impl.getRelay(std::move(queryArg), std::move(operationNameArg), std::move(variablesArg)) } };
 };
 
 template <class TImpl>
@@ -58,7 +58,7 @@ private:
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getRelay(service::FieldParams&& params, std::string&& queryArg, std::optional<std::string>&& operationNameArg, std::optional<std::string>&& variablesArg) const = 0;
+		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getRelay(service::FieldParams&& params, std::string&& queryArg, std::optional<std::string>&& operationNameArg, std::optional<std::string>&& variablesArg) const = 0;
 	};
 
 	template <class T>
@@ -70,7 +70,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getRelay(service::FieldParams&& params, std::string&& queryArg, std::optional<std::string>&& operationNameArg, std::optional<std::string>&& variablesArg) const final
+		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getRelay(service::FieldParams&& params, std::string&& queryArg, std::optional<std::string>&& operationNameArg, std::optional<std::string>&& variablesArg) const final
 		{
 			if constexpr (methods::QueryHas::getRelayWithParams<T>)
 			{

--- a/samples/proxy/schema/schema.graphql
+++ b/samples/proxy/schema/schema.graphql
@@ -2,5 +2,5 @@
 # Licensed under the MIT License.
 
 type Query {
-  relay(query: String!, operationName: String, variables: String): String!
+  relay(query: String!, operationName: String, variables: String): String
 }

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -1231,20 +1231,20 @@ AwaitableResolver Object::resolve(const SelectionSetParams& selectionSetParams,
 
 	for (auto& child : children)
 	{
-		auto location = std::move(child.location).value_or(schema_location {});
-		auto path = std::move(child.path).value_or(error_path {});
-
 		try
 		{
 			co_await launch;
 
-			auto value = co_await child.result;
+			auto value = co_await std::move(child.result);
 
 			if (!document.data.emplace_back(std::string { child.name }, std::move(value.data)))
 			{
 				std::ostringstream message;
 
 				message << "Ambiguous field error name: " << child.name;
+
+				auto location = std::move(child.location).value_or(schema_location {});
+				auto path = std::move(child.path).value_or(error_path {});
 
 				document.errors.push_back({ message.str(), std::move(location), std::move(path) });
 			}
@@ -1270,6 +1270,9 @@ AwaitableResolver Object::resolve(const SelectionSetParams& selectionSetParams,
 			std::ostringstream message;
 
 			message << "Field error name: " << child.name << " unknown error: " << ex.what();
+
+			auto location = std::move(child.location).value_or(schema_location {});
+			auto path = std::move(child.path).value_or(error_path {});
 
 			document.errors.push_back({ message.str(), std::move(location), std::move(path) });
 			document.data.emplace_back(std::string { child.name }, {});

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -1053,8 +1053,8 @@ void SelectionVisitor::visitField(const peg::ast_node& field)
 			selection,
 			_fragments,
 			_variables));
-		auto location = std::make_optional<schema_location>(position.line, position.column);
-		auto path = std::make_optional<error_path>(buildErrorPath(selectionSetParams.errorPath));
+		auto location = std::make_optional(schema_location { position.line, position.column });
+		auto path = std::make_optional(buildErrorPath(selectionSetParams.errorPath));
 
 		_values.push_back({ alias, std::move(location), std::move(path), std::move(result) });
 	}

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -1245,10 +1245,11 @@ AwaitableResolver Object::resolve(const SelectionSetParams& selectionSetParams,
 
 				message << "Ambiguous field error name: " << child.name;
 
+				field_path path { parent, path_segment { child.name } };
+
 				document.errors.push_back({ message.str(),
 					child.location.value_or(schema_location {}),
-					buildErrorPath(
-						std::make_optional(field_path { parent, path_segment { child.name } })) });
+					buildErrorPath(std::make_optional(path)) });
 			}
 
 			if (!value.errors.empty())
@@ -1273,10 +1274,11 @@ AwaitableResolver Object::resolve(const SelectionSetParams& selectionSetParams,
 
 			message << "Field error name: " << child.name << " unknown error: " << ex.what();
 
+			field_path path { parent, path_segment { child.name } };
+
 			document.errors.push_back({ message.str(),
 				child.location.value_or(schema_location {}),
-				buildErrorPath(
-					std::make_optional(field_path { parent, path_segment { child.name } })) });
+				buildErrorPath(std::make_optional(path)) });
 			document.data.emplace_back(std::string { child.name }, {});
 		}
 	}


### PR DESCRIPTION
I tried running the `client` HTTP sample without starting the `server`, and I noticed that the `Boost.Beast` error from failing to connect was not being handled gracefully.

In the process of adding error reporting to the `client`, I realized that exceptions thrown from awaitable resolvers are caught in the `Object::resolve` method instead of the `SelectionVisitor::visitField` method, and they are missing the field location and path information. We only report the error message.