### PR TITLE
Export compile commands and fix some SonarLint warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ cmake_policy(SET CMP0091 NEW)
 # Do not set default MSVC warning flags: https://cmake.org/cmake/help/latest/policy/CMP0092.html
 cmake_policy(SET CMP0092 NEW)
 
+# Export compile commands for other tools, e.g. SonarLint.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Default to the last updated version from version.txt.
 file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.txt" VERSION_FILE)
 file(READ "${VERSION_FILE}" LATEST_VERSION)

--- a/doc/awaitable.md
+++ b/doc/awaitable.md
@@ -8,14 +8,14 @@ specifically a type-erased `graphql::service::await_async` class in
 [GraphQLService.h](../include/graphqlservice/GraphQLService.h):
 ```cpp
 // Type-erased awaitable.
-class [[nodiscard]] await_async final
+class [[nodiscard("unnecessary construction")]] await_async final
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual bool await_ready() const = 0;
+		[[nodiscard("unexpected call")]] virtual bool await_ready() const = 0;
 		virtual void await_suspend(coro::coroutine_handle<> h) const = 0;
 		virtual void await_resume() const = 0;
 	};
@@ -71,7 +71,7 @@ Many APIs which used to return some sort of `std::future` now return an alias fo
 `graphql::internal::Awaitable<...>`. This template is defined in [Awaitable.h](../include/graphqlservice/internal/Awaitable.h):
 ```cpp
 template <typename T>
-class [[nodiscard]] Awaitable
+class [[nodiscard("unnecessary construction")]] Awaitable
 {
 public:
 	Awaitable(std::future<T> value)
@@ -79,14 +79,14 @@ public:
 	{
 	}
 
-	[[nodiscard]] T get()
+	[[nodiscard("unnecessary construction")]] T get()
 	{
 		return _value.get();
 	}
 
 	struct promise_type
 	{
-		[[nodiscard]] Awaitable get_return_object() noexcept
+		[[nodiscard("unnecessary construction")]] Awaitable get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
@@ -105,7 +105,7 @@ public:
 
 	};
 
-	[[nodiscard]] constexpr bool await_ready() const noexcept
+	[[nodiscard("unexpected call")]] constexpr bool await_ready() const noexcept
 	{
 		return true;
 	}
@@ -115,7 +115,7 @@ public:
 		h.resume();
 	}
 
-	[[nodiscard]] T await_resume()
+	[[nodiscard("unnecessary construction")]] T await_resume()
 	{
 		return _value.get();
 	}

--- a/doc/fieldparams.md
+++ b/doc/fieldparams.md
@@ -21,7 +21,7 @@ The `graphql::service::FieldParams` struct is declared in [GraphQLService.h](../
 ```cpp
 // Pass a common bundle of parameters to all of the generated Object::getField accessors in a
 // SelectionSet
-struct [[nodiscard]] SelectionSetParams
+struct [[nodiscard("unnecessary construction")]] SelectionSetParams
 {
 	// Context for this selection set.
 	const ResolverContext resolverContext;
@@ -46,7 +46,7 @@ struct [[nodiscard]] SelectionSetParams
 };
 
 // Pass a common bundle of parameters to all of the generated Object::getField accessors.
-struct [[nodiscard]] FieldParams : SelectionSetParams
+struct [[nodiscard("unnecessary construction")]] FieldParams : SelectionSetParams
 {
 	GRAPHQLSERVICE_EXPORT explicit FieldParams(
 		SelectionSetParams&& selectionSetParams, Directives directives);
@@ -64,7 +64,7 @@ The `SelectionSetParams::resolverContext` enum member informs the `getField`
 accessors about what type of operation is being resolved:
 ```cpp
 // Resolvers may be called in multiple different Operation contexts.
-enum class [[nodiscard]] ResolverContext {
+enum class [[nodiscard("unnecessary construction")]] ResolverContext {
 	// Resolving a Query operation.
 	Query,
 
@@ -94,7 +94,7 @@ The `SelectionSetParams::state` member is a reference to the
 // any per-request state that you want to maintain throughout the request (e.g. optimizing or
 // batching backend requests), you can inherit from RequestState and pass it to Request::resolve to
 // correlate the asynchronous/recursive callbacks and accumulate state in it.
-struct [[nodiscard]] RequestState : std::enable_shared_from_this<RequestState>
+struct [[nodiscard("unnecessary construction")]] RequestState : std::enable_shared_from_this<RequestState>
 {
 	virtual ~RequestState() = default;
 };

--- a/doc/json.md
+++ b/doc/json.md
@@ -46,7 +46,7 @@ to some other output mechanism, without building a single string buffer for the 
 document in memory. For example, you might use this to write directly to a buffered IPC pipe
 or network connection:
 ```cpp
-class [[nodiscard]] Writer final
+class [[nodiscard("unnecessary construction")]] Writer final
 {
 private:
 	struct Concept

--- a/doc/responses.md
+++ b/doc/responses.md
@@ -10,7 +10,7 @@ represented in GraphQL, as of the
 [October 2021 spec](https://spec.graphql.org/October2021/#sec-Serialization-Format):
 
 ```c++
-enum class [[nodiscard]] Type : std::uint8_t {
+enum class [[nodiscard("unnecessary conversion")]] Type : std::uint8_t {
 	Map,	   // JSON Object
 	List,	   // JSON Array
 	String,	   // JSON String

--- a/doc/subscriptions.md
+++ b/doc/subscriptions.md
@@ -13,13 +13,13 @@ the subscriptions to those listeners.
 Subscriptions are created by calling the `Request::subscribe` method in
 [GraphQLService.h](../include/graphqlservice/GraphQLService.h):
 ```cpp
-GRAPHQLSERVICE_EXPORT [[nodiscard]] AwaitableSubscribe subscribe(RequestSubscribeParams params);
+GRAPHQLSERVICE_EXPORT [[nodiscard("leaked subscription")]] AwaitableSubscribe subscribe(RequestSubscribeParams params);
 ```
 
 You need to fill in a `RequestSubscribeParams` struct with the subscription event
 callback, the [parsed](./parsing.md) `query` and any other relevant operation parameters:
 ```cpp
-struct [[nodiscard]] RequestSubscribeParams
+struct [[nodiscard("unnecessary construction")]] RequestSubscribeParams
 {
 	// Callback which receives the event data.
 	SubscriptionCallback callback;
@@ -64,13 +64,13 @@ The `internal::Awaitable<T>` template is described in [awaitable.md](./awaitable
 Subscriptions are removed by calling the `Request::unsubscribe` method in
 [GraphQLService.h](../include/graphqlservice/GraphQLService.h):
 ```cpp
-GRAPHQLSERVICE_EXPORT [[nodiscard]] AwaitableUnsubscribe unsubscribe(RequestUnsubscribeParams params);
+GRAPHQLSERVICE_EXPORT [[nodiscard("potentially leaked subscription")]] AwaitableUnsubscribe unsubscribe(RequestUnsubscribeParams params);
 ```
 
 You need to fill in a `RequestUnsubscribeParams` struct with the `SubscriptionKey`
 returned by `Request::subscribe` in `AwaitableSubscribe`:
 ```cpp
-struct [[nodiscard]] RequestUnsubscribeParams
+struct [[nodiscard("unnecessary construction")]] RequestUnsubscribeParams
 {
 	// Key returned by a previous call to subscribe.
 	SubscriptionKey key;
@@ -117,7 +117,7 @@ The `Request::deliver` method determines which subscriptions should receive
 an event based on several factors, which makes the `RequestDeliverParams` struct
 more complicated:
 ```cpp
-struct [[nodiscard]] RequestDeliverParams
+struct [[nodiscard("unnecessary construction")]] RequestDeliverParams
 {
 	// Deliver to subscriptions on this field.
 	std::string_view field;
@@ -155,7 +155,7 @@ using SubscriptionArguments = std::map<std::string_view, response::Value>;
 using SubscriptionArgumentFilterCallback = std::function<bool(response::MapType::const_reference)>;
 using SubscriptionDirectiveFilterCallback = std::function<bool(Directives::const_reference)>;
 
-struct [[nodiscard]] SubscriptionFilter
+struct [[nodiscard("unnecessary construction")]] SubscriptionFilter
 {
 	// Optional field argument filter, which can either be a set of required arguments, or a
 	// callback which returns true if the arguments match custom criteria.
@@ -186,6 +186,6 @@ that, there's a public `Request::findOperationDefinition` method which returns
 the operation type as a `std::string_view` along with a pointer to the AST node
 for the selected operation in the parsed query:
 ```cpp
-GRAPHQLSERVICE_EXPORT [[nodiscard]] std::pair<std::string_view, const peg::ast_node*>
+GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::pair<std::string_view, const peg::ast_node*>
 findOperationDefinition(peg::ast& query, std::string_view operationName) const;
 ```

--- a/include/ClientGenerator.h
+++ b/include/ClientGenerator.h
@@ -11,53 +11,57 @@
 
 namespace graphql::generator::client {
 
-struct [[nodiscard]] GeneratorPaths
+struct [[nodiscard("unnecessary construction")]] GeneratorPaths
 {
 	const std::string headerPath;
 	const std::string sourcePath;
 };
 
-struct [[nodiscard]] GeneratorOptions
+struct [[nodiscard("unnecessary construction")]] GeneratorOptions
 {
 	const GeneratorPaths paths;
 	const bool verbose = false;
 };
 
-class [[nodiscard]] Generator
+class [[nodiscard("unnecessary construction")]] Generator
 {
 public:
 	// Initialize the generator with the introspection client or a custom GraphQL client.
-	explicit Generator(
-		SchemaOptions&& schemaOptions, RequestOptions&& requestOptions, GeneratorOptions&& options);
+	explicit Generator(SchemaOptions && schemaOptions,
+		RequestOptions && requestOptions,
+		GeneratorOptions && options);
 
 	// Run the generator and return a list of filenames that were output.
-	[[nodiscard]] std::vector<std::string> Build() const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::vector<std::string> Build() const noexcept;
 
 private:
-	[[nodiscard]] std::string getHeaderDir() const noexcept;
-	[[nodiscard]] std::string getSourceDir() const noexcept;
-	[[nodiscard]] std::string getHeaderPath() const noexcept;
-	[[nodiscard]] std::string getSourcePath() const noexcept;
-	[[nodiscard]] const std::string& getClientNamespace() const noexcept;
-	[[nodiscard]] const std::string& getOperationNamespace(
+	[[nodiscard("unnecessary memory copy")]] std::string getHeaderDir() const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getSourceDir() const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getHeaderPath() const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getSourcePath() const noexcept;
+	[[nodiscard("unnecessary call")]] const std::string& getClientNamespace() const noexcept;
+	[[nodiscard("unnecessary call")]] const std::string& getOperationNamespace(
 		const Operation& operation) const noexcept;
-	[[nodiscard]] std::string getResponseFieldCppType(
-		const ResponseField& responseField, std::string_view currentScope = {}) const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getResponseFieldCppType(
+		const ResponseField& responseField,
+		std::string_view currentScope = {}) const noexcept;
 
-	[[nodiscard]] bool outputHeader() const noexcept;
-	void outputRequestComment(std::ostream& headerFile) const noexcept;
-	void outputGetRequestDeclaration(std::ostream& headerFile) const noexcept;
-	void outputGetOperationNameDeclaration(std::ostream& headerFile) const noexcept;
-	[[nodiscard]] bool outputResponseFieldType(std::ostream& headerFile,
-		const ResponseField& responseField, size_t indent = 0) const noexcept;
+	[[nodiscard("unnecessary call")]] bool outputHeader() const noexcept;
+	void outputRequestComment(std::ostream & headerFile) const noexcept;
+	void outputGetRequestDeclaration(std::ostream & headerFile) const noexcept;
+	void outputGetOperationNameDeclaration(std::ostream & headerFile) const noexcept;
+	[[nodiscard("unnecessary call")]] bool outputResponseFieldType(std::ostream & headerFile,
+		const ResponseField& responseField,
+		size_t indent = 0) const noexcept;
 
-	[[nodiscard]] bool outputSource() const noexcept;
-	void outputGetRequestImplementation(std::ostream& sourceFile) const noexcept;
-	void outputGetOperationNameImplementation(
-		std::ostream& sourceFile, const Operation& operation) const noexcept;
-	bool outputModifiedResponseImplementation(std::ostream& sourceFile,
-		const std::string& outerScope, const ResponseField& responseField) const noexcept;
-	[[nodiscard]] static std::string getTypeModifierList(
+	[[nodiscard("unnecessary call")]] bool outputSource() const noexcept;
+	void outputGetRequestImplementation(std::ostream & sourceFile) const noexcept;
+	void outputGetOperationNameImplementation(std::ostream & sourceFile, const Operation& operation)
+		const noexcept;
+	bool outputModifiedResponseImplementation(std::ostream & sourceFile,
+		const std::string& outerScope,
+		const ResponseField& responseField) const noexcept;
+	[[nodiscard("unnecessary memory copy")]] static std::string getTypeModifierList(
 		const TypeModifierStack& modifiers) noexcept;
 
 	const SchemaLoader _schemaLoader;

--- a/include/GeneratorLoader.h
+++ b/include/GeneratorLoader.h
@@ -11,7 +11,7 @@
 namespace graphql::generator {
 
 // Types that we understand and use to generate the skeleton of a service.
-enum class [[nodiscard]] SchemaType {
+enum class [[nodiscard("unnecessary conversion")]] SchemaType {
 	Scalar,
 	Enum,
 	Input,
@@ -30,10 +30,11 @@ using TypeModifierStack = std::vector<service::TypeModifier>;
 
 // Recursively visit a Type node until we reach a NamedType and we've
 // taken stock of all of the modifier wrappers.
-class [[nodiscard]] TypeVisitor
+class [[nodiscard("unnecessary construction")]] TypeVisitor
 {
 public:
-	[[nodiscard]] std::pair<std::string_view, TypeModifierStack> getType();
+	[[nodiscard("unnecessary construction")]] std::pair<std::string_view, TypeModifierStack>
+	getType();
 
 	void visit(const peg::ast_node& typeName);
 
@@ -49,10 +50,10 @@ private:
 
 // Recursively visit a Value node representing the default value on an input field
 // and build a JSON representation of the hardcoded value.
-class [[nodiscard]] DefaultValueVisitor
+class [[nodiscard("unnecessary construction")]] DefaultValueVisitor
 {
 public:
-	[[nodiscard]] response::Value getValue();
+	[[nodiscard("unnecessary construction")]] response::Value getValue();
 
 	void visit(const peg::ast_node& value);
 

--- a/include/GeneratorUtil.h
+++ b/include/GeneratorUtil.h
@@ -13,10 +13,10 @@
 namespace graphql::generator {
 
 // RAII object to help with emitting matching include guard begin and end statements
-class [[nodiscard]] IncludeGuardScope
+class [[nodiscard("unnecessary construction")]] IncludeGuardScope
 {
 public:
-	explicit IncludeGuardScope(std::ostream& outputFile, std::string_view headerFileName) noexcept;
+	explicit IncludeGuardScope(std::ostream & outputFile, std::string_view headerFileName) noexcept;
 	~IncludeGuardScope() noexcept;
 
 private:
@@ -25,12 +25,13 @@ private:
 };
 
 // RAII object to help with emitting matching namespace begin and end statements
-class [[nodiscard]] NamespaceScope
+class [[nodiscard("unnecessary construction")]] NamespaceScope
 {
 public:
-	explicit NamespaceScope(
-		std::ostream& outputFile, std::string_view cppNamespace, bool deferred = false) noexcept;
-	NamespaceScope(NamespaceScope&& other) noexcept;
+	explicit NamespaceScope(std::ostream & outputFile,
+		std::string_view cppNamespace,
+		bool deferred = false) noexcept;
+	NamespaceScope(NamespaceScope && other) noexcept;
 	~NamespaceScope() noexcept;
 
 	bool enter() noexcept;
@@ -44,10 +45,10 @@ private:
 
 // Keep track of whether we want to add a blank separator line once some additional content is about
 // to be output.
-class [[nodiscard]] PendingBlankLine
+class [[nodiscard("unnecessary construction")]] PendingBlankLine
 {
 public:
-	explicit PendingBlankLine(std::ostream& outputFile) noexcept;
+	explicit PendingBlankLine(std::ostream & outputFile) noexcept;
 
 	void add() noexcept;
 	bool reset() noexcept;

--- a/include/RequestLoader.h
+++ b/include/RequestLoader.h
@@ -25,14 +25,14 @@ struct ResponseField;
 
 using ResponseFieldList = std::vector<ResponseField>;
 
-struct [[nodiscard]] ResponseType
+struct [[nodiscard("unnecessary construction")]] ResponseType
 {
 	RequestSchemaType type;
 	std::string_view cppType;
 	ResponseFieldList fields;
 };
 
-struct [[nodiscard]] ResponseField
+struct [[nodiscard("unnecessary construction")]] ResponseField
 {
 	RequestSchemaType type;
 	TypeModifierStack modifiers;
@@ -42,7 +42,7 @@ struct [[nodiscard]] ResponseField
 	ResponseFieldList children;
 };
 
-struct [[nodiscard]] RequestInputType
+struct [[nodiscard("unnecessary construction")]] RequestInputType
 {
 	RequestSchemaType type;
 	std::unordered_set<std::string_view> dependencies {};
@@ -51,7 +51,7 @@ struct [[nodiscard]] RequestInputType
 
 using RequestInputTypeList = std::vector<RequestInputType>;
 
-struct [[nodiscard]] RequestVariable
+struct [[nodiscard("unnecessary construction")]] RequestVariable
 {
 	RequestInputType inputType;
 	TypeModifierStack modifiers;
@@ -64,7 +64,7 @@ struct [[nodiscard]] RequestVariable
 
 using RequestVariableList = std::vector<RequestVariable>;
 
-struct [[nodiscard]] Operation
+struct [[nodiscard("unnecessary construction")]] Operation
 {
 	const peg::ast_node* operation;
 	std::string_view name;
@@ -79,7 +79,7 @@ struct [[nodiscard]] Operation
 
 using OperationList = std::vector<Operation>;
 
-struct [[nodiscard]] RequestOptions
+struct [[nodiscard("unnecessary construction")]] RequestOptions
 {
 	const std::string requestFilename;
 	const std::optional<std::string> operationName;
@@ -88,75 +88,82 @@ struct [[nodiscard]] RequestOptions
 
 class SchemaLoader;
 
-class [[nodiscard]] RequestLoader
+class [[nodiscard("unnecessary construction")]] RequestLoader
 {
 public:
-	explicit RequestLoader(RequestOptions&& requestOptions, const SchemaLoader& schemaLoader);
+	explicit RequestLoader(RequestOptions && requestOptions, const SchemaLoader& schemaLoader);
 
-	[[nodiscard]] std::string_view getRequestFilename() const noexcept;
-	[[nodiscard]] const OperationList& getOperations() const noexcept;
-	[[nodiscard]] std::string_view getOperationDisplayName(
+	[[nodiscard("unnecessary call")]] std::string_view getRequestFilename() const noexcept;
+	[[nodiscard("unnecessary call")]] const OperationList& getOperations() const noexcept;
+	[[nodiscard("unnecessary call")]] std::string_view getOperationDisplayName(
 		const Operation& operation) const noexcept;
-	[[nodiscard]] std::string getOperationNamespace(const Operation& operation) const noexcept;
-	[[nodiscard]] std::string_view getOperationType(const Operation& operation) const noexcept;
-	[[nodiscard]] std::string_view getRequestText() const noexcept;
+	[[nodiscard("unnecessary call")]] std::string getOperationNamespace(const Operation& operation)
+		const noexcept;
+	[[nodiscard("unnecessary call")]] std::string_view getOperationType(const Operation& operation)
+		const noexcept;
+	[[nodiscard("unnecessary call")]] std::string_view getRequestText() const noexcept;
 
-	[[nodiscard]] const ResponseType& getResponseType(const Operation& operation) const noexcept;
-	[[nodiscard]] const RequestVariableList& getVariables(
+	[[nodiscard("unnecessary call")]] const ResponseType& getResponseType(
 		const Operation& operation) const noexcept;
-
-	[[nodiscard]] const RequestInputTypeList& getReferencedInputTypes(
-		const Operation& operation) const noexcept;
-	[[nodiscard]] const RequestSchemaTypeList& getReferencedEnums(
+	[[nodiscard("unnecessary call")]] const RequestVariableList& getVariables(
 		const Operation& operation) const noexcept;
 
-	[[nodiscard]] std::string getInputCppType(
+	[[nodiscard("unnecessary call")]] const RequestInputTypeList& getReferencedInputTypes(
+		const Operation& operation) const noexcept;
+	[[nodiscard("unnecessary call")]] const RequestSchemaTypeList& getReferencedEnums(
+		const Operation& operation) const noexcept;
+
+	[[nodiscard("unnecessary call")]] std::string getInputCppType(
 		const RequestSchemaType& wrappedInputType) const noexcept;
-	[[nodiscard]] std::string getInputCppType(
-		const RequestSchemaType& inputType, const TypeModifierStack& modifiers) const noexcept;
-	[[nodiscard]] static std::string getOutputCppType(
-		std::string_view outputCppType, const TypeModifierStack& modifiers) noexcept;
+	[[nodiscard("unnecessary call")]] std::string getInputCppType(
+		const RequestSchemaType& inputType,
+		const TypeModifierStack& modifiers) const noexcept;
+	[[nodiscard("unnecessary call")]] static std::string getOutputCppType(
+		std::string_view outputCppType,
+		const TypeModifierStack& modifiers) noexcept;
 
-	[[nodiscard]] static std::pair<RequestSchemaType, TypeModifierStack> unwrapSchemaType(
-		RequestSchemaType&& type) noexcept;
+	[[nodiscard("unnecessary call")]] static std::pair<RequestSchemaType, TypeModifierStack>
+		unwrapSchemaType(RequestSchemaType && type) noexcept;
 
 private:
 	void buildSchema();
 	void addTypesToSchema();
-	[[nodiscard]] RequestSchemaType getSchemaType(
-		std::string_view type, const TypeModifierStack& modifiers) const noexcept;
+	[[nodiscard("unnecessary call")]] RequestSchemaType getSchemaType(std::string_view type,
+		const TypeModifierStack& modifiers) const noexcept;
 	void validateRequest() const;
 
-	[[nodiscard]] static std::string_view trimWhitespace(std::string_view content) noexcept;
+	[[nodiscard("unnecessary call")]] static std::string_view trimWhitespace(
+		std::string_view content) noexcept;
 
 	void findOperation();
 	void collectFragments() noexcept;
-	void collectVariables(Operation& operation) noexcept;
-	void collectInputTypes(Operation& operation, const RequestSchemaType& variableType) noexcept;
-	void reorderInputTypeDependencies(Operation& operation);
-	void collectEnums(Operation& operation, const RequestSchemaType& variableType) noexcept;
-	void collectEnums(Operation& operation, const ResponseField& responseField) noexcept;
+	void collectVariables(Operation & operation) noexcept;
+	void collectInputTypes(Operation & operation, const RequestSchemaType& variableType) noexcept;
+	void reorderInputTypeDependencies(Operation & operation);
+	void collectEnums(Operation & operation, const RequestSchemaType& variableType) noexcept;
+	void collectEnums(Operation & operation, const ResponseField& responseField) noexcept;
 
 	using FragmentDefinitionMap = std::map<std::string_view, const peg::ast_node*>;
 
 	// SelectionVisitor visits the AST and fills in the ResponseType for the request.
-	class [[nodiscard]] SelectionVisitor
+	class [[nodiscard("unnecessary construction")]] SelectionVisitor
 	{
 	public:
 		explicit SelectionVisitor(const SchemaLoader& schemaLoader,
-			const FragmentDefinitionMap& fragments, const std::shared_ptr<schema::Schema>& schema,
+			const FragmentDefinitionMap& fragments,
+			const std::shared_ptr<schema::Schema>& schema,
 			const RequestSchemaType& type);
 
 		void visit(const peg::ast_node& selection);
 
-		[[nodiscard]] ResponseFieldList getFields();
+		[[nodiscard("unnecessary construction")]] ResponseFieldList getFields();
 
 	private:
 		void visitField(const peg::ast_node& field);
 		void visitFragmentSpread(const peg::ast_node& fragmentSpread);
 		void visitInlineFragment(const peg::ast_node& inlineFragment);
 
-		void mergeFragmentFields(ResponseFieldList&& fragmentFields) noexcept;
+		void mergeFragmentFields(ResponseFieldList && fragmentFields) noexcept;
 
 		const SchemaLoader& _schemaLoader;
 		const FragmentDefinitionMap& _fragments;

--- a/include/SchemaGenerator.h
+++ b/include/SchemaGenerator.h
@@ -10,13 +10,13 @@
 
 namespace graphql::generator::schema {
 
-struct [[nodiscard]] GeneratorPaths
+struct [[nodiscard("unnecessary construction")]] GeneratorPaths
 {
 	const std::string headerPath;
 	const std::string sourcePath;
 };
 
-struct [[nodiscard]] GeneratorOptions
+struct [[nodiscard("unnecessary construction")]] GeneratorOptions
 {
 	const GeneratorPaths paths;
 	const bool verbose = false;
@@ -24,55 +24,68 @@ struct [[nodiscard]] GeneratorOptions
 	const bool noIntrospection = false;
 };
 
-class [[nodiscard]] Generator
+class [[nodiscard("unnecessary construction")]] Generator
 {
 public:
 	// Initialize the generator with the introspection schema or a custom GraphQL schema.
-	explicit Generator(SchemaOptions&& schemaOptions, GeneratorOptions&& options);
+	explicit Generator(SchemaOptions && schemaOptions, GeneratorOptions && options);
 
 	// Run the generator and return a list of filenames that were output.
-	[[nodiscard]] std::vector<std::string> Build() const noexcept;
+	[[nodiscard("unnecessary construction")]] std::vector<std::string> Build() const noexcept;
 
 private:
-	[[nodiscard]] std::string getHeaderDir() const noexcept;
-	[[nodiscard]] std::string getSourceDir() const noexcept;
-	[[nodiscard]] std::string getHeaderPath() const noexcept;
-	[[nodiscard]] std::string getSourcePath() const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getHeaderDir() const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getSourceDir() const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getHeaderPath() const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getSourcePath() const noexcept;
 
-	[[nodiscard]] bool outputHeader() const noexcept;
-	void outputInterfaceDeclaration(std::ostream& headerFile, std::string_view cppType) const;
-	void outputObjectImplements(std::ostream& headerFile, const ObjectType& objectType) const;
-	void outputObjectStubs(std::ostream& headerFile, const ObjectType& objectType) const;
-	void outputObjectDeclaration(
-		std::ostream& headerFile, const ObjectType& objectType, bool isQueryType) const;
-	[[nodiscard]] std::string getFieldDeclaration(const InputField& inputField) const noexcept;
-	[[nodiscard]] std::string getFieldDeclaration(const OutputField& outputField) const noexcept;
-	[[nodiscard]] std::string getResolverDeclaration(const OutputField& outputField) const noexcept;
+	[[nodiscard("unnecessary call")]] bool outputHeader() const noexcept;
+	void outputInterfaceDeclaration(std::ostream & headerFile, std::string_view cppType) const;
+	void outputObjectImplements(std::ostream & headerFile, const ObjectType& objectType) const;
+	void outputObjectStubs(std::ostream & headerFile, const ObjectType& objectType) const;
+	void outputObjectDeclaration(std::ostream & headerFile,
+		const ObjectType& objectType,
+		bool isQueryType) const;
+	[[nodiscard("unnecessary memory copy")]] std::string getFieldDeclaration(
+		const InputField& inputField) const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getFieldDeclaration(
+		const OutputField& outputField) const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getResolverDeclaration(
+		const OutputField& outputField) const noexcept;
 
-	[[nodiscard]] bool outputSource() const noexcept;
-	void outputInterfaceImplementation(std::ostream& sourceFile, std::string_view cppType) const;
-	void outputInterfaceIntrospection(
-		std::ostream& sourceFile, const InterfaceType& interfaceType) const;
-	void outputUnionIntrospection(std::ostream& sourceFile, const UnionType& unionType) const;
-	void outputObjectImplementation(
-		std::ostream& sourceFile, const ObjectType& objectType, bool isQueryType) const;
-	void outputObjectIntrospection(std::ostream& sourceFile, const ObjectType& objectType) const;
-	void outputIntrospectionInterfaces(std::ostream& sourceFile, std::string_view cppType,
+	[[nodiscard("unnecessary call")]] bool outputSource() const noexcept;
+	void outputInterfaceImplementation(std::ostream & sourceFile, std::string_view cppType) const;
+	void outputInterfaceIntrospection(std::ostream & sourceFile, const InterfaceType& interfaceType)
+		const;
+	void outputUnionIntrospection(std::ostream & sourceFile, const UnionType& unionType) const;
+	void outputObjectImplementation(std::ostream & sourceFile,
+		const ObjectType& objectType,
+		bool isQueryType) const;
+	void outputObjectIntrospection(std::ostream & sourceFile, const ObjectType& objectType) const;
+	void outputIntrospectionInterfaces(std::ostream & sourceFile,
+		std::string_view cppType,
 		const std::vector<std::string_view>& interfaces) const;
-	void outputIntrospectionFields(
-		std::ostream& sourceFile, std::string_view cppType, const OutputFieldList& fields) const;
-	[[nodiscard]] std::string getArgumentDefaultValue(
-		size_t level, const response::Value& defaultValue) const noexcept;
-	[[nodiscard]] std::string getArgumentDeclaration(const InputField& argument,
-		const char* prefixToken, const char* argumentsToken,
+	void outputIntrospectionFields(std::ostream & sourceFile,
+		std::string_view cppType,
+		const OutputFieldList& fields) const;
+	[[nodiscard("unnecessary memory copy")]] std::string getArgumentDefaultValue(size_t level,
+		const response::Value& defaultValue) const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getArgumentDeclaration(
+		const InputField& argument,
+		const char* prefixToken,
+		const char* argumentsToken,
 		const char* defaultToken) const noexcept;
-	[[nodiscard]] std::string getArgumentAccessType(const InputField& argument) const noexcept;
-	[[nodiscard]] std::string getResultAccessType(const OutputField& result) const noexcept;
-	[[nodiscard]] std::string getTypeModifiers(const TypeModifierStack& modifiers) const noexcept;
-	[[nodiscard]] std::string getIntrospectionType(
-		std::string_view type, const TypeModifierStack& modifiers) const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getArgumentAccessType(
+		const InputField& argument) const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getResultAccessType(
+		const OutputField& result) const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getTypeModifiers(
+		const TypeModifierStack& modifiers) const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getIntrospectionType(std::string_view type,
+		const TypeModifierStack& modifiers) const noexcept;
 
-	[[nodiscard]] std::vector<std::string> outputSeparateFiles() const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::vector<std::string> outputSeparateFiles()
+		const noexcept;
 
 	static const std::string s_currentDirectory;
 

--- a/include/SchemaLoader.h
+++ b/include/SchemaLoader.h
@@ -20,8 +20,7 @@
 namespace graphql::generator {
 
 // These are the set of built-in types in GraphQL.
-enum class [[nodiscard]] BuiltinType
-{
+enum class [[nodiscard("unnecessary conversion")]] BuiltinType {
 	Int,
 	Float,
 	String,
@@ -44,7 +43,7 @@ using TypeNameMap = std::unordered_map<std::string_view, size_t>;
 // Scalar types are opaque to the generator, it's up to the service implementation
 // to handle parsing, validating, and serializing them. We just need to track which
 // scalar type names have been declared so we recognize the references.
-struct [[nodiscard]] ScalarType
+struct [[nodiscard("unnecessary construction")]] ScalarType
 {
 	std::string_view type;
 	std::string_view description;
@@ -54,7 +53,7 @@ struct [[nodiscard]] ScalarType
 using ScalarTypeList = std::vector<ScalarType>;
 
 // Enum types map a type name to a collection of valid string values.
-struct [[nodiscard]] EnumValueType
+struct [[nodiscard("unnecessary construction")]] EnumValueType
 {
 	std::string_view value;
 	std::string_view cppValue;
@@ -63,7 +62,7 @@ struct [[nodiscard]] EnumValueType
 	std::optional<tao::graphqlpeg::position> position;
 };
 
-struct [[nodiscard]] EnumType
+struct [[nodiscard("unnecessary construction")]] EnumType
 {
 	std::string_view type;
 	std::string_view cppType;
@@ -76,15 +75,14 @@ using EnumTypeList = std::vector<EnumType>;
 // Input types are complex types that have a set of named fields. Each field may be
 // a scalar type (including lists or non-null wrappers) or another nested input type,
 // but it cannot include output object types.
-enum class [[nodiscard]] InputFieldType
-{
+enum class [[nodiscard("unnecessary conversion")]] InputFieldType {
 	Builtin,
 	Scalar,
 	Enum,
 	Input,
 };
 
-struct [[nodiscard]] InputField
+struct [[nodiscard("unnecessary construction")]] InputField
 {
 	std::string_view type;
 	std::string_view name;
@@ -99,7 +97,7 @@ struct [[nodiscard]] InputField
 
 using InputFieldList = std::vector<InputField>;
 
-struct [[nodiscard]] InputType
+struct [[nodiscard("unnecessary construction")]] InputType
 {
 	std::string_view type;
 	std::string_view cppType;
@@ -112,7 +110,7 @@ struct [[nodiscard]] InputType
 using InputTypeList = std::vector<InputType>;
 
 // Directives are defined with arguments and a list of valid locations.
-struct [[nodiscard]] Directive
+struct [[nodiscard("unnecessary construction")]] Directive
 {
 	std::string_view name;
 	bool isRepeatable = false;
@@ -124,7 +122,7 @@ struct [[nodiscard]] Directive
 using DirectiveList = std::vector<Directive>;
 
 // Union types map a type name to a set of potential concrete type names.
-struct [[nodiscard]] UnionType
+struct [[nodiscard("unnecessary construction")]] UnionType
 {
 	std::string_view type;
 	std::string_view cppType;
@@ -138,8 +136,7 @@ using UnionTypeList = std::vector<UnionType>;
 // field may be a scalar type (including lists or non-null wrappers) or another nested
 // output type, but it cannot include input object types. Each field can also take
 // optional arguments which are all input types.
-enum class [[nodiscard]] OutputFieldType
-{
+enum class [[nodiscard("unnecessary conversion")]] OutputFieldType {
 	Builtin,
 	Scalar,
 	Enum,
@@ -151,7 +148,7 @@ enum class [[nodiscard]] OutputFieldType
 constexpr std::string_view strGet = "get";
 constexpr std::string_view strApply = "apply";
 
-struct [[nodiscard]] OutputField
+struct [[nodiscard("unnecessary construction")]] OutputField
 {
 	std::string_view type;
 	std::string_view name;
@@ -172,7 +169,7 @@ using OutputFieldList = std::vector<OutputField>;
 // are inherited by concrete object output types which support all of the fields in
 // the interface, and the concrete object matches the interface for fragment type
 // conditions. The fields can include any output type.
-struct [[nodiscard]] InterfaceType
+struct [[nodiscard("unnecessary construction")]] InterfaceType
 {
 	std::string_view type;
 	std::string_view cppType;
@@ -185,7 +182,7 @@ using InterfaceTypeList = std::vector<InterfaceType>;
 
 // Object types are concrete complex output types that have a set of fields. They
 // may inherit multiple interfaces.
-struct [[nodiscard]] ObjectType
+struct [[nodiscard("unnecessary construction")]] ObjectType
 {
 	std::string_view type;
 	std::string_view cppType;
@@ -198,7 +195,7 @@ struct [[nodiscard]] ObjectType
 using ObjectTypeList = std::vector<ObjectType>;
 
 // The schema maps operation types to named types.
-struct [[nodiscard]] OperationType
+struct [[nodiscard("unnecessary construction")]] OperationType
 {
 	std::string_view type;
 	std::string_view cppType;
@@ -207,7 +204,7 @@ struct [[nodiscard]] OperationType
 
 using OperationTypeList = std::vector<OperationType>;
 
-struct [[nodiscard]] SchemaOptions
+struct [[nodiscard("unnecessary construction")]] SchemaOptions
 {
 	const std::string schemaFilename;
 	const std::string filenamePrefix;
@@ -215,62 +212,71 @@ struct [[nodiscard]] SchemaOptions
 	const bool isIntrospection = false;
 };
 
-class [[nodiscard]] SchemaLoader
+class [[nodiscard("unnecessary construction")]] SchemaLoader
 {
 public:
 	// Initialize the loader with the introspection schema or a custom GraphQL schema.
-	explicit SchemaLoader(SchemaOptions&& schemaOptions);
+	explicit SchemaLoader(SchemaOptions && schemaOptions);
 
-	[[nodiscard]] bool isIntrospection() const noexcept;
-	[[nodiscard]] std::string_view getSchemaDescription() const noexcept;
-	[[nodiscard]] std::string_view getFilenamePrefix() const noexcept;
-	[[nodiscard]] std::string_view getSchemaNamespace() const noexcept;
+	[[nodiscard("unnecessary call")]] bool isIntrospection() const noexcept;
+	[[nodiscard("unnecessary call")]] std::string_view getSchemaDescription() const noexcept;
+	[[nodiscard("unnecessary call")]] std::string_view getFilenamePrefix() const noexcept;
+	[[nodiscard("unnecessary call")]] std::string_view getSchemaNamespace() const noexcept;
 
-	[[nodiscard]] static std::string_view getIntrospectionNamespace() noexcept;
-	[[nodiscard]] static const BuiltinTypeMap& getBuiltinTypes() noexcept;
-	[[nodiscard]] static const CppTypeMap& getBuiltinCppTypes() noexcept;
-	[[nodiscard]] static std::string_view getScalarCppType() noexcept;
+	[[nodiscard("unnecessary call")]] static std::string_view getIntrospectionNamespace() noexcept;
+	[[nodiscard("unnecessary call")]] static const BuiltinTypeMap& getBuiltinTypes() noexcept;
+	[[nodiscard("unnecessary call")]] static const CppTypeMap& getBuiltinCppTypes() noexcept;
+	[[nodiscard("unnecessary call")]] static std::string_view getScalarCppType() noexcept;
 
-	[[nodiscard]] SchemaType getSchemaType(std::string_view type) const;
-	[[nodiscard]] const tao::graphqlpeg::position& getTypePosition(std::string_view type) const;
-
-	[[nodiscard]] size_t getScalarIndex(std::string_view type) const;
-	[[nodiscard]] const ScalarTypeList& getScalarTypes() const noexcept;
-
-	[[nodiscard]] size_t getEnumIndex(std::string_view type) const;
-	[[nodiscard]] const EnumTypeList& getEnumTypes() const noexcept;
-
-	[[nodiscard]] size_t getInputIndex(std::string_view type) const;
-	[[nodiscard]] const InputTypeList& getInputTypes() const noexcept;
-
-	[[nodiscard]] size_t getUnionIndex(std::string_view type) const;
-	[[nodiscard]] const UnionTypeList& getUnionTypes() const noexcept;
-
-	[[nodiscard]] size_t getInterfaceIndex(std::string_view type) const;
-	[[nodiscard]] const InterfaceTypeList& getInterfaceTypes() const noexcept;
-
-	[[nodiscard]] size_t getObjectIndex(std::string_view type) const;
-	[[nodiscard]] const ObjectTypeList& getObjectTypes() const noexcept;
-
-	[[nodiscard]] const DirectiveList& getDirectives() const noexcept;
-	[[nodiscard]] const tao::graphqlpeg::position& getDirectivePosition(
+	[[nodiscard("unnecessary call")]] SchemaType getSchemaType(std::string_view type) const;
+	[[nodiscard("unnecessary call")]] const tao::graphqlpeg::position& getTypePosition(
 		std::string_view type) const;
 
-	[[nodiscard]] const OperationTypeList& getOperationTypes() const noexcept;
+	[[nodiscard("unnecessary call")]] size_t getScalarIndex(std::string_view type) const;
+	[[nodiscard("unnecessary call")]] const ScalarTypeList& getScalarTypes() const noexcept;
 
-	[[nodiscard]] static std::string_view getSafeCppName(std::string_view type) noexcept;
+	[[nodiscard("unnecessary call")]] size_t getEnumIndex(std::string_view type) const;
+	[[nodiscard("unnecessary call")]] const EnumTypeList& getEnumTypes() const noexcept;
 
-	[[nodiscard]] std::string_view getCppType(std::string_view type) const noexcept;
-	[[nodiscard]] std::string getInputCppType(const InputField& field) const noexcept;
-	[[nodiscard]] std::string getOutputCppType(const OutputField& field) const noexcept;
+	[[nodiscard("unnecessary call")]] size_t getInputIndex(std::string_view type) const;
+	[[nodiscard("unnecessary call")]] const InputTypeList& getInputTypes() const noexcept;
 
-	[[nodiscard]] static std::string getOutputCppAccessor(const OutputField& field) noexcept;
-	[[nodiscard]] static std::string getOutputCppResolver(const OutputField& field) noexcept;
+	[[nodiscard("unnecessary call")]] size_t getUnionIndex(std::string_view type) const;
+	[[nodiscard("unnecessary call")]] const UnionTypeList& getUnionTypes() const noexcept;
 
-	[[nodiscard]] static bool shouldMoveInputField(const InputField& field) noexcept;
+	[[nodiscard("unnecessary call")]] size_t getInterfaceIndex(std::string_view type) const;
+	[[nodiscard("unnecessary call")]] const InterfaceTypeList& getInterfaceTypes() const noexcept;
+
+	[[nodiscard("unnecessary call")]] size_t getObjectIndex(std::string_view type) const;
+	[[nodiscard("unnecessary call")]] const ObjectTypeList& getObjectTypes() const noexcept;
+
+	[[nodiscard("unnecessary call")]] const DirectiveList& getDirectives() const noexcept;
+	[[nodiscard("unnecessary call")]] const tao::graphqlpeg::position& getDirectivePosition(
+		std::string_view type) const;
+
+	[[nodiscard("unnecessary call")]] const OperationTypeList& getOperationTypes() const noexcept;
+
+	[[nodiscard("unnecessary call")]] static std::string_view getSafeCppName(
+		std::string_view type) noexcept;
+
+	[[nodiscard("unnecessary call")]] std::string_view getCppType(std::string_view type)
+		const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getInputCppType(const InputField& field)
+		const noexcept;
+	[[nodiscard("unnecessary memory copy")]] std::string getOutputCppType(const OutputField& field)
+		const noexcept;
+
+	[[nodiscard("unnecessary memory copy")]] static std::string getOutputCppAccessor(
+		const OutputField& field) noexcept;
+	[[nodiscard("unnecessary memory copy")]] static std::string getOutputCppResolver(
+		const OutputField& field) noexcept;
+
+	[[nodiscard("unnecessary call")]] static bool shouldMoveInputField(
+		const InputField& field) noexcept;
 
 private:
-	[[nodiscard]] static bool isExtension(const peg::ast_node& definition) noexcept;
+	[[nodiscard("unnecessary call")]] static bool isExtension(
+		const peg::ast_node& definition) noexcept;
 
 	void visitDefinition(const peg::ast_node& definition);
 
@@ -290,27 +296,32 @@ private:
 	void visitObjectTypeExtension(const peg::ast_node& objectTypeExtension);
 	void visitDirectiveDefinition(const peg::ast_node& directiveDefinition);
 
-	static void blockReservedName(
-		std::string_view name, std::optional<tao::graphqlpeg::position> position = std::nullopt);
-	[[nodiscard]] static OutputFieldList getOutputFields(const peg::ast_node::children_t& fields);
-	[[nodiscard]] static InputFieldList getInputFields(const peg::ast_node::children_t& fields);
+	static void blockReservedName(std::string_view name,
+		std::optional<tao::graphqlpeg::position> position = std::nullopt);
+	[[nodiscard("unnecessary memory copy")]] static OutputFieldList getOutputFields(
+		const peg::ast_node::children_t& fields);
+	[[nodiscard("unnecessary memory copy")]] static InputFieldList getInputFields(
+		const peg::ast_node::children_t& fields);
 
 	void validateSchema();
-	void fixupOutputFieldList(OutputFieldList& fields,
+	void fixupOutputFieldList(OutputFieldList & fields,
 		const std::optional<std::unordered_set<std::string_view>>& interfaceFields,
 		const std::optional<std::string_view>& accessor);
-	void fixupInputFieldList(InputFieldList& fields);
+	void fixupInputFieldList(InputFieldList & fields);
 	void reorderInputTypeDependencies();
 	void validateImplementedInterfaces() const;
-	[[nodiscard]] const InterfaceType& findInterfaceType(
-		std::string_view typeName, std::string_view interfaceName) const;
-	void validateInterfaceFields(std::string_view typeName, std::string_view interfaceName,
+	[[nodiscard("unnecessary call")]] const InterfaceType& findInterfaceType(
+		std::string_view typeName,
+		std::string_view interfaceName) const;
+	void validateInterfaceFields(std::string_view typeName,
+		std::string_view interfaceName,
 		const OutputFieldList& typeFields) const;
-	void validateTransitiveInterfaces(
-		std::string_view typeName, const std::vector<std::string_view>& interfaces) const;
+	void validateTransitiveInterfaces(std::string_view typeName,
+		const std::vector<std::string_view>& interfaces) const;
 
-	[[nodiscard]] static std::string getJoinedCppName(
-		std::string_view prefix, std::string_view fieldName) noexcept;
+	[[nodiscard("unnecessary memory copy")]] static std::string getJoinedCppName(
+		std::string_view prefix,
+		std::string_view fieldName) noexcept;
 
 	static const std::string_view s_introspectionNamespace;
 	static const BuiltinTypeMap s_builtinTypes;

--- a/include/Validation.h
+++ b/include/Validation.h
@@ -15,10 +15,10 @@ namespace graphql::service {
 using ValidateType = std::optional<std::reference_wrapper<const schema::BaseType>>;
 using SharedType = std::shared_ptr<const schema::BaseType>;
 
-[[nodiscard]] SharedType getSharedType(const ValidateType& type) noexcept;
-[[nodiscard]] ValidateType getValidateType(const SharedType& type) noexcept;
+[[nodiscard("unnecessary call")]] SharedType getSharedType(const ValidateType& type) noexcept;
+[[nodiscard("unnecessary call")]] ValidateType getValidateType(const SharedType& type) noexcept;
 
-struct [[nodiscard]] ValidateArgument
+struct [[nodiscard("unnecessary construction")]] ValidateArgument
 {
 	bool defaultValue = false;
 	bool nonNullDefaultValue = false;
@@ -27,7 +27,7 @@ struct [[nodiscard]] ValidateArgument
 
 using ValidateTypeFieldArguments = internal::string_view_map<ValidateArgument>;
 
-struct [[nodiscard]] ValidateTypeField
+struct [[nodiscard("unnecessary construction")]] ValidateTypeField
 {
 	ValidateType returnType;
 	ValidateTypeFieldArguments arguments;
@@ -35,47 +35,47 @@ struct [[nodiscard]] ValidateTypeField
 
 using ValidateDirectiveArguments = internal::string_view_map<ValidateArgument>;
 
-struct [[nodiscard]] ValidateDirective
+struct [[nodiscard("unnecessary construction")]] ValidateDirective
 {
 	bool isRepeatable = false;
 	internal::sorted_set<introspection::DirectiveLocation> locations;
 	ValidateDirectiveArguments arguments;
 };
 
-struct [[nodiscard]] ValidateArgumentVariable
+struct [[nodiscard("unnecessary construction")]] ValidateArgumentVariable
 {
-	[[nodiscard]] bool operator==(const ValidateArgumentVariable& other) const;
+	[[nodiscard("unnecessary call")]] bool operator==(const ValidateArgumentVariable& other) const;
 
 	std::string_view name;
 };
 
-struct [[nodiscard]] ValidateArgumentEnumValue
+struct [[nodiscard("unnecessary construction")]] ValidateArgumentEnumValue
 {
-	[[nodiscard]] bool operator==(const ValidateArgumentEnumValue& other) const;
+	[[nodiscard("unnecessary call")]] bool operator==(const ValidateArgumentEnumValue& other) const;
 
 	std::string_view value;
 };
 
 struct ValidateArgumentValue;
 
-struct [[nodiscard]] ValidateArgumentValuePtr
+struct [[nodiscard("unnecessary construction")]] ValidateArgumentValuePtr
 {
-	[[nodiscard]] bool operator==(const ValidateArgumentValuePtr& other) const;
+	[[nodiscard("unnecessary call")]] bool operator==(const ValidateArgumentValuePtr& other) const;
 
 	std::unique_ptr<ValidateArgumentValue> value;
 	schema_location position;
 };
 
-struct [[nodiscard]] ValidateArgumentList
+struct [[nodiscard("unnecessary construction")]] ValidateArgumentList
 {
-	[[nodiscard]] bool operator==(const ValidateArgumentList& other) const;
+	[[nodiscard("unnecessary call")]] bool operator==(const ValidateArgumentList& other) const;
 
 	std::vector<ValidateArgumentValuePtr> values;
 };
 
-struct [[nodiscard]] ValidateArgumentMap
+struct [[nodiscard("unnecessary construction")]] ValidateArgumentMap
 {
-	[[nodiscard]] bool operator==(const ValidateArgumentMap& other) const;
+	[[nodiscard("unnecessary call")]] bool operator==(const ValidateArgumentMap& other) const;
 
 	internal::string_view_map<ValidateArgumentValuePtr> values;
 };
@@ -83,30 +83,30 @@ struct [[nodiscard]] ValidateArgumentMap
 using ValidateArgumentVariant = std::variant<ValidateArgumentVariable, int, double,
 	std::string_view, bool, ValidateArgumentEnumValue, ValidateArgumentList, ValidateArgumentMap>;
 
-struct [[nodiscard]] ValidateArgumentValue
+struct [[nodiscard("unnecessary construction")]] ValidateArgumentValue
 {
-	ValidateArgumentValue(ValidateArgumentVariable&& value);
+	ValidateArgumentValue(ValidateArgumentVariable && value);
 	ValidateArgumentValue(int value);
 	ValidateArgumentValue(double value);
 	ValidateArgumentValue(std::string_view value);
 	ValidateArgumentValue(bool value);
-	ValidateArgumentValue(ValidateArgumentEnumValue&& value);
-	ValidateArgumentValue(ValidateArgumentList&& value);
-	ValidateArgumentValue(ValidateArgumentMap&& value);
+	ValidateArgumentValue(ValidateArgumentEnumValue && value);
+	ValidateArgumentValue(ValidateArgumentList && value);
+	ValidateArgumentValue(ValidateArgumentMap && value);
 
 	ValidateArgumentVariant data;
 };
 
 // ValidateArgumentValueVisitor visits the AST and builds a record of a field return type and map
 // of the arguments for comparison to see if 2 fields with the same result name can be merged.
-class [[nodiscard]] ValidateArgumentValueVisitor
+class [[nodiscard("unnecessary construction")]] ValidateArgumentValueVisitor
 {
 public:
-	ValidateArgumentValueVisitor(std::list<schema_error>& errors);
+	ValidateArgumentValueVisitor(std::list<schema_error> & errors);
 
 	void visit(const peg::ast_node& value);
 
-	[[nodiscard]] ValidateArgumentValuePtr getArgumentValue();
+	[[nodiscard("unnecessary call")]] ValidateArgumentValuePtr getArgumentValue();
 
 private:
 	void visitVariable(const peg::ast_node& variable);
@@ -125,12 +125,14 @@ private:
 
 using ValidateFieldArguments = internal::string_view_map<ValidateArgumentValuePtr>;
 
-struct [[nodiscard]] ValidateField
+struct [[nodiscard("unnecessary construction")]] ValidateField
 {
-	ValidateField(ValidateType&& returnType, ValidateType&& objectType, std::string_view fieldName,
-		ValidateFieldArguments&& arguments);
+	ValidateField(ValidateType && returnType,
+		ValidateType && objectType,
+		std::string_view fieldName,
+		ValidateFieldArguments && arguments);
 
-	[[nodiscard]] bool operator==(const ValidateField& other) const;
+	[[nodiscard("unnecessary call")]] bool operator==(const ValidateField& other) const;
 
 	ValidateType returnType;
 	ValidateType objectType;
@@ -142,16 +144,16 @@ using ValidateTypes = internal::string_view_map<ValidateType>;
 
 // ValidateVariableTypeVisitor visits the AST and builds a ValidateType structure representing
 // a variable type in an operation definition as if it came from an Introspection query.
-class [[nodiscard]] ValidateVariableTypeVisitor
+class [[nodiscard("unnecessary construction")]] ValidateVariableTypeVisitor
 {
 public:
-	ValidateVariableTypeVisitor(
-		const std::shared_ptr<schema::Schema>& schema, const ValidateTypes& types);
+	ValidateVariableTypeVisitor(const std::shared_ptr<schema::Schema>& schema,
+		const ValidateTypes& types);
 
 	void visit(const peg::ast_node& typeName);
 
-	[[nodiscard]] bool isInputType() const;
-	[[nodiscard]] ValidateType getType();
+	[[nodiscard("unnecessary call")]] bool isInputType() const;
+	[[nodiscard("unnecessary call")]] ValidateType getType();
 
 private:
 	void visitNamedType(const peg::ast_node& namedType);
@@ -167,17 +169,18 @@ private:
 
 // ValidateExecutableVisitor visits the AST and validates that it is executable against the service
 // schema.
-class [[nodiscard]] ValidateExecutableVisitor
+class [[nodiscard("unnecessary construction")]] ValidateExecutableVisitor
 {
 public:
 	GRAPHQLSERVICE_EXPORT ValidateExecutableVisitor(std::shared_ptr<schema::Schema> schema);
 
 	GRAPHQLSERVICE_EXPORT void visit(const peg::ast_node& root);
 
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::list<schema_error> getStructuredErrors();
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary construction")]] std::list<schema_error>
+	getStructuredErrors();
 
 private:
-	[[nodiscard]] static ValidateTypeFieldArguments getArguments(
+	[[nodiscard("unnecessary call")]] static ValidateTypeFieldArguments getArguments(
 		const std::vector<std::shared_ptr<const schema::InputValue>>& args);
 
 	using FieldTypes = internal::string_view_map<ValidateTypeField>;
@@ -186,22 +189,24 @@ private:
 	using InputTypeFields = internal::string_view_map<InputFieldTypes>;
 	using EnumValues = internal::string_view_map<internal::string_view_set>;
 
-	[[nodiscard]] constexpr bool isScalarType(introspection::TypeKind kind);
+	[[nodiscard("unnecessary call")]] constexpr bool isScalarType(introspection::TypeKind kind);
 
-	[[nodiscard]] bool matchesScopedType(std::string_view name) const;
+	[[nodiscard("unnecessary call")]] bool matchesScopedType(std::string_view name) const;
 
-	[[nodiscard]] TypeFields::const_iterator getScopedTypeFields();
-	[[nodiscard]] InputTypeFields::const_iterator getInputTypeFields(std::string_view name);
-	[[nodiscard]] static const ValidateType& getValidateFieldType(
+	[[nodiscard("unnecessary call")]] TypeFields::const_iterator getScopedTypeFields();
+	[[nodiscard("unnecessary call")]] InputTypeFields::const_iterator getInputTypeFields(
+		std::string_view name);
+	[[nodiscard("unnecessary call")]] static const ValidateType& getValidateFieldType(
 		const FieldTypes::mapped_type& value);
-	[[nodiscard]] static const ValidateType& getValidateFieldType(
+	[[nodiscard("unnecessary call")]] static const ValidateType& getValidateFieldType(
 		const InputFieldTypes::mapped_type& value);
 	template <class _FieldTypes>
-	[[nodiscard]] static ValidateType getFieldType(
-		const _FieldTypes& fields, std::string_view name);
+	[[nodiscard("unnecessary call")]] static ValidateType getFieldType(const _FieldTypes& fields,
+		std::string_view name);
 	template <class _FieldTypes>
-	[[nodiscard]] static ValidateType getWrappedFieldType(
-		const _FieldTypes& fields, std::string_view name);
+	[[nodiscard("unnecessary call")]] static ValidateType getWrappedFieldType(
+		const _FieldTypes& fields,
+		std::string_view name);
 
 	void visitFragmentDefinition(const peg::ast_node& fragmentDefinition);
 	void visitOperationDefinition(const peg::ast_node& operationDefinition);
@@ -212,13 +217,16 @@ private:
 	void visitFragmentSpread(const peg::ast_node& fragmentSpread);
 	void visitInlineFragment(const peg::ast_node& inlineFragment);
 
-	void visitDirectives(
-		introspection::DirectiveLocation location, const peg::ast_node& directives);
+	void visitDirectives(introspection::DirectiveLocation location,
+		const peg::ast_node& directives);
 
-	[[nodiscard]] bool validateInputValue(bool hasNonNullDefaultValue,
-		const ValidateArgumentValuePtr& argument, const ValidateType& type);
-	[[nodiscard]] bool validateVariableType(bool isNonNull, const ValidateType& variableType,
-		const schema_location& position, const ValidateType& inputType);
+	[[nodiscard("unnecessary call")]] bool validateInputValue(bool hasNonNullDefaultValue,
+		const ValidateArgumentValuePtr& argument,
+		const ValidateType& type);
+	[[nodiscard("unnecessary call")]] bool validateVariableType(bool isNonNull,
+		const ValidateType& variableType,
+		const schema_location& position,
+		const ValidateType& inputType);
 
 	const std::shared_ptr<schema::Schema> _schema;
 	std::list<schema_error> _errors;

--- a/include/graphqlservice/GraphQLParse.h
+++ b/include/graphqlservice/GraphQLParse.h
@@ -27,7 +27,7 @@ namespace peg {
 class ast_node;
 struct ast_input;
 
-struct [[nodiscard]] ast
+struct [[nodiscard("unnecessary parse")]] ast
 {
 	std::shared_ptr<ast_input> input;
 	std::shared_ptr<ast_node> root;
@@ -38,19 +38,20 @@ struct [[nodiscard]] ast
 // another value for the depthLimit parameter in these parse functions.
 constexpr size_t c_defaultDepthLimit = 25;
 
-GRAPHQLPEG_EXPORT [[nodiscard]] ast parseSchemaString(
+GRAPHQLPEG_EXPORT [[nodiscard("unnecessary parse")]] ast parseSchemaString(
 	std::string_view input, size_t depthLimit = c_defaultDepthLimit);
-GRAPHQLPEG_EXPORT [[nodiscard]] ast parseSchemaFile(
+GRAPHQLPEG_EXPORT [[nodiscard("unnecessary parse")]] ast parseSchemaFile(
 	std::string_view filename, size_t depthLimit = c_defaultDepthLimit);
 
-GRAPHQLPEG_EXPORT [[nodiscard]] ast parseString(
+GRAPHQLPEG_EXPORT [[nodiscard("unnecessary parse")]] ast parseString(
 	std::string_view input, size_t depthLimit = c_defaultDepthLimit);
-GRAPHQLPEG_EXPORT [[nodiscard]] ast parseFile(
+GRAPHQLPEG_EXPORT [[nodiscard("unnecessary parse")]] ast parseFile(
 	std::string_view filename, size_t depthLimit = c_defaultDepthLimit);
 
 } // namespace peg
 
-GRAPHQLPEG_EXPORT [[nodiscard]] peg::ast operator"" _graphql(const char* text, size_t size);
+GRAPHQLPEG_EXPORT [[nodiscard("unnecessary parse")]] peg::ast operator"" _graphql(
+	const char* text, size_t size);
 
 } // namespace graphql
 

--- a/include/graphqlservice/GraphQLResponse.h
+++ b/include/graphqlservice/GraphQLResponse.h
@@ -33,8 +33,7 @@ namespace graphql::response {
 // GraphQL responses are not technically JSON-specific, although that is probably the most common
 // way of representing them. These are the primitive types that may be represented in GraphQL, as
 // of the [October 2021 spec](https://spec.graphql.org/October2021/#sec-Serialization-Format).
-enum class [[nodiscard]] Type : std::uint8_t
-{
+enum class [[nodiscard("unnecessary conversion")]] Type : std::uint8_t {
 	Map,	   // JSON Object
 	List,	   // JSON Array
 	String,	   // JSON String
@@ -57,7 +56,7 @@ using IntType = int;
 using FloatType = double;
 using ScalarType = Value;
 
-struct [[nodiscard]] IdType
+struct [[nodiscard("unnecessary conversion")]] IdType
 {
 	using ByteData = std::vector<std::uint8_t>;
 	using OpaqueString = std::string;
@@ -77,62 +76,73 @@ struct [[nodiscard]] IdType
 	IdType& operator=(const IdType& rhs) = delete;
 
 	// Conversion
-	GRAPHQLRESPONSE_EXPORT IdType(ByteData&& data) noexcept;
-	GRAPHQLRESPONSE_EXPORT IdType(OpaqueString&& opaque) noexcept;
+	GRAPHQLRESPONSE_EXPORT IdType(ByteData && data) noexcept;
+	GRAPHQLRESPONSE_EXPORT IdType(OpaqueString && opaque) noexcept;
 
 	template <typename ValueType>
-	[[nodiscard]] const ValueType& get() const;
+	[[nodiscard("unnecessary call")]] const ValueType& get() const;
 
 	template <typename ValueType>
-	[[nodiscard]] ValueType release();
+	[[nodiscard("unnecessary call")]] ValueType release();
 
 	// Comparison
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool operator==(const IdType& rhs) const noexcept;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool operator==(const ByteData& rhs) const noexcept;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool operator==(const OpaqueString& rhs) const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] bool operator==(const IdType& rhs)
+		const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] bool operator==(const ByteData& rhs)
+		const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] bool operator==(
+		const OpaqueString& rhs) const noexcept;
 
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool operator<(const IdType& rhs) const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] bool operator<(const IdType& rhs)
+		const noexcept;
 
 	// Check the type
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool isBase64() const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] bool isBase64() const noexcept;
 
 	// Shared accessors
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool empty() const noexcept;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] size_t size() const noexcept;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] size_t max_size() const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] bool empty() const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] size_t size() const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] size_t max_size() const noexcept;
 	GRAPHQLRESPONSE_EXPORT void reserve(size_t new_cap);
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] size_t capacity() const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] size_t capacity() const noexcept;
 	GRAPHQLRESPONSE_EXPORT void shrink_to_fit();
 	GRAPHQLRESPONSE_EXPORT void clear() noexcept;
 
 	// ByteData accessors
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] const std::uint8_t& at(size_t pos) const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] std::uint8_t& at(size_t pos);
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] const std::uint8_t& operator[](size_t pos) const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] std::uint8_t& operator[](size_t pos);
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] const std::uint8_t& front() const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] std::uint8_t& front();
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] const std::uint8_t& back() const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] std::uint8_t& back();
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] const std::uint8_t* data() const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] std::uint8_t* data();
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] const std::uint8_t& at(size_t pos)
+		const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] std::uint8_t& at(size_t pos);
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] const std::uint8_t& operator[](
+		size_t pos) const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] std::uint8_t& operator[](size_t pos);
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] const std::uint8_t& front() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] std::uint8_t& front();
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] const std::uint8_t& back() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] std::uint8_t& back();
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] const std::uint8_t* data() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] std::uint8_t* data();
 
 	// ByteData iterators
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] ByteData::const_iterator begin() const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] ByteData::iterator begin();
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] ByteData::const_iterator cbegin() const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] ByteData::const_iterator end() const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] ByteData::iterator end();
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] ByteData::const_iterator cend() const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] ByteData::const_reverse_iterator rbegin() const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] ByteData::reverse_iterator rbegin();
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] ByteData::const_reverse_iterator crbegin() const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] ByteData::const_reverse_iterator rend() const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] ByteData::reverse_iterator rend();
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] ByteData::const_reverse_iterator crend() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] ByteData::const_iterator begin() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] ByteData::iterator begin();
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] ByteData::const_iterator cbegin()
+		const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] ByteData::const_iterator end() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] ByteData::iterator end();
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] ByteData::const_iterator cend() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] ByteData::const_reverse_iterator
+	rbegin() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] ByteData::reverse_iterator rbegin();
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] ByteData::const_reverse_iterator
+	crbegin() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] ByteData::const_reverse_iterator rend()
+		const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] ByteData::reverse_iterator rend();
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] ByteData::const_reverse_iterator
+	crend() const;
 
 	// OpaqueString accessors
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] const char* c_str() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] const char* c_str() const;
 
 private:
 	std::variant<ByteData, OpaqueString> _data;
@@ -211,19 +221,19 @@ struct ValueTypeTraits<FloatType>
 };
 
 // Represent a discriminated union of GraphQL response value types.
-struct [[nodiscard]] Value
+struct [[nodiscard("unnecessary conversion")]] Value
 {
 	GRAPHQLRESPONSE_EXPORT Value(Type type = Type::Null);
 	GRAPHQLRESPONSE_EXPORT ~Value();
 
 	GRAPHQLRESPONSE_EXPORT explicit Value(const char* value);
-	GRAPHQLRESPONSE_EXPORT explicit Value(StringType&& value);
+	GRAPHQLRESPONSE_EXPORT explicit Value(StringType && value);
 	GRAPHQLRESPONSE_EXPORT explicit Value(BooleanType value);
 	GRAPHQLRESPONSE_EXPORT explicit Value(IntType value);
 	GRAPHQLRESPONSE_EXPORT explicit Value(FloatType value);
-	GRAPHQLRESPONSE_EXPORT explicit Value(IdType&& value);
+	GRAPHQLRESPONSE_EXPORT explicit Value(IdType && value);
 
-	GRAPHQLRESPONSE_EXPORT Value(Value&& other) noexcept;
+	GRAPHQLRESPONSE_EXPORT Value(Value && other) noexcept;
 	GRAPHQLRESPONSE_EXPORT explicit Value(const Value& other);
 
 	GRAPHQLRESPONSE_EXPORT Value(std::shared_ptr<const Value> other) noexcept;
@@ -232,37 +242,41 @@ struct [[nodiscard]] Value
 	Value& operator=(const Value& rhs) = delete;
 
 	// Comparison
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool operator==(const Value& rhs) const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] bool operator==(const Value& rhs)
+		const noexcept;
 
 	// Check the Type
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] Type type() const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] Type type() const noexcept;
 
 	// JSON doesn't distinguish between Type::String, Type::EnumValue, and Type::ID, so if this
 	// value comes from JSON and it's a string we need to track the fact that it can be interpreted
 	// as any of those types.
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] Value&& from_json() noexcept;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool maybe_enum() const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] Value&& from_json() noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] bool maybe_enum() const noexcept;
 
 	// Input values don't distinguish between Type::String and Type::ID, so if this value comes from
 	// a string literal input value we need to track that fact that it can be interpreted as either
 	// of those types.
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] Value&& from_input() noexcept;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] bool maybe_id() const noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] Value&& from_input() noexcept;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] bool maybe_id() const noexcept;
 
 	// Valid for Type::Map or Type::List
 	GRAPHQLRESPONSE_EXPORT void reserve(size_t count);
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] size_t size() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] size_t size() const;
 
 	// Valid for Type::Map
-	GRAPHQLRESPONSE_EXPORT bool emplace_back(std::string&& name, Value&& value);
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] MapType::const_iterator find(std::string_view name) const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] MapType::const_iterator begin() const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] MapType::const_iterator end() const;
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] const Value& operator[](std::string_view name) const;
+	GRAPHQLRESPONSE_EXPORT bool emplace_back(std::string && name, Value && value);
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] MapType::const_iterator find(
+		std::string_view name) const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] MapType::const_iterator begin() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] MapType::const_iterator end() const;
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] const Value& operator[](
+		std::string_view name) const;
 
 	// Valid for Type::List
-	GRAPHQLRESPONSE_EXPORT void emplace_back(Value&& value);
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] const Value& operator[](size_t index) const;
+	GRAPHQLRESPONSE_EXPORT void emplace_back(Value && value);
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] const Value& operator[](size_t index)
+		const;
 
 	// Specialized for all single-value Types.
 	template <typename ValueType>
@@ -270,26 +284,26 @@ struct [[nodiscard]] Value
 
 	// Specialized for all Types.
 	template <typename ValueType>
-	[[nodiscard]] typename ValueTypeTraits<ValueType>::get_type get() const;
+	[[nodiscard("unnecessary call")]] typename ValueTypeTraits<ValueType>::get_type get() const;
 
 	// Specialized for all Types which allocate extra memory.
 	template <typename ValueType>
-	[[nodiscard]] typename ValueTypeTraits<ValueType>::release_type release();
+	[[nodiscard("unnecessary call")]] typename ValueTypeTraits<ValueType>::release_type release();
 
 private:
 	// Type::Map
-	struct [[nodiscard]] MapData
+	struct [[nodiscard("unnecessary construction")]] MapData
 	{
-		[[nodiscard]] bool operator==(const MapData& rhs) const;
+		[[nodiscard("unnecessary call")]] bool operator==(const MapData& rhs) const;
 
 		MapType map;
 		std::vector<size_t> members;
 	};
 
 	// Type::String
-	struct [[nodiscard]] StringData
+	struct [[nodiscard("unnecessary construction")]] StringData
 	{
-		[[nodiscard]] bool operator==(const StringData& rhs) const;
+		[[nodiscard("unnecessary call")]] bool operator==(const StringData& rhs) const;
 
 		StringType string;
 		bool from_json = false;
@@ -297,30 +311,39 @@ private:
 	};
 
 	// Type::Null
-	struct [[nodiscard]] NullData
+	struct [[nodiscard("unnecessary construction")]] NullData
 	{
-		[[nodiscard]] bool operator==(const NullData& rhs) const;
+		[[nodiscard("unnecessary call")]] bool operator==(const NullData& rhs) const;
 	};
 
 	// Type::EnumValue
 	using EnumData = StringType;
 
 	// Type::Scalar
-	struct [[nodiscard]] ScalarData
+	struct [[nodiscard("unnecessary construction")]] ScalarData
 	{
-		[[nodiscard]] bool operator==(const ScalarData& rhs) const;
+		[[nodiscard("unnecessary call")]] bool operator==(const ScalarData& rhs) const;
 
 		std::unique_ptr<ScalarType> scalar;
 	};
 
 	using SharedData = std::shared_ptr<const Value>;
 
-	using TypeData = std::variant<MapData, ListType, StringData, NullData, BooleanType, IntType,
-		FloatType, EnumData, IdType, ScalarData, SharedData>;
+	using TypeData = std::variant<MapData,
+		ListType,
+		StringData,
+		NullData,
+		BooleanType,
+		IntType,
+		FloatType,
+		EnumData,
+		IdType,
+		ScalarData,
+		SharedData>;
 
-	[[nodiscard]] const TypeData& data() const noexcept;
+	[[nodiscard("unnecessary call")]] const TypeData& data() const noexcept;
 
-	[[nodiscard]] static Type typeOf(const TypeData& data) noexcept;
+	[[nodiscard("unnecessary call")]] static Type typeOf(const TypeData& data) noexcept;
 
 	TypeData _data;
 };
@@ -369,7 +392,7 @@ GRAPHQLRESPONSE_EXPORT IdType Value::release<IdType>();
 
 using AwaitableValue = internal::Awaitable<Value>;
 
-class [[nodiscard]] Writer final
+class [[nodiscard("unnecessary construction")]] Writer final
 {
 private:
 	struct Concept

--- a/include/graphqlservice/GraphQLService.h
+++ b/include/graphqlservice/GraphQLService.h
@@ -107,6 +107,18 @@ private:
 	std::list<schema_error> _structuredErrors;
 };
 
+// This exception is thrown when an generated stub is called for an unimplemented method.
+class [[nodiscard]] unimplemented_method : public std::runtime_error
+{
+public:
+	GRAPHQLSERVICE_EXPORT explicit unimplemented_method(std::string_view methodName);
+
+	unimplemented_method() = delete;
+
+private:
+	static GRAPHQLSERVICE_EXPORT std::string getMessage(std::string_view methodName) noexcept;
+};
+
 // The RequestState is nullable, but if you have multiple threads processing requests and there's
 // any per-request state that you want to maintain throughout the request (e.g. optimizing or
 // batching backend requests), you can inherit from RequestState and pass it to Request::resolve to

--- a/include/graphqlservice/JSONResponse.h
+++ b/include/graphqlservice/JSONResponse.h
@@ -22,9 +22,10 @@
 
 namespace graphql::response {
 
-JSONRESPONSE_EXPORT [[nodiscard]] std::string toJSON(Value&& response);
+JSONRESPONSE_EXPORT [[nodiscard("unnecessary conversion")]] std::string toJSON(Value&& response);
 
-JSONRESPONSE_EXPORT [[nodiscard]] Value parseJSON(const std::string& json);
+JSONRESPONSE_EXPORT [[nodiscard("unnecessary conversion")]] Value parseJSON(
+	const std::string& json);
 
 } // namespace graphql::response
 

--- a/include/graphqlservice/internal/Awaitable.h
+++ b/include/graphqlservice/internal/Awaitable.h
@@ -22,10 +22,10 @@
 namespace graphql::internal {
 
 template <typename T>
-class [[nodiscard]] Awaitable;
+class [[nodiscard("unnecessary construction")]] Awaitable;
 
 template <>
-class [[nodiscard]] Awaitable<void>
+class [[nodiscard("unnecessary construction")]] Awaitable<void>
 {
 public:
 	Awaitable(std::future<void> value)
@@ -40,7 +40,7 @@ public:
 
 	struct promise_type
 	{
-		[[nodiscard]] Awaitable get_return_object() noexcept
+		[[nodiscard("unnecessary construction")]] Awaitable get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
@@ -69,7 +69,7 @@ public:
 		std::promise<void> _promise;
 	};
 
-	[[nodiscard]] constexpr bool await_ready() const noexcept
+	[[nodiscard("unexpected call")]] constexpr bool await_ready() const noexcept
 	{
 		return true;
 	}
@@ -89,7 +89,7 @@ private:
 };
 
 template <typename T>
-class [[nodiscard]] Awaitable
+class [[nodiscard("unnecessary construction")]] Awaitable
 {
 public:
 	Awaitable(std::future<T> value)
@@ -97,14 +97,14 @@ public:
 	{
 	}
 
-	[[nodiscard]] T get()
+	[[nodiscard("unnecessary construction")]] T get()
 	{
 		return _value.get();
 	}
 
 	struct promise_type
 	{
-		[[nodiscard]] Awaitable get_return_object() noexcept
+		[[nodiscard("unnecessary construction")]] Awaitable get_return_object() noexcept
 		{
 			return { _promise.get_future() };
 		}
@@ -138,7 +138,7 @@ public:
 		std::promise<T> _promise;
 	};
 
-	[[nodiscard]] constexpr bool await_ready() const noexcept
+	[[nodiscard("unexpected call")]] constexpr bool await_ready() const noexcept
 	{
 		return true;
 	}
@@ -148,7 +148,7 @@ public:
 		h.resume();
 	}
 
-	[[nodiscard]] T await_resume()
+	[[nodiscard("unnecessary construction")]] T await_resume()
 	{
 		return _value.get();
 	}

--- a/include/graphqlservice/internal/Base64.h
+++ b/include/graphqlservice/internal/Base64.h
@@ -30,7 +30,8 @@ class Base64
 {
 public:
 	// Map a single Base64-encoded character to its 6-bit integer value.
-	[[nodiscard]] static constexpr std::uint8_t fromBase64(char ch) noexcept
+	[[nodiscard("unnecessary conversion")]] static constexpr std::uint8_t fromBase64(
+		char ch) noexcept
 	{
 		return (ch >= 'A' && ch <= 'Z'
 				? ch - 'A'
@@ -41,11 +42,11 @@ public:
 	}
 
 	// Convert a Base64-encoded string to a vector of bytes.
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] static std::vector<std::uint8_t> fromBase64(
-		std::string_view encoded);
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary conversion")]] static std::vector<std::uint8_t>
+	fromBase64(std::string_view encoded);
 
 	// Map a single 6-bit integer value to its Base64-encoded character.
-	[[nodiscard]] static constexpr char toBase64(std::uint8_t i) noexcept
+	[[nodiscard("unnecessary conversion")]] static constexpr char toBase64(std::uint8_t i) noexcept
 	{
 		return (i < 26
 				? static_cast<char>(i + static_cast<std::uint8_t>('A'))
@@ -55,10 +56,10 @@ public:
 	}
 
 	// Convert a set of bytes to Base64.
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] static std::string toBase64(
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary conversion")]] static std::string toBase64(
 		const std::vector<std::uint8_t>& bytes);
 
-	enum class [[nodiscard]] Comparison {
+	enum class [[nodiscard("unnecessary call")]] Comparison {
 		// Valid Base64 always compares as less than non-empty invalid Base64.
 		InvalidBase64 = -2,
 
@@ -68,21 +69,21 @@ public:
 	};
 
 	// Compare a set of bytes to a possible Base64 string without performing any heap allocations.
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] static Comparison compareBase64(
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] static Comparison compareBase64(
 		const std::vector<std::uint8_t>& bytes, std::string_view maybeEncoded) noexcept;
 
 	// Validate whether or not a string is valid Base64 without performing any heap allocations.
-	GRAPHQLRESPONSE_EXPORT [[nodiscard]] static bool validateBase64(
+	GRAPHQLRESPONSE_EXPORT [[nodiscard("unnecessary call")]] static bool validateBase64(
 		std::string_view maybeEncoded) noexcept;
 
 private:
 	static constexpr char padding = '=';
 
 	// Throw a std::logic_error if the character is out of range.
-	[[nodiscard]] static std::uint8_t verifyFromBase64(char ch);
+	[[nodiscard("unnecessary call")]] static std::uint8_t verifyFromBase64(char ch);
 
 	// Throw a std::logic_error if the integer is out of range.
-	[[nodiscard]] static char verifyToBase64(std::uint8_t i);
+	[[nodiscard("unnecessary call")]] static char verifyToBase64(std::uint8_t i);
 };
 
 } // namespace graphql::internal

--- a/include/graphqlservice/internal/Introspection.h
+++ b/include/graphqlservice/internal/Introspection.h
@@ -19,115 +19,141 @@ class Field;
 class InputValue;
 class EnumValue;
 
-class [[nodiscard]] Schema
+class [[nodiscard("unnecessary construction")]] Schema
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit Schema(const std::shared_ptr<schema::Schema>& schema);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDescription() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::vector<std::shared_ptr<object::Type>> getTypes() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<object::Type> getQueryType() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<object::Type> getMutationType() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<object::Type> getSubscriptionType() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::vector<std::shared_ptr<object::Directive>>
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::optional<std::string>
+	getDescription() const;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] std::vector<std::shared_ptr<object::Type>> getTypes() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::shared_ptr<object::Type>
+	getQueryType() const;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] std::shared_ptr<object::Type> getMutationType() const;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] std::shared_ptr<object::Type> getSubscriptionType() const;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] std::vector<std::shared_ptr<object::Directive>>
 	getDirectives() const;
 
 private:
 	const std::shared_ptr<schema::Schema> _schema;
 };
 
-class [[nodiscard]] Type
+class [[nodiscard("unnecessary construction")]] Type
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit Type(const std::shared_ptr<const schema::BaseType>& type);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] TypeKind getKind() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getName() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDescription() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::vector<std::shared_ptr<object::Field>>>
-	getFields(std::optional<bool>&& includeDeprecatedArg) const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::vector<std::shared_ptr<object::Type>>>
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] TypeKind getKind() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::optional<std::string> getName()
+		const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::optional<std::string>
+	getDescription() const;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] std::optional<std::vector<std::shared_ptr<object::Field>>>
+		getFields(std::optional<bool> && includeDeprecatedArg) const;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] std::optional<std::vector<std::shared_ptr<object::Type>>>
 	getInterfaces() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::vector<std::shared_ptr<object::Type>>>
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] std::optional<std::vector<std::shared_ptr<object::Type>>>
 	getPossibleTypes() const;
 	GRAPHQLSERVICE_EXPORT
-	[[nodiscard]] std::optional<std::vector<std::shared_ptr<object::EnumValue>>> getEnumValues(
-		std::optional<bool>&& includeDeprecatedArg) const;
+	[[nodiscard("unnecessary call")]] std::optional<std::vector<std::shared_ptr<object::EnumValue>>>
+		getEnumValues(std::optional<bool> && includeDeprecatedArg) const;
 	GRAPHQLSERVICE_EXPORT
-	[[nodiscard]] std::optional<std::vector<std::shared_ptr<object::InputValue>>> getInputFields()
-		const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<object::Type> getOfType() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getSpecifiedByURL() const;
+	[[nodiscard(
+		"unnecessary call")]] std::optional<std::vector<std::shared_ptr<object::InputValue>>>
+	getInputFields() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::shared_ptr<object::Type>
+	getOfType() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::optional<std::string>
+	getSpecifiedByURL() const;
 
 private:
 	const std::shared_ptr<const schema::BaseType> _type;
 };
 
-class [[nodiscard]] Field
+class [[nodiscard("unnecessary construction")]] Field
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit Field(const std::shared_ptr<const schema::Field>& field);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string getName() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDescription() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::vector<std::shared_ptr<object::InputValue>> getArgs()
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string getName() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::optional<std::string>
+	getDescription() const;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] std::vector<std::shared_ptr<object::InputValue>> getArgs()
 		const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<object::Type> getType() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] bool getIsDeprecated() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDeprecationReason() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::shared_ptr<object::Type> getType()
+		const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] bool getIsDeprecated() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::optional<std::string>
+	getDeprecationReason() const;
 
 private:
 	const std::shared_ptr<const schema::Field> _field;
 };
 
-class [[nodiscard]] InputValue
+class [[nodiscard("unnecessary construction")]] InputValue
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit InputValue(
 		const std::shared_ptr<const schema::InputValue>& inputValue);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string getName() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDescription() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<object::Type> getType() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDefaultValue() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string getName() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::optional<std::string>
+	getDescription() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::shared_ptr<object::Type> getType()
+		const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::optional<std::string>
+	getDefaultValue() const;
 
 private:
 	const std::shared_ptr<const schema::InputValue> _inputValue;
 };
 
-class [[nodiscard]] EnumValue
+class [[nodiscard("unnecessary construction")]] EnumValue
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit EnumValue(
 		const std::shared_ptr<const schema::EnumValue>& enumValue);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string getName() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDescription() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] bool getIsDeprecated() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDeprecationReason() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string getName() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::optional<std::string>
+	getDescription() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] bool getIsDeprecated() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::optional<std::string>
+	getDeprecationReason() const;
 
 private:
 	const std::shared_ptr<const schema::EnumValue> _enumValue;
 };
 
-class [[nodiscard]] Directive
+class [[nodiscard("unnecessary construction")]] Directive
 {
 public:
 	GRAPHQLSERVICE_EXPORT explicit Directive(
 		const std::shared_ptr<const schema::Directive>& directive);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string getName() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::optional<std::string> getDescription() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::vector<DirectiveLocation> getLocations() const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::vector<std::shared_ptr<object::InputValue>> getArgs()
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string getName() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::optional<std::string>
+	getDescription() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::vector<DirectiveLocation>
+	getLocations() const;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] std::vector<std::shared_ptr<object::InputValue>> getArgs()
 		const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] bool getIsRepeatable() const;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] bool getIsRepeatable() const;
 
 private:
 	const std::shared_ptr<const schema::Directive> _directive;

--- a/include/graphqlservice/internal/Schema.h
+++ b/include/graphqlservice/internal/Schema.h
@@ -13,8 +13,8 @@
 namespace graphql {
 namespace introspection {
 
-enum class [[nodiscard]] TypeKind;
-enum class [[nodiscard]] DirectiveLocation;
+enum class [[nodiscard("unnecessary conversion")]] TypeKind;
+enum class [[nodiscard("unnecessary conversion")]] DirectiveLocation;
 
 } // namespace introspection
 
@@ -34,35 +34,42 @@ class Field;
 class InputValue;
 class EnumValue;
 
-class [[nodiscard]] Schema : public std::enable_shared_from_this<Schema>
+class [[nodiscard("unnecessary construction")]] Schema : public std::enable_shared_from_this<Schema>
 {
 public:
-	GRAPHQLSERVICE_EXPORT explicit Schema(
-		bool noIntrospection = false, std::string_view description = "");
+	GRAPHQLSERVICE_EXPORT explicit Schema(bool noIntrospection = false,
+		std::string_view description = "");
 
 	GRAPHQLSERVICE_EXPORT void AddQueryType(std::shared_ptr<ObjectType> query);
 	GRAPHQLSERVICE_EXPORT void AddMutationType(std::shared_ptr<ObjectType> mutation);
 	GRAPHQLSERVICE_EXPORT void AddSubscriptionType(std::shared_ptr<ObjectType> subscription);
 	GRAPHQLSERVICE_EXPORT void AddType(std::string_view name, std::shared_ptr<BaseType> type);
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::shared_ptr<const BaseType>& LookupType(
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] const std::shared_ptr<const BaseType>& LookupType(
 		std::string_view name) const;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::shared_ptr<const BaseType> WrapType(
-		introspection::TypeKind kind, std::shared_ptr<const BaseType> ofType);
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::shared_ptr<const BaseType>
+	WrapType(introspection::TypeKind kind, std::shared_ptr<const BaseType> ofType);
 	GRAPHQLSERVICE_EXPORT void AddDirective(std::shared_ptr<Directive> directive);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] bool supportsIntrospection() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] bool supportsIntrospection()
+		const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view description()
+		const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] const std::vector<
 		std::pair<std::string_view, std::shared_ptr<const BaseType>>>&
 	types() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::shared_ptr<const ObjectType>& queryType()
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] const std::shared_ptr<const ObjectType>& queryType()
 		const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::shared_ptr<const ObjectType>& mutationType()
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] const std::shared_ptr<const ObjectType>& mutationType()
 		const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::shared_ptr<const ObjectType>& subscriptionType()
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] const std::shared_ptr<const ObjectType>& subscriptionType()
 		const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const Directive>>&
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] const std::vector<std::shared_ptr<const Directive>>&
 	directives() const noexcept;
 
 private:
@@ -83,31 +90,40 @@ private:
 		_listWrappers;
 };
 
-class [[nodiscard]] BaseType : public std::enable_shared_from_this<BaseType>
+class [[nodiscard("unnecessary construction")]] BaseType
+	: public std::enable_shared_from_this<BaseType>
 {
 public:
 	GRAPHQLSERVICE_EXPORT virtual ~BaseType() = default;
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] introspection::TypeKind kind() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] virtual std::string_view name() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] virtual const std::vector<std::shared_ptr<const Field>>&
-	fields() const noexcept;
-	GRAPHQLSERVICE_EXPORT
-	[[nodiscard]] virtual const std::vector<std::shared_ptr<const InterfaceType>>& interfaces()
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] introspection::TypeKind kind()
 		const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] virtual const std::vector<std::weak_ptr<const BaseType>>&
-	possibleTypes() const noexcept;
-	GRAPHQLSERVICE_EXPORT
-	[[nodiscard]] virtual const std::vector<std::shared_ptr<const EnumValue>>& enumValues()
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] virtual std::string_view name()
+		const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view description()
 		const noexcept;
 	GRAPHQLSERVICE_EXPORT
-	[[nodiscard]] virtual const std::vector<std::shared_ptr<const InputValue>>& inputFields()
-		const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] virtual const std::weak_ptr<const BaseType>& ofType()
-		const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] virtual std::string_view specifiedByURL() const noexcept;
+		[[nodiscard("unnecessary call")]] virtual const std::vector<std::shared_ptr<const Field>>&
+		fields() const noexcept;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard(
+		"unnecessary call")]] virtual const std::vector<std::shared_ptr<const InterfaceType>>&
+	interfaces() const noexcept;
+	GRAPHQLSERVICE_EXPORT
+		[[nodiscard("unnecessary call")]] virtual const std::vector<std::weak_ptr<const BaseType>>&
+		possibleTypes() const noexcept;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] virtual const std::vector<std::shared_ptr<const EnumValue>>&
+	enumValues() const noexcept;
+	GRAPHQLSERVICE_EXPORT
+	[[nodiscard("unnecessary call")]] virtual const std::vector<std::shared_ptr<const InputValue>>&
+	inputFields() const noexcept;
+	GRAPHQLSERVICE_EXPORT
+		[[nodiscard("unnecessary call")]] virtual const std::weak_ptr<const BaseType>&
+		ofType() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] virtual std::string_view
+	specifiedByURL() const noexcept;
 
 protected:
 	BaseType(introspection::TypeKind kind, std::string_view description);
@@ -117,7 +133,7 @@ private:
 	const std::string_view _description;
 };
 
-class [[nodiscard]] ScalarType : public BaseType
+class [[nodiscard("unnecessary construction")]] ScalarType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -125,21 +141,25 @@ private:
 	struct init;
 
 public:
-	explicit ScalarType(init&& params);
+	explicit ScalarType(init && params);
 
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<ScalarType> Make(
-		std::string_view name, std::string_view description, std::string_view specifiedByURL);
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] static std::shared_ptr<ScalarType> Make(
+		std::string_view name,
+		std::string_view description,
+		std::string_view specifiedByURL);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view specifiedByURL() const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view name()
+		const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view specifiedByURL()
+		const noexcept final;
 
 private:
 	const std::string_view _name;
 	const std::string_view _specifiedByURL;
 };
 
-class [[nodiscard]] ObjectType : public BaseType
+class [[nodiscard("unnecessary construction")]] ObjectType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -147,21 +167,25 @@ private:
 	struct init;
 
 public:
-	explicit ObjectType(init&& params);
+	explicit ObjectType(init && params);
 
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<ObjectType> Make(
-		std::string_view name, std::string_view description);
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] static std::shared_ptr<ObjectType> Make(
+		std::string_view name,
+		std::string_view description);
 
 	GRAPHQLSERVICE_EXPORT void AddInterfaces(
-		std::vector<std::shared_ptr<const InterfaceType>>&& interfaces);
-	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<const Field>>&& fields);
+		std::vector<std::shared_ptr<const InterfaceType>> && interfaces);
+	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<const Field>> && fields);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const Field>>& fields()
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view name()
 		const noexcept final;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const InterfaceType>>&
-	interfaces() const noexcept final;
+	GRAPHQLSERVICE_EXPORT
+		[[nodiscard("unnecessary call")]] const std::vector<std::shared_ptr<const Field>>&
+		fields() const noexcept final;
+	GRAPHQLSERVICE_EXPORT
+		[[nodiscard("unnecessary call")]] const std::vector<std::shared_ptr<const InterfaceType>>&
+		interfaces() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -170,7 +194,7 @@ private:
 	std::vector<std::shared_ptr<const Field>> _fields;
 };
 
-class [[nodiscard]] InterfaceType : public BaseType
+class [[nodiscard("unnecessary construction")]] InterfaceType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -178,24 +202,28 @@ private:
 	struct init;
 
 public:
-	explicit InterfaceType(init&& params);
+	explicit InterfaceType(init && params);
 
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<InterfaceType> Make(
-		std::string_view name, std::string_view description);
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] static std::shared_ptr<InterfaceType>
+	Make(std::string_view name, std::string_view description);
 
 	GRAPHQLSERVICE_EXPORT void AddPossibleType(std::weak_ptr<BaseType> possibleType);
 	GRAPHQLSERVICE_EXPORT void AddInterfaces(
-		std::vector<std::shared_ptr<const InterfaceType>>&& interfaces);
-	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<const Field>>&& fields);
+		std::vector<std::shared_ptr<const InterfaceType>> && interfaces);
+	GRAPHQLSERVICE_EXPORT void AddFields(std::vector<std::shared_ptr<const Field>> && fields);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const Field>>& fields()
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view name()
 		const noexcept final;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::weak_ptr<const BaseType>>&
-	possibleTypes() const noexcept final;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const InterfaceType>>&
-	interfaces() const noexcept final;
+	GRAPHQLSERVICE_EXPORT
+		[[nodiscard("unnecessary call")]] const std::vector<std::shared_ptr<const Field>>&
+		fields() const noexcept final;
+	GRAPHQLSERVICE_EXPORT
+		[[nodiscard("unnecessary call")]] const std::vector<std::weak_ptr<const BaseType>>&
+		possibleTypes() const noexcept final;
+	GRAPHQLSERVICE_EXPORT
+		[[nodiscard("unnecessary call")]] const std::vector<std::shared_ptr<const InterfaceType>>&
+		interfaces() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -205,7 +233,7 @@ private:
 	std::vector<std::weak_ptr<const BaseType>> _possibleTypes;
 };
 
-class [[nodiscard]] UnionType : public BaseType
+class [[nodiscard("unnecessary construction")]] UnionType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -213,18 +241,21 @@ private:
 	struct init;
 
 public:
-	explicit UnionType(init&& params);
+	explicit UnionType(init && params);
 
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<UnionType> Make(
-		std::string_view name, std::string_view description);
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] static std::shared_ptr<UnionType> Make(
+		std::string_view name,
+		std::string_view description);
 
 	GRAPHQLSERVICE_EXPORT void AddPossibleTypes(
-		std::vector<std::weak_ptr<const BaseType>>&& possibleTypes);
+		std::vector<std::weak_ptr<const BaseType>> && possibleTypes);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::weak_ptr<const BaseType>>&
-	possibleTypes() const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view name()
+		const noexcept final;
+	GRAPHQLSERVICE_EXPORT
+		[[nodiscard("unnecessary call")]] const std::vector<std::weak_ptr<const BaseType>>&
+		possibleTypes() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -232,14 +263,14 @@ private:
 	std::vector<std::weak_ptr<const BaseType>> _possibleTypes;
 };
 
-struct [[nodiscard]] EnumValueType
+struct [[nodiscard("unnecessary call")]] EnumValueType
 {
 	std::string_view value;
 	std::string_view description;
 	std::optional<std::string_view> deprecationReason;
 };
 
-class [[nodiscard]] EnumType : public BaseType
+class [[nodiscard("unnecessary construction")]] EnumType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -247,17 +278,20 @@ private:
 	struct init;
 
 public:
-	explicit EnumType(init&& params);
+	explicit EnumType(init && params);
 
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<EnumType> Make(
-		std::string_view name, std::string_view description);
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] static std::shared_ptr<EnumType> Make(
+		std::string_view name,
+		std::string_view description);
 
-	GRAPHQLSERVICE_EXPORT void AddEnumValues(std::vector<EnumValueType>&& enumValues);
+	GRAPHQLSERVICE_EXPORT void AddEnumValues(std::vector<EnumValueType> && enumValues);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const EnumValue>>&
-	enumValues() const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view name()
+		const noexcept final;
+	GRAPHQLSERVICE_EXPORT
+		[[nodiscard("unnecessary call")]] const std::vector<std::shared_ptr<const EnumValue>>&
+		enumValues() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -265,7 +299,7 @@ private:
 	std::vector<std::shared_ptr<const EnumValue>> _enumValues;
 };
 
-class [[nodiscard]] InputObjectType : public BaseType
+class [[nodiscard("unnecessary construction")]] InputObjectType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -273,18 +307,20 @@ private:
 	struct init;
 
 public:
-	explicit InputObjectType(init&& params);
+	explicit InputObjectType(init && params);
 
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<InputObjectType> Make(
-		std::string_view name, std::string_view description);
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] static std::shared_ptr<InputObjectType>
+	Make(std::string_view name, std::string_view description);
 
 	GRAPHQLSERVICE_EXPORT void AddInputValues(
-		std::vector<std::shared_ptr<const InputValue>>&& inputValues);
+		std::vector<std::shared_ptr<const InputValue>> && inputValues);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept final;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const InputValue>>&
-	inputFields() const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view name()
+		const noexcept final;
+	GRAPHQLSERVICE_EXPORT
+		[[nodiscard("unnecessary call")]] const std::vector<std::shared_ptr<const InputValue>>&
+		inputFields() const noexcept final;
 
 private:
 	const std::string_view _name;
@@ -292,7 +328,7 @@ private:
 	std::vector<std::shared_ptr<const InputValue>> _inputValues;
 };
 
-class [[nodiscard]] WrapperType : public BaseType
+class [[nodiscard("unnecessary construction")]] WrapperType : public BaseType
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -300,20 +336,20 @@ private:
 	struct init;
 
 public:
-	explicit WrapperType(init&& params);
+	explicit WrapperType(init && params);
 
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<WrapperType> Make(
-		introspection::TypeKind kind, std::weak_ptr<const BaseType> ofType);
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] static std::shared_ptr<WrapperType>
+	Make(introspection::TypeKind kind, std::weak_ptr<const BaseType> ofType);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::weak_ptr<const BaseType>& ofType()
-		const noexcept final;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] const std::weak_ptr<const BaseType>&
+	ofType() const noexcept final;
 
 private:
 	const std::weak_ptr<const BaseType> _ofType;
 };
 
-class [[nodiscard]] Field : public std::enable_shared_from_this<Field>
+class [[nodiscard("unnecessary construction")]] Field : public std::enable_shared_from_this<Field>
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -321,21 +357,28 @@ private:
 	struct init;
 
 public:
-	explicit Field(init&& params);
+	explicit Field(init && params);
 
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<Field> Make(std::string_view name,
-		std::string_view description, std::optional<std::string_view> deprecationReason,
-		std::weak_ptr<const BaseType> type,
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] static std::shared_ptr<Field> Make(
+		std::string_view name,
+		std::string_view description,
+		std::optional<std::string_view>
+			deprecationReason,
+		std::weak_ptr<const BaseType>
+			type,
 		std::vector<std::shared_ptr<const InputValue>>&& args = {});
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const InputValue>>& args()
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view description()
 		const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::weak_ptr<const BaseType>& type() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::optional<std::string_view>& deprecationReason()
-		const noexcept;
+	GRAPHQLSERVICE_EXPORT
+		[[nodiscard("unnecessary call")]] const std::vector<std::shared_ptr<const InputValue>>&
+		args() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] const std::weak_ptr<const BaseType>&
+	type() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] const std::optional<std::string_view>&
+	deprecationReason() const noexcept;
 
 private:
 	const std::string_view _name;
@@ -345,7 +388,8 @@ private:
 	const std::vector<std::shared_ptr<const InputValue>> _args;
 };
 
-class [[nodiscard]] InputValue : public std::enable_shared_from_this<InputValue>
+class [[nodiscard("unnecessary construction")]] InputValue
+	: public std::enable_shared_from_this<InputValue>
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -353,17 +397,23 @@ private:
 	struct init;
 
 public:
-	explicit InputValue(init&& params);
+	explicit InputValue(init && params);
 
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<InputValue> Make(
-		std::string_view name, std::string_view description, std::weak_ptr<const BaseType> type,
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] static std::shared_ptr<InputValue> Make(
+		std::string_view name,
+		std::string_view description,
+		std::weak_ptr<const BaseType>
+			type,
 		std::string_view defaultValue);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::weak_ptr<const BaseType>& type() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view defaultValue() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view description()
+		const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] const std::weak_ptr<const BaseType>&
+	type() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view defaultValue()
+		const noexcept;
 
 private:
 	const std::string_view _name;
@@ -372,7 +422,8 @@ private:
 	const std::string_view _defaultValue;
 };
 
-class [[nodiscard]] EnumValue : public std::enable_shared_from_this<EnumValue>
+class [[nodiscard("unnecessary construction")]] EnumValue
+	: public std::enable_shared_from_this<EnumValue>
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -380,17 +431,20 @@ private:
 	struct init;
 
 public:
-	explicit EnumValue(init&& params);
+	explicit EnumValue(init && params);
 
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<EnumValue> Make(
-		std::string_view name, std::string_view description,
-		std::optional<std::string_view> deprecationReason);
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] static std::shared_ptr<EnumValue> Make(
+		std::string_view name,
+		std::string_view description,
+		std::optional<std::string_view>
+			deprecationReason);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::optional<std::string_view>& deprecationReason()
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view description()
 		const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] const std::optional<std::string_view>&
+	deprecationReason() const noexcept;
 
 private:
 	const std::string_view _name;
@@ -398,7 +452,8 @@ private:
 	const std::optional<std::string_view> _deprecationReason;
 };
 
-class [[nodiscard]] Directive : public std::enable_shared_from_this<Directive>
+class [[nodiscard("unnecessary construction")]] Directive
+	: public std::enable_shared_from_this<Directive>
 {
 private:
 	// Use a private constructor parameter type to enable std::make_shared inside of the static Make
@@ -406,21 +461,26 @@ private:
 	struct init;
 
 public:
-	explicit Directive(init&& params);
+	explicit Directive(init && params);
 
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] static std::shared_ptr<Directive> Make(
-		std::string_view name, std::string_view description,
-		std::vector<introspection::DirectiveLocation>&& locations,
-		std::vector<std::shared_ptr<const InputValue>>&& args, bool isRepeatable);
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] static std::shared_ptr<Directive> Make(
+		std::string_view name,
+		std::string_view description,
+		std::vector<introspection::DirectiveLocation> && locations,
+		std::vector<std::shared_ptr<const InputValue>> && args,
+		bool isRepeatable);
 
 	// Accessors
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view name() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] std::string_view description() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<introspection::DirectiveLocation>&
-	locations() const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] const std::vector<std::shared_ptr<const InputValue>>& args()
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view name() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] std::string_view description()
 		const noexcept;
-	GRAPHQLSERVICE_EXPORT [[nodiscard]] bool isRepeatable() const noexcept;
+	GRAPHQLSERVICE_EXPORT
+		[[nodiscard("unnecessary call")]] const std::vector<introspection::DirectiveLocation>&
+		locations() const noexcept;
+	GRAPHQLSERVICE_EXPORT
+		[[nodiscard("unnecessary call")]] const std::vector<std::shared_ptr<const InputValue>>&
+		args() const noexcept;
+	GRAPHQLSERVICE_EXPORT [[nodiscard("unnecessary call")]] bool isRepeatable() const noexcept;
 
 private:
 	const std::string_view _name;

--- a/include/graphqlservice/internal/SortedMap.h
+++ b/include/graphqlservice/internal/SortedMap.h
@@ -16,7 +16,7 @@
 namespace graphql::internal {
 
 template <class K, class V>
-struct [[nodiscard]] sorted_map_key
+struct [[nodiscard("unnecessary construction")]] sorted_map_key
 {
 	constexpr sorted_map_key(const std::pair<K, V>& entry) noexcept
 		: key { entry.first }
@@ -35,7 +35,7 @@ struct [[nodiscard]] sorted_map_key
 
 template <class Compare, class Iterator, class K,
 	class V = decltype(std::declval<Iterator>()->second)>
-[[nodiscard]] constexpr std::pair<Iterator, Iterator> sorted_map_equal_range(
+[[nodiscard("unnecessary call")]] constexpr std::pair<Iterator, Iterator> sorted_map_equal_range(
 	Iterator itrBegin, Iterator itrEnd, K key) noexcept
 {
 	return std::equal_range(itrBegin,
@@ -47,7 +47,8 @@ template <class Compare, class Iterator, class K,
 }
 
 template <class Compare, class Container, class K>
-[[nodiscard]] constexpr auto sorted_map_lookup(const Container& container, K key) noexcept
+[[nodiscard("unnecessary call")]] constexpr auto sorted_map_lookup(
+	const Container& container, K key) noexcept
 {
 	const auto [itr, itrEnd] =
 		sorted_map_equal_range<Compare>(container.begin(), container.end(), key);
@@ -56,7 +57,7 @@ template <class Compare, class Container, class K>
 }
 
 template <class K, class V, class Compare = std::less<K>>
-class [[nodiscard]] sorted_map
+class [[nodiscard("unnecessary construction")]] sorted_map
 {
 public:
 	using vector_type = std::vector<std::pair<K, V>>;
@@ -66,7 +67,7 @@ public:
 
 	constexpr sorted_map() noexcept = default;
 	constexpr sorted_map(const sorted_map& other) = default;
-	sorted_map(sorted_map&& other) noexcept = default;
+	sorted_map(sorted_map && other) noexcept = default;
 
 	constexpr sorted_map(std::initializer_list<std::pair<K, V>> init)
 		: _data { init }
@@ -81,7 +82,8 @@ public:
 	sorted_map& operator=(const sorted_map& rhs) = default;
 	sorted_map& operator=(sorted_map&& rhs) noexcept = default;
 
-	[[nodiscard]] constexpr bool operator==(const sorted_map& rhs) const noexcept
+	[[nodiscard("unnecessary call")]] constexpr bool operator==(const sorted_map& rhs)
+		const noexcept
 	{
 		return _data == rhs._data;
 	}
@@ -91,7 +93,7 @@ public:
 		_data.reserve(size);
 	}
 
-	[[nodiscard]] constexpr size_t capacity() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr size_t capacity() const noexcept
 	{
 		return _data.capacity();
 	}
@@ -101,37 +103,37 @@ public:
 		_data.clear();
 	}
 
-	[[nodiscard]] constexpr bool empty() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr bool empty() const noexcept
 	{
 		return _data.empty();
 	}
 
-	[[nodiscard]] constexpr size_t size() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr size_t size() const noexcept
 	{
 		return _data.size();
 	}
 
-	[[nodiscard]] constexpr const_iterator begin() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr const_iterator begin() const noexcept
 	{
 		return _data.begin();
 	}
 
-	[[nodiscard]] constexpr const_iterator end() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr const_iterator end() const noexcept
 	{
 		return _data.end();
 	}
 
-	[[nodiscard]] constexpr const_reverse_iterator rbegin() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr const_reverse_iterator rbegin() const noexcept
 	{
 		return _data.rbegin();
 	}
 
-	[[nodiscard]] constexpr const_reverse_iterator rend() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr const_reverse_iterator rend() const noexcept
 	{
 		return _data.rend();
 	}
 
-	[[nodiscard]] constexpr const_iterator find(K key) const noexcept
+	[[nodiscard("unnecessary call")]] constexpr const_iterator find(K key) const noexcept
 	{
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
 
@@ -139,7 +141,7 @@ public:
 	}
 
 	template <typename KeyArg>
-	[[nodiscard]] constexpr const_iterator find(KeyArg&& keyArg) const noexcept
+	[[nodiscard("unnecessary call")]] constexpr const_iterator find(KeyArg && keyArg) const noexcept
 	{
 		const K key { std::forward<KeyArg>(keyArg) };
 
@@ -147,7 +149,7 @@ public:
 	}
 
 	template <typename KeyArg, typename... ValueArgs>
-	std::pair<const_iterator, bool> emplace(KeyArg&& keyArg, ValueArgs&&... args) noexcept
+	std::pair<const_iterator, bool> emplace(KeyArg && keyArg, ValueArgs && ... args) noexcept
 	{
 		K key { std::forward<KeyArg>(keyArg) };
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
@@ -174,7 +176,7 @@ public:
 	}
 
 	template <typename KeyArg>
-	const_iterator erase(KeyArg&& keyArg) noexcept
+	const_iterator erase(KeyArg && keyArg) noexcept
 	{
 		const K key { std::forward<KeyArg>(keyArg) };
 
@@ -187,7 +189,7 @@ public:
 	}
 
 	template <typename KeyArg>
-	[[nodiscard]] V& operator[](KeyArg&& keyArg) noexcept
+	[[nodiscard("unnecessary call")]] V& operator[](KeyArg&& keyArg) noexcept
 	{
 		K key { std::forward<KeyArg>(keyArg) };
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
@@ -201,7 +203,7 @@ public:
 	}
 
 	template <typename KeyArg>
-	[[nodiscard]] V& at(KeyArg&& keyArg)
+	[[nodiscard("unnecessary call")]] V& at(KeyArg && keyArg)
 	{
 		const K key { std::forward<KeyArg>(keyArg) };
 		const auto [itr, itrEnd] = sorted_map_equal_range<Compare>(_data.begin(), _data.end(), key);
@@ -219,7 +221,7 @@ private:
 };
 
 template <class K, class Compare = std::less<K>>
-class [[nodiscard]] sorted_set
+class [[nodiscard("unnecessary construction")]] sorted_set
 {
 public:
 	using vector_type = std::vector<K>;
@@ -228,7 +230,7 @@ public:
 
 	constexpr sorted_set() noexcept = default;
 	constexpr sorted_set(const sorted_set& other) = default;
-	sorted_set(sorted_set&& other) noexcept = default;
+	sorted_set(sorted_set && other) noexcept = default;
 
 	constexpr sorted_set(std::initializer_list<K> init)
 		: _data { init }
@@ -241,7 +243,8 @@ public:
 	sorted_set& operator=(const sorted_set& rhs) = default;
 	sorted_set& operator=(sorted_set&& rhs) noexcept = default;
 
-	[[nodiscard]] constexpr bool operator==(const sorted_set& rhs) const noexcept
+	[[nodiscard("unnecessary call")]] constexpr bool operator==(const sorted_set& rhs)
+		const noexcept
 	{
 		return _data == rhs._data;
 	}
@@ -251,7 +254,7 @@ public:
 		_data.reserve(size);
 	}
 
-	[[nodiscard]] constexpr size_t capacity() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr size_t capacity() const noexcept
 	{
 		return _data.capacity();
 	}
@@ -261,37 +264,37 @@ public:
 		_data.clear();
 	}
 
-	[[nodiscard]] constexpr bool empty() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr bool empty() const noexcept
 	{
 		return _data.empty();
 	}
 
-	[[nodiscard]] constexpr size_t size() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr size_t size() const noexcept
 	{
 		return _data.size();
 	}
 
-	[[nodiscard]] constexpr const_iterator begin() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr const_iterator begin() const noexcept
 	{
 		return _data.begin();
 	}
 
-	[[nodiscard]] constexpr const_iterator end() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr const_iterator end() const noexcept
 	{
 		return _data.end();
 	}
 
-	[[nodiscard]] constexpr const_reverse_iterator rbegin() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr const_reverse_iterator rbegin() const noexcept
 	{
 		return _data.rbegin();
 	}
 
-	[[nodiscard]] constexpr const_reverse_iterator rend() const noexcept
+	[[nodiscard("unnecessary call")]] constexpr const_reverse_iterator rend() const noexcept
 	{
 		return _data.rend();
 	}
 
-	[[nodiscard]] constexpr const_iterator find(K key) const noexcept
+	[[nodiscard("unnecessary call")]] constexpr const_iterator find(K key) const noexcept
 	{
 		const auto [itr, itrEnd] = std::equal_range(begin(), end(), key, [](K lhs, K rhs) noexcept {
 			return Compare {}(lhs, rhs);
@@ -301,7 +304,7 @@ public:
 	}
 
 	template <typename Arg>
-	[[nodiscard]] constexpr const_iterator find(Arg&& arg) const noexcept
+	[[nodiscard("unnecessary call")]] constexpr const_iterator find(Arg && arg) const noexcept
 	{
 		const K key { std::forward<Arg>(arg) };
 
@@ -309,7 +312,7 @@ public:
 	}
 
 	template <typename Arg>
-	std::pair<const_iterator, bool> emplace(Arg&& key) noexcept
+	std::pair<const_iterator, bool> emplace(Arg && key) noexcept
 	{
 		const auto [itr, itrEnd] =
 			std::equal_range(_data.begin(), _data.end(), key, [](K lhs, K rhs) noexcept {
@@ -340,7 +343,7 @@ public:
 	}
 
 	template <typename Arg>
-	const_iterator erase(Arg&& arg) noexcept
+	const_iterator erase(Arg && arg) noexcept
 	{
 		const K key { std::forward<Arg>(arg) };
 
@@ -356,14 +359,13 @@ private:
 	vector_type _data;
 };
 
-struct [[nodiscard]] shorter_or_less
-{
-	[[nodiscard]] constexpr bool operator()(
-		std::string_view lhs, std::string_view rhs) const noexcept
-	{
-		return lhs.size() == rhs.size() ? lhs < rhs : lhs.size() < rhs.size();
-	}
-};
+struct [[nodiscard("unnecessary construction")]] shorter_or_less {
+	[[nodiscard("unnecessary call")]] constexpr bool operator()(
+		std::string_view lhs, std::string_view rhs)
+		const noexcept { return lhs.size() == rhs.size() ? lhs < rhs : lhs.size() < rhs.size();
+} // namespace graphql::internal
+}
+;
 
 template <class V>
 using string_view_map = sorted_map<std::string_view, V, shorter_or_less>;

--- a/include/graphqlservice/internal/SyntaxTree.h
+++ b/include/graphqlservice/internal/SyntaxTree.h
@@ -23,16 +23,16 @@ namespace graphql::peg {
 using namespace tao::graphqlpeg;
 namespace peginternal = tao::graphqlpeg::internal;
 
-class [[nodiscard]] ast_node : public parse_tree::basic_node<ast_node>
+class [[nodiscard("unnecessary construction")]] ast_node : public parse_tree::basic_node<ast_node>
 {
 public:
 	GRAPHQLPEG_EXPORT void remove_content() noexcept;
 
 	GRAPHQLPEG_EXPORT void unescaped_view(std::string_view unescaped) noexcept;
-	[[nodiscard]] GRAPHQLPEG_EXPORT std::string_view unescaped_view() const;
+	[[nodiscard("unnecessary call")]] GRAPHQLPEG_EXPORT std::string_view unescaped_view() const;
 
 	template <typename U>
-	[[nodiscard]] bool is_type() const noexcept
+	[[nodiscard("unnecessary call")]] bool is_type() const noexcept
 	{
 		const auto u = type_name<U>();
 
@@ -57,7 +57,7 @@ public:
 
 private:
 	template <typename U>
-	[[nodiscard]] static std::string_view type_name() noexcept
+	[[nodiscard("unnecessary call")]] static std::string_view type_name() noexcept
 	{
 		// This is cached in a static local variable per-specialization, but each module may have
 		// its own instance of the specialization and the local variable. Within a single module,
@@ -69,7 +69,7 @@ private:
 	}
 
 	template <typename U>
-	[[nodiscard]] static size_t type_hash() noexcept
+	[[nodiscard("unnecessary call")]] static size_t type_hash() noexcept
 	{
 		// This is cached in a static local variable per-specialization, but each module may have
 		// its own instance of the specialization and the local variable.

--- a/include/graphqlservice/introspection/DirectiveObject.h
+++ b/include/graphqlservice/introspection/DirectiveObject.h
@@ -12,31 +12,31 @@
 
 namespace graphql::introspection::object {
 
-class [[nodiscard]] Directive final
+class [[nodiscard("unnecessary construction")]] Directive final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveLocations(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveIsRepeatable(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveLocations(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveIsRepeatable(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsRepeatable() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getIsRepeatable() const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -44,27 +44,27 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getName() const override
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const override
 		{
 			return { _pimpl->getLocations() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const override
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsRepeatable() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getIsRepeatable() const override
 		{
 			return { _pimpl->getIsRepeatable() };
 		}
@@ -75,8 +75,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT explicit Directive(std::shared_ptr<introspection::Directive> pimpl) noexcept;

--- a/include/graphqlservice/introspection/EnumValueObject.h
+++ b/include/graphqlservice/introspection/EnumValueObject.h
@@ -12,29 +12,29 @@
 
 namespace graphql::introspection::object {
 
-class [[nodiscard]] EnumValue final
+class [[nodiscard("unnecessary construction")]] EnumValue final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -42,22 +42,22 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getName() const override
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getIsDeprecated() const override
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const override
 		{
 			return { _pimpl->getDeprecationReason() };
 		}
@@ -68,8 +68,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT explicit EnumValue(std::shared_ptr<introspection::EnumValue> pimpl) noexcept;

--- a/include/graphqlservice/introspection/FieldObject.h
+++ b/include/graphqlservice/introspection/FieldObject.h
@@ -12,33 +12,33 @@
 
 namespace graphql::introspection::object {
 
-class [[nodiscard]] Field final
+class [[nodiscard("unnecessary construction")]] Field final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -46,32 +46,32 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getName() const override
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const override
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Type>> getType() const override
 		{
 			return { _pimpl->getType() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getIsDeprecated() const override
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const override
 		{
 			return { _pimpl->getDeprecationReason() };
 		}
@@ -82,8 +82,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT explicit Field(std::shared_ptr<introspection::Field> pimpl) noexcept;

--- a/include/graphqlservice/introspection/InputValueObject.h
+++ b/include/graphqlservice/introspection/InputValueObject.h
@@ -12,29 +12,29 @@
 
 namespace graphql::introspection::object {
 
-class [[nodiscard]] InputValue final
+class [[nodiscard("unnecessary construction")]] InputValue final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDefaultValue(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDefaultValue(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -42,22 +42,22 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getName() const override
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Type>> getType() const override
 		{
 			return { _pimpl->getType() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const override
 		{
 			return { _pimpl->getDefaultValue() };
 		}
@@ -68,8 +68,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT explicit InputValue(std::shared_ptr<introspection::InputValue> pimpl) noexcept;

--- a/include/graphqlservice/introspection/IntrospectionSchema.h
+++ b/include/graphqlservice/introspection/IntrospectionSchema.h
@@ -34,7 +34,7 @@ enum class TypeKind
 	NON_NULL
 };
 
-[[nodiscard]] constexpr auto getTypeKindNames() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getTypeKindNames() noexcept
 {
 	using namespace std::literals;
 
@@ -50,7 +50,7 @@ enum class TypeKind
 	};
 }
 
-[[nodiscard]] constexpr auto getTypeKindValues() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getTypeKindValues() noexcept
 {
 	using namespace std::literals;
 
@@ -89,7 +89,7 @@ enum class DirectiveLocation
 	INPUT_FIELD_DEFINITION
 };
 
-[[nodiscard]] constexpr auto getDirectiveLocationNames() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getDirectiveLocationNames() noexcept
 {
 	using namespace std::literals;
 
@@ -116,7 +116,7 @@ enum class DirectiveLocation
 	};
 }
 
-[[nodiscard]] constexpr auto getDirectiveLocationValues() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getDirectiveLocationValues() noexcept
 {
 	using namespace std::literals;
 

--- a/include/graphqlservice/introspection/SchemaObject.h
+++ b/include/graphqlservice/introspection/SchemaObject.h
@@ -12,33 +12,33 @@
 
 namespace graphql::introspection::object {
 
-class [[nodiscard]] Schema final
+class [[nodiscard("unnecessary construction")]] Schema final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveTypes(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveQueryType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveMutationType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveSubscriptionType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDirectives(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveTypes(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveQueryType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveMutationType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveSubscriptionType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDirectives(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -46,32 +46,32 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const override
 		{
 			return { _pimpl->getTypes() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const override
 		{
 			return { _pimpl->getQueryType() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const override
 		{
 			return { _pimpl->getMutationType() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const override
 		{
 			return { _pimpl->getSubscriptionType() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const override
 		{
 			return { _pimpl->getDirectives() };
 		}
@@ -82,8 +82,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT explicit Schema(std::shared_ptr<introspection::Schema> pimpl) noexcept;

--- a/include/graphqlservice/introspection/TypeObject.h
+++ b/include/graphqlservice/introspection/TypeObject.h
@@ -12,41 +12,41 @@
 
 namespace graphql::introspection::object {
 
-class [[nodiscard]] Type final
+class [[nodiscard("unnecessary construction")]] Type final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveKind(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveFields(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveInterfaces(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolvePossibleTypes(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveEnumValues(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveInputFields(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveOfType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveSpecifiedByURL(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveKind(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveFields(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveInterfaces(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolvePossibleTypes(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveEnumValues(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveInputFields(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveOfType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveSpecifiedByURL(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::AwaitableScalar<TypeKind> getKind() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getName() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getOfType() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<TypeKind> getKind() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getName() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Type>> getOfType() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -54,52 +54,52 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<TypeKind> getKind() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<TypeKind> getKind() const override
 		{
 			return { _pimpl->getKind() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getName() const override
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const override
 		{
 			return { _pimpl->getFields(std::move(includeDeprecatedArg)) };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const override
 		{
 			return { _pimpl->getInterfaces() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const override
 		{
 			return { _pimpl->getPossibleTypes() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const override
 		{
 			return { _pimpl->getEnumValues(std::move(includeDeprecatedArg)) };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const override
 		{
 			return { _pimpl->getInputFields() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getOfType() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Type>> getOfType() const override
 		{
 			return { _pimpl->getOfType() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const override
 		{
 			return { _pimpl->getSpecifiedByURL() };
 		}
@@ -110,8 +110,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT explicit Type(std::shared_ptr<introspection::Type> pimpl) noexcept;

--- a/samples/client/benchmark/BenchmarkClient.cpp
+++ b/samples/client/benchmark/BenchmarkClient.cpp
@@ -201,22 +201,22 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
-[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetRequestText() noexcept
 {
 	return benchmark::GetRequestText();
 }
 
-[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+[[nodiscard("unnecessary call")]] const peg::ast& Traits::GetRequestObject() noexcept
 {
 	return benchmark::GetRequestObject();
 }
 
-[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetOperationName() noexcept
 {
 	return Query::GetOperationName();
 }
 
-[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+[[nodiscard("unnecessary conversion")]] Traits::Response Traits::parseResponse(response::Value&& response)
 {
 	return Query::parseResponse(std::move(response));
 }

--- a/samples/client/benchmark/BenchmarkClient.h
+++ b/samples/client/benchmark/BenchmarkClient.h
@@ -50,10 +50,10 @@ namespace graphql::client {
 namespace benchmark {
 
 // Return the original text of the request document.
-[[nodiscard]] const std::string& GetRequestText() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetRequestText() noexcept;
 
 // Return a pre-parsed, pre-validated request object.
-[[nodiscard]] const peg::ast& GetRequestObject() noexcept;
+[[nodiscard("unnecessary call")]] const peg::ast& GetRequestObject() noexcept;
 
 } // namespace benchmark
 
@@ -63,20 +63,20 @@ using benchmark::GetRequestText;
 using benchmark::GetRequestObject;
 
 // Return the name of this operation in the shared request document.
-[[nodiscard]] const std::string& GetOperationName() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetOperationName() noexcept;
 
-struct [[nodiscard]] Response
+struct [[nodiscard("unnecessary construction")]] Response
 {
-	struct [[nodiscard]] appointments_AppointmentConnection
+	struct [[nodiscard("unnecessary construction")]] appointments_AppointmentConnection
 	{
-		struct [[nodiscard]] pageInfo_PageInfo
+		struct [[nodiscard("unnecessary construction")]] pageInfo_PageInfo
 		{
 			bool hasNextPage {};
 		};
 
-		struct [[nodiscard]] edges_AppointmentEdge
+		struct [[nodiscard("unnecessary construction")]] edges_AppointmentEdge
 		{
-			struct [[nodiscard]] node_Appointment
+			struct [[nodiscard("unnecessary construction")]] node_Appointment
 			{
 				response::IdType id {};
 				std::optional<response::Value> when {};
@@ -94,17 +94,17 @@ struct [[nodiscard]] Response
 	appointments_AppointmentConnection appointments {};
 };
 
-[[nodiscard]] Response parseResponse(response::Value&& response);
+[[nodiscard("unnecessary conversion")]] Response parseResponse(response::Value&& response);
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept;
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
-	[[nodiscard]] static const std::string& GetOperationName() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard("unnecessary call")]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetOperationName() noexcept;
 
 	using Response = Query::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response);
+	[[nodiscard("unnecessary conversion")]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::Query

--- a/samples/client/multiple/MultipleQueriesClient.cpp
+++ b/samples/client/multiple/MultipleQueriesClient.cpp
@@ -123,6 +123,7 @@ const peg::ast& GetRequestObject() noexcept
 
 CompleteTaskInput::CompleteTaskInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 CompleteTaskInput::CompleteTaskInput(
@@ -155,6 +156,7 @@ CompleteTaskInput::CompleteTaskInput(CompleteTaskInput&& other) noexcept
 
 CompleteTaskInput::~CompleteTaskInput()
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 CompleteTaskInput& CompleteTaskInput::operator=(const CompleteTaskInput& other)
@@ -292,22 +294,22 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
-[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetRequestText() noexcept
 {
 	return multiple::GetRequestText();
 }
 
-[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+[[nodiscard("unnecessary call")]] const peg::ast& Traits::GetRequestObject() noexcept
 {
 	return multiple::GetRequestObject();
 }
 
-[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetOperationName() noexcept
 {
 	return Appointments::GetOperationName();
 }
 
-[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+[[nodiscard("unnecessary conversion")]] Traits::Response Traits::parseResponse(response::Value&& response)
 {
 	return Appointments::parseResponse(std::move(response));
 }
@@ -425,22 +427,22 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
-[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetRequestText() noexcept
 {
 	return multiple::GetRequestText();
 }
 
-[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+[[nodiscard("unnecessary call")]] const peg::ast& Traits::GetRequestObject() noexcept
 {
 	return multiple::GetRequestObject();
 }
 
-[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetOperationName() noexcept
 {
 	return Tasks::GetOperationName();
 }
 
-[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+[[nodiscard("unnecessary conversion")]] Traits::Response Traits::parseResponse(response::Value&& response)
 {
 	return Tasks::parseResponse(std::move(response));
 }
@@ -558,22 +560,22 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
-[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetRequestText() noexcept
 {
 	return multiple::GetRequestText();
 }
 
-[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+[[nodiscard("unnecessary call")]] const peg::ast& Traits::GetRequestObject() noexcept
 {
 	return multiple::GetRequestObject();
 }
 
-[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetOperationName() noexcept
 {
 	return UnreadCounts::GetOperationName();
 }
 
-[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+[[nodiscard("unnecessary conversion")]] Traits::Response Traits::parseResponse(response::Value&& response)
 {
 	return UnreadCounts::parseResponse(std::move(response));
 }
@@ -699,22 +701,22 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
-[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetRequestText() noexcept
 {
 	return multiple::GetRequestText();
 }
 
-[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+[[nodiscard("unnecessary call")]] const peg::ast& Traits::GetRequestObject() noexcept
 {
 	return multiple::GetRequestObject();
 }
 
-[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetOperationName() noexcept
 {
 	return Miscellaneous::GetOperationName();
 }
 
-[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+[[nodiscard("unnecessary conversion")]] Traits::Response Traits::parseResponse(response::Value&& response)
 {
 	return Miscellaneous::parseResponse(std::move(response));
 }
@@ -850,27 +852,27 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
-[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetRequestText() noexcept
 {
 	return multiple::GetRequestText();
 }
 
-[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+[[nodiscard("unnecessary call")]] const peg::ast& Traits::GetRequestObject() noexcept
 {
 	return multiple::GetRequestObject();
 }
 
-[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetOperationName() noexcept
 {
 	return CompleteTaskMutation::GetOperationName();
 }
 
-[[nodiscard]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
+[[nodiscard("unnecessary conversion")]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
 {
 	return CompleteTaskMutation::serializeVariables(std::move(variables));
 }
 
-[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+[[nodiscard("unnecessary conversion")]] Traits::Response Traits::parseResponse(response::Value&& response)
 {
 	return CompleteTaskMutation::parseResponse(std::move(response));
 }

--- a/samples/client/multiple/MultipleQueriesClient.h
+++ b/samples/client/multiple/MultipleQueriesClient.h
@@ -112,12 +112,12 @@ namespace graphql::client {
 namespace multiple {
 
 // Return the original text of the request document.
-[[nodiscard]] const std::string& GetRequestText() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetRequestText() noexcept;
 
 // Return a pre-parsed, pre-validated request object.
-[[nodiscard]] const peg::ast& GetRequestObject() noexcept;
+[[nodiscard("unnecessary call")]] const peg::ast& GetRequestObject() noexcept;
 
-enum class [[nodiscard]] TaskState
+enum class [[nodiscard("unnecessary conversion")]] TaskState
 {
 	Unassigned,
 	New,
@@ -125,7 +125,7 @@ enum class [[nodiscard]] TaskState
 	Complete,
 };
 
-struct [[nodiscard]] CompleteTaskInput
+struct [[nodiscard("unnecessary construction")]] CompleteTaskInput
 {
 	explicit CompleteTaskInput() noexcept;
 	explicit CompleteTaskInput(
@@ -154,15 +154,15 @@ using multiple::GetRequestText;
 using multiple::GetRequestObject;
 
 // Return the name of this operation in the shared request document.
-[[nodiscard]] const std::string& GetOperationName() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetOperationName() noexcept;
 
-struct [[nodiscard]] Response
+struct [[nodiscard("unnecessary construction")]] Response
 {
-	struct [[nodiscard]] appointments_AppointmentConnection
+	struct [[nodiscard("unnecessary construction")]] appointments_AppointmentConnection
 	{
-		struct [[nodiscard]] edges_AppointmentEdge
+		struct [[nodiscard("unnecessary construction")]] edges_AppointmentEdge
 		{
-			struct [[nodiscard]] node_Appointment
+			struct [[nodiscard("unnecessary construction")]] node_Appointment
 			{
 				response::IdType id {};
 				std::optional<std::string> subject {};
@@ -180,17 +180,17 @@ struct [[nodiscard]] Response
 	appointments_AppointmentConnection appointments {};
 };
 
-[[nodiscard]] Response parseResponse(response::Value&& response);
+[[nodiscard("unnecessary conversion")]] Response parseResponse(response::Value&& response);
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept;
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
-	[[nodiscard]] static const std::string& GetOperationName() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard("unnecessary call")]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetOperationName() noexcept;
 
 	using Response = Appointments::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response);
+	[[nodiscard("unnecessary conversion")]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::Appointments
@@ -201,15 +201,15 @@ using multiple::GetRequestText;
 using multiple::GetRequestObject;
 
 // Return the name of this operation in the shared request document.
-[[nodiscard]] const std::string& GetOperationName() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetOperationName() noexcept;
 
-struct [[nodiscard]] Response
+struct [[nodiscard("unnecessary construction")]] Response
 {
-	struct [[nodiscard]] tasks_TaskConnection
+	struct [[nodiscard("unnecessary construction")]] tasks_TaskConnection
 	{
-		struct [[nodiscard]] edges_TaskEdge
+		struct [[nodiscard("unnecessary construction")]] edges_TaskEdge
 		{
-			struct [[nodiscard]] node_Task
+			struct [[nodiscard("unnecessary construction")]] node_Task
 			{
 				response::IdType id {};
 				std::optional<std::string> title {};
@@ -226,17 +226,17 @@ struct [[nodiscard]] Response
 	tasks_TaskConnection tasks {};
 };
 
-[[nodiscard]] Response parseResponse(response::Value&& response);
+[[nodiscard("unnecessary conversion")]] Response parseResponse(response::Value&& response);
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept;
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
-	[[nodiscard]] static const std::string& GetOperationName() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard("unnecessary call")]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetOperationName() noexcept;
 
 	using Response = Tasks::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response);
+	[[nodiscard("unnecessary conversion")]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::Tasks
@@ -247,15 +247,15 @@ using multiple::GetRequestText;
 using multiple::GetRequestObject;
 
 // Return the name of this operation in the shared request document.
-[[nodiscard]] const std::string& GetOperationName() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetOperationName() noexcept;
 
-struct [[nodiscard]] Response
+struct [[nodiscard("unnecessary construction")]] Response
 {
-	struct [[nodiscard]] unreadCounts_FolderConnection
+	struct [[nodiscard("unnecessary construction")]] unreadCounts_FolderConnection
 	{
-		struct [[nodiscard]] edges_FolderEdge
+		struct [[nodiscard("unnecessary construction")]] edges_FolderEdge
 		{
-			struct [[nodiscard]] node_Folder
+			struct [[nodiscard("unnecessary construction")]] node_Folder
 			{
 				response::IdType id {};
 				std::optional<std::string> name {};
@@ -272,17 +272,17 @@ struct [[nodiscard]] Response
 	unreadCounts_FolderConnection unreadCounts {};
 };
 
-[[nodiscard]] Response parseResponse(response::Value&& response);
+[[nodiscard("unnecessary conversion")]] Response parseResponse(response::Value&& response);
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept;
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
-	[[nodiscard]] static const std::string& GetOperationName() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard("unnecessary call")]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetOperationName() noexcept;
 
 	using Response = UnreadCounts::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response);
+	[[nodiscard("unnecessary conversion")]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::UnreadCounts
@@ -293,13 +293,13 @@ using multiple::GetRequestText;
 using multiple::GetRequestObject;
 
 // Return the name of this operation in the shared request document.
-[[nodiscard]] const std::string& GetOperationName() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetOperationName() noexcept;
 
 using multiple::TaskState;
 
-struct [[nodiscard]] Response
+struct [[nodiscard("unnecessary construction")]] Response
 {
-	struct [[nodiscard]] anyType_UnionType
+	struct [[nodiscard("unnecessary construction")]] anyType_UnionType
 	{
 		std::string _typename {};
 		response::IdType id {};
@@ -315,17 +315,17 @@ struct [[nodiscard]] Response
 	std::optional<std::string> default_ {};
 };
 
-[[nodiscard]] Response parseResponse(response::Value&& response);
+[[nodiscard("unnecessary conversion")]] Response parseResponse(response::Value&& response);
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept;
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
-	[[nodiscard]] static const std::string& GetOperationName() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard("unnecessary call")]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetOperationName() noexcept;
 
 	using Response = Miscellaneous::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response);
+	[[nodiscard("unnecessary conversion")]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::Miscellaneous
@@ -336,25 +336,25 @@ using multiple::GetRequestText;
 using multiple::GetRequestObject;
 
 // Return the name of this operation in the shared request document.
-[[nodiscard]] const std::string& GetOperationName() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetOperationName() noexcept;
 
 using multiple::TaskState;
 
 using multiple::CompleteTaskInput;
 
-struct [[nodiscard]] Variables
+struct [[nodiscard("unnecessary construction")]] Variables
 {
 	std::unique_ptr<CompleteTaskInput> input {};
 	bool skipClientMutationId {};
 };
 
-[[nodiscard]] response::Value serializeVariables(Variables&& variables);
+[[nodiscard("unnecessary conversion")]] response::Value serializeVariables(Variables&& variables);
 
-struct [[nodiscard]] Response
+struct [[nodiscard("unnecessary construction")]] Response
 {
-	struct [[nodiscard]] completedTask_CompleteTaskPayload
+	struct [[nodiscard("unnecessary construction")]] completedTask_CompleteTaskPayload
 	{
-		struct [[nodiscard]] completedTask_Task
+		struct [[nodiscard("unnecessary construction")]] completedTask_Task
 		{
 			response::IdType completedTaskId {};
 			std::optional<std::string> title {};
@@ -368,21 +368,21 @@ struct [[nodiscard]] Response
 	completedTask_CompleteTaskPayload completedTask {};
 };
 
-[[nodiscard]] Response parseResponse(response::Value&& response);
+[[nodiscard("unnecessary conversion")]] Response parseResponse(response::Value&& response);
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept;
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
-	[[nodiscard]] static const std::string& GetOperationName() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard("unnecessary call")]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetOperationName() noexcept;
 
 	using Variables = CompleteTaskMutation::Variables;
 
-	[[nodiscard]] static response::Value serializeVariables(Variables&& variables);
+	[[nodiscard("unnecessary conversion")]] static response::Value serializeVariables(Variables&& variables);
 
 	using Response = CompleteTaskMutation::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response);
+	[[nodiscard("unnecessary conversion")]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace mutation::CompleteTaskMutation

--- a/samples/client/mutate/MutateClient.cpp
+++ b/samples/client/mutate/MutateClient.cpp
@@ -56,6 +56,7 @@ const peg::ast& GetRequestObject() noexcept
 
 CompleteTaskInput::CompleteTaskInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 CompleteTaskInput::CompleteTaskInput(
@@ -88,6 +89,7 @@ CompleteTaskInput::CompleteTaskInput(CompleteTaskInput&& other) noexcept
 
 CompleteTaskInput::~CompleteTaskInput()
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 CompleteTaskInput& CompleteTaskInput::operator=(const CompleteTaskInput& other)
@@ -265,27 +267,27 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
-[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetRequestText() noexcept
 {
 	return mutate::GetRequestText();
 }
 
-[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+[[nodiscard("unnecessary call")]] const peg::ast& Traits::GetRequestObject() noexcept
 {
 	return mutate::GetRequestObject();
 }
 
-[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetOperationName() noexcept
 {
 	return CompleteTaskMutation::GetOperationName();
 }
 
-[[nodiscard]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
+[[nodiscard("unnecessary conversion")]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
 {
 	return CompleteTaskMutation::serializeVariables(std::move(variables));
 }
 
-[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+[[nodiscard("unnecessary conversion")]] Traits::Response Traits::parseResponse(response::Value&& response)
 {
 	return CompleteTaskMutation::parseResponse(std::move(response));
 }

--- a/samples/client/mutate/MutateClient.h
+++ b/samples/client/mutate/MutateClient.h
@@ -45,12 +45,12 @@ namespace graphql::client {
 namespace mutate {
 
 // Return the original text of the request document.
-[[nodiscard]] const std::string& GetRequestText() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetRequestText() noexcept;
 
 // Return a pre-parsed, pre-validated request object.
-[[nodiscard]] const peg::ast& GetRequestObject() noexcept;
+[[nodiscard("unnecessary call")]] const peg::ast& GetRequestObject() noexcept;
 
-enum class [[nodiscard]] TaskState
+enum class [[nodiscard("unnecessary conversion")]] TaskState
 {
 	Unassigned,
 	New,
@@ -58,7 +58,7 @@ enum class [[nodiscard]] TaskState
 	Complete,
 };
 
-struct [[nodiscard]] CompleteTaskInput
+struct [[nodiscard("unnecessary construction")]] CompleteTaskInput
 {
 	explicit CompleteTaskInput() noexcept;
 	explicit CompleteTaskInput(
@@ -87,25 +87,25 @@ using mutate::GetRequestText;
 using mutate::GetRequestObject;
 
 // Return the name of this operation in the shared request document.
-[[nodiscard]] const std::string& GetOperationName() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetOperationName() noexcept;
 
 using mutate::TaskState;
 
 using mutate::CompleteTaskInput;
 
-struct [[nodiscard]] Variables
+struct [[nodiscard("unnecessary construction")]] Variables
 {
 	std::unique_ptr<CompleteTaskInput> input {};
 	bool skipClientMutationId {};
 };
 
-[[nodiscard]] response::Value serializeVariables(Variables&& variables);
+[[nodiscard("unnecessary conversion")]] response::Value serializeVariables(Variables&& variables);
 
-struct [[nodiscard]] Response
+struct [[nodiscard("unnecessary construction")]] Response
 {
-	struct [[nodiscard]] completedTask_CompleteTaskPayload
+	struct [[nodiscard("unnecessary construction")]] completedTask_CompleteTaskPayload
 	{
-		struct [[nodiscard]] completedTask_Task
+		struct [[nodiscard("unnecessary construction")]] completedTask_Task
 		{
 			response::IdType completedTaskId {};
 			std::optional<std::string> title {};
@@ -119,21 +119,21 @@ struct [[nodiscard]] Response
 	completedTask_CompleteTaskPayload completedTask {};
 };
 
-[[nodiscard]] Response parseResponse(response::Value&& response);
+[[nodiscard("unnecessary conversion")]] Response parseResponse(response::Value&& response);
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept;
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
-	[[nodiscard]] static const std::string& GetOperationName() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard("unnecessary call")]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetOperationName() noexcept;
 
 	using Variables = CompleteTaskMutation::Variables;
 
-	[[nodiscard]] static response::Value serializeVariables(Variables&& variables);
+	[[nodiscard("unnecessary conversion")]] static response::Value serializeVariables(Variables&& variables);
 
 	using Response = CompleteTaskMutation::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response);
+	[[nodiscard("unnecessary conversion")]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace mutation::CompleteTaskMutation

--- a/samples/client/nestedinput/NestedInputClient.cpp
+++ b/samples/client/nestedinput/NestedInputClient.cpp
@@ -50,6 +50,7 @@ const peg::ast& GetRequestObject() noexcept
 
 InputA::InputA() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 InputA::InputA(
@@ -70,6 +71,7 @@ InputA::InputA(InputA&& other) noexcept
 
 InputA::~InputA()
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 InputA& InputA::operator=(const InputA& other)
@@ -86,6 +88,7 @@ InputA& InputA::operator=(InputA&& other) noexcept
 
 InputB::InputB() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 InputB::InputB(
@@ -106,6 +109,7 @@ InputB::InputB(InputB&& other) noexcept
 
 InputB::~InputB()
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 InputB& InputB::operator=(const InputB& other)
@@ -122,6 +126,7 @@ InputB& InputB::operator=(InputB&& other) noexcept
 
 InputABCD::InputABCD() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 InputABCD::InputABCD(
@@ -158,6 +163,7 @@ InputABCD::InputABCD(InputABCD&& other) noexcept
 
 InputABCD::~InputABCD()
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 InputABCD& InputABCD::operator=(const InputABCD& other)
@@ -178,6 +184,7 @@ InputABCD& InputABCD::operator=(InputABCD&& other) noexcept
 
 InputBC::InputBC() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 InputBC::InputBC(
@@ -202,6 +209,7 @@ InputBC::InputBC(InputBC&& other) noexcept
 
 InputBC::~InputBC()
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 InputBC& InputBC::operator=(const InputBC& other)
@@ -349,27 +357,27 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
-[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetRequestText() noexcept
 {
 	return nestedinput::GetRequestText();
 }
 
-[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+[[nodiscard("unnecessary call")]] const peg::ast& Traits::GetRequestObject() noexcept
 {
 	return nestedinput::GetRequestObject();
 }
 
-[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetOperationName() noexcept
 {
 	return testQuery::GetOperationName();
 }
 
-[[nodiscard]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
+[[nodiscard("unnecessary conversion")]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
 {
 	return testQuery::serializeVariables(std::move(variables));
 }
 
-[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+[[nodiscard("unnecessary conversion")]] Traits::Response Traits::parseResponse(response::Value&& response)
 {
 	return testQuery::parseResponse(std::move(response));
 }

--- a/samples/client/nestedinput/NestedInputClient.h
+++ b/samples/client/nestedinput/NestedInputClient.h
@@ -39,12 +39,12 @@ namespace graphql::client {
 namespace nestedinput {
 
 // Return the original text of the request document.
-[[nodiscard]] const std::string& GetRequestText() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetRequestText() noexcept;
 
 // Return a pre-parsed, pre-validated request object.
-[[nodiscard]] const peg::ast& GetRequestObject() noexcept;
+[[nodiscard("unnecessary call")]] const peg::ast& GetRequestObject() noexcept;
 
-struct [[nodiscard]] InputA
+struct [[nodiscard("unnecessary construction")]] InputA
 {
 	explicit InputA() noexcept;
 	explicit InputA(
@@ -59,7 +59,7 @@ struct [[nodiscard]] InputA
 	bool a {};
 };
 
-struct [[nodiscard]] InputB
+struct [[nodiscard("unnecessary construction")]] InputB
 {
 	explicit InputB() noexcept;
 	explicit InputB(
@@ -76,7 +76,7 @@ struct [[nodiscard]] InputB
 
 struct InputBC;
 
-struct [[nodiscard]] InputABCD
+struct [[nodiscard("unnecessary construction")]] InputABCD
 {
 	explicit InputABCD() noexcept;
 	explicit InputABCD(
@@ -99,7 +99,7 @@ struct [[nodiscard]] InputABCD
 	int value {};
 };
 
-struct [[nodiscard]] InputBC
+struct [[nodiscard("unnecessary construction")]] InputBC
 {
 	explicit InputBC() noexcept;
 	explicit InputBC(
@@ -124,25 +124,25 @@ using nestedinput::GetRequestText;
 using nestedinput::GetRequestObject;
 
 // Return the name of this operation in the shared request document.
-[[nodiscard]] const std::string& GetOperationName() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetOperationName() noexcept;
 
 using nestedinput::InputA;
 using nestedinput::InputB;
 using nestedinput::InputABCD;
 using nestedinput::InputBC;
 
-struct [[nodiscard]] Variables
+struct [[nodiscard("unnecessary construction")]] Variables
 {
 	InputABCD stream {};
 };
 
-[[nodiscard]] response::Value serializeVariables(Variables&& variables);
+[[nodiscard("unnecessary conversion")]] response::Value serializeVariables(Variables&& variables);
 
-struct [[nodiscard]] Response
+struct [[nodiscard("unnecessary construction")]] Response
 {
-	struct [[nodiscard]] control_Control
+	struct [[nodiscard("unnecessary construction")]] control_Control
 	{
-		struct [[nodiscard]] test_Output
+		struct [[nodiscard("unnecessary construction")]] test_Output
 		{
 			std::optional<bool> id {};
 		};
@@ -153,21 +153,21 @@ struct [[nodiscard]] Response
 	control_Control control {};
 };
 
-[[nodiscard]] Response parseResponse(response::Value&& response);
+[[nodiscard("unnecessary conversion")]] Response parseResponse(response::Value&& response);
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept;
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
-	[[nodiscard]] static const std::string& GetOperationName() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard("unnecessary call")]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetOperationName() noexcept;
 
 	using Variables = testQuery::Variables;
 
-	[[nodiscard]] static response::Value serializeVariables(Variables&& variables);
+	[[nodiscard("unnecessary conversion")]] static response::Value serializeVariables(Variables&& variables);
 
 	using Response = testQuery::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response);
+	[[nodiscard("unnecessary conversion")]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::testQuery

--- a/samples/client/query/QueryClient.cpp
+++ b/samples/client/query/QueryClient.cpp
@@ -488,22 +488,22 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
-[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetRequestText() noexcept
 {
 	return query::GetRequestText();
 }
 
-[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+[[nodiscard("unnecessary call")]] const peg::ast& Traits::GetRequestObject() noexcept
 {
 	return query::GetRequestObject();
 }
 
-[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetOperationName() noexcept
 {
 	return Query::GetOperationName();
 }
 
-[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+[[nodiscard("unnecessary conversion")]] Traits::Response Traits::parseResponse(response::Value&& response)
 {
 	return Query::parseResponse(std::move(response));
 }

--- a/samples/client/query/QueryClient.h
+++ b/samples/client/query/QueryClient.h
@@ -93,12 +93,12 @@ namespace graphql::client {
 namespace query {
 
 // Return the original text of the request document.
-[[nodiscard]] const std::string& GetRequestText() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetRequestText() noexcept;
 
 // Return a pre-parsed, pre-validated request object.
-[[nodiscard]] const peg::ast& GetRequestObject() noexcept;
+[[nodiscard("unnecessary call")]] const peg::ast& GetRequestObject() noexcept;
 
-enum class [[nodiscard]] TaskState
+enum class [[nodiscard("unnecessary conversion")]] TaskState
 {
 	Unassigned,
 	New,
@@ -114,17 +114,17 @@ using query::GetRequestText;
 using query::GetRequestObject;
 
 // Return the name of this operation in the shared request document.
-[[nodiscard]] const std::string& GetOperationName() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetOperationName() noexcept;
 
 using query::TaskState;
 
-struct [[nodiscard]] Response
+struct [[nodiscard("unnecessary construction")]] Response
 {
-	struct [[nodiscard]] appointments_AppointmentConnection
+	struct [[nodiscard("unnecessary construction")]] appointments_AppointmentConnection
 	{
-		struct [[nodiscard]] edges_AppointmentEdge
+		struct [[nodiscard("unnecessary construction")]] edges_AppointmentEdge
 		{
-			struct [[nodiscard]] node_Appointment
+			struct [[nodiscard("unnecessary construction")]] node_Appointment
 			{
 				response::IdType id {};
 				std::optional<std::string> subject {};
@@ -139,11 +139,11 @@ struct [[nodiscard]] Response
 		std::optional<std::vector<std::optional<edges_AppointmentEdge>>> edges {};
 	};
 
-	struct [[nodiscard]] tasks_TaskConnection
+	struct [[nodiscard("unnecessary construction")]] tasks_TaskConnection
 	{
-		struct [[nodiscard]] edges_TaskEdge
+		struct [[nodiscard("unnecessary construction")]] edges_TaskEdge
 		{
-			struct [[nodiscard]] node_Task
+			struct [[nodiscard("unnecessary construction")]] node_Task
 			{
 				response::IdType id {};
 				std::optional<std::string> title {};
@@ -157,11 +157,11 @@ struct [[nodiscard]] Response
 		std::optional<std::vector<std::optional<edges_TaskEdge>>> edges {};
 	};
 
-	struct [[nodiscard]] unreadCounts_FolderConnection
+	struct [[nodiscard("unnecessary construction")]] unreadCounts_FolderConnection
 	{
-		struct [[nodiscard]] edges_FolderEdge
+		struct [[nodiscard("unnecessary construction")]] edges_FolderEdge
 		{
-			struct [[nodiscard]] node_Folder
+			struct [[nodiscard("unnecessary construction")]] node_Folder
 			{
 				response::IdType id {};
 				std::optional<std::string> name {};
@@ -175,7 +175,7 @@ struct [[nodiscard]] Response
 		std::optional<std::vector<std::optional<edges_FolderEdge>>> edges {};
 	};
 
-	struct [[nodiscard]] anyType_UnionType
+	struct [[nodiscard("unnecessary construction")]] anyType_UnionType
 	{
 		std::string _typename {};
 		response::IdType id {};
@@ -194,17 +194,17 @@ struct [[nodiscard]] Response
 	std::optional<std::string> default_ {};
 };
 
-[[nodiscard]] Response parseResponse(response::Value&& response);
+[[nodiscard("unnecessary conversion")]] Response parseResponse(response::Value&& response);
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept;
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
-	[[nodiscard]] static const std::string& GetOperationName() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard("unnecessary call")]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetOperationName() noexcept;
 
 	using Response = Query::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response);
+	[[nodiscard("unnecessary conversion")]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::Query

--- a/samples/client/subscribe/SubscribeClient.cpp
+++ b/samples/client/subscribe/SubscribeClient.cpp
@@ -123,22 +123,22 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
-[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetRequestText() noexcept
 {
 	return subscribe::GetRequestText();
 }
 
-[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+[[nodiscard("unnecessary call")]] const peg::ast& Traits::GetRequestObject() noexcept
 {
 	return subscribe::GetRequestObject();
 }
 
-[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetOperationName() noexcept
 {
 	return TestSubscription::GetOperationName();
 }
 
-[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+[[nodiscard("unnecessary conversion")]] Traits::Response Traits::parseResponse(response::Value&& response)
 {
 	return TestSubscription::parseResponse(std::move(response));
 }

--- a/samples/client/subscribe/SubscribeClient.h
+++ b/samples/client/subscribe/SubscribeClient.h
@@ -43,10 +43,10 @@ namespace graphql::client {
 namespace subscribe {
 
 // Return the original text of the request document.
-[[nodiscard]] const std::string& GetRequestText() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetRequestText() noexcept;
 
 // Return a pre-parsed, pre-validated request object.
-[[nodiscard]] const peg::ast& GetRequestObject() noexcept;
+[[nodiscard("unnecessary call")]] const peg::ast& GetRequestObject() noexcept;
 
 } // namespace subscribe
 
@@ -56,11 +56,11 @@ using subscribe::GetRequestText;
 using subscribe::GetRequestObject;
 
 // Return the name of this operation in the shared request document.
-[[nodiscard]] const std::string& GetOperationName() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetOperationName() noexcept;
 
-struct [[nodiscard]] Response
+struct [[nodiscard("unnecessary construction")]] Response
 {
-	struct [[nodiscard]] nextAppointment_Appointment
+	struct [[nodiscard("unnecessary construction")]] nextAppointment_Appointment
 	{
 		response::IdType nextAppointmentId {};
 		std::optional<response::Value> when {};
@@ -71,17 +71,17 @@ struct [[nodiscard]] Response
 	std::optional<nextAppointment_Appointment> nextAppointment {};
 };
 
-[[nodiscard]] Response parseResponse(response::Value&& response);
+[[nodiscard("unnecessary conversion")]] Response parseResponse(response::Value&& response);
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept;
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
-	[[nodiscard]] static const std::string& GetOperationName() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard("unnecessary call")]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetOperationName() noexcept;
 
 	using Response = TestSubscription::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response);
+	[[nodiscard("unnecessary conversion")]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace subscription::TestSubscription

--- a/samples/learn/CMakeLists.txt
+++ b/samples/learn/CMakeLists.txt
@@ -13,7 +13,6 @@ add_library(star_wars STATIC
   MutationData.cpp
   StarWarsData.cpp)
 target_link_libraries(star_wars PUBLIC learn_schema)
-target_include_directories(star_wars PUBLIC star_wars)
 target_include_directories(star_wars INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(learn_star_wars sample.cpp)

--- a/samples/learn/schema/CharacterObject.h
+++ b/samples/learn/schema/CharacterObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::learn::object {
 
-class [[nodiscard]] Character final
+class [[nodiscard("unnecessary construction")]] Character final
 	: public service::Object
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
-		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept override
+		[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept override
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept override
+		[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept override
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/learn/schema/DroidObject.h
+++ b/samples/learn/schema/DroidObject.h
@@ -94,34 +94,34 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::DroidHas
 
-class [[nodiscard]] Droid final
+class [[nodiscard("unnecessary construction")]] Droid final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveFriends(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveAppearsIn(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolvePrimaryFunction(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveFriends(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveAppearsIn(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolvePrimaryFunction(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -129,7 +129,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::DroidHas::getIdWithParams<T>)
 			{
@@ -142,7 +142,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::DroidHas::getNameWithParams<T>)
 			{
@@ -155,7 +155,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::DroidHas::getFriendsWithParams<T>)
 			{
@@ -168,7 +168,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::DroidHas::getAppearsInWithParams<T>)
 			{
@@ -181,7 +181,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getPrimaryFunction(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::DroidHas::getPrimaryFunctionWithParams<T>)
 			{
@@ -220,13 +220,13 @@ private:
 	friend Character;
 
 	template <class I>
-	[[nodiscard]] static constexpr bool implements() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr bool implements() noexcept
 	{
 		return implements::DroidIs<I>;
 	}
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -240,7 +240,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Droid)gql" };
 	}

--- a/samples/learn/schema/HumanObject.h
+++ b/samples/learn/schema/HumanObject.h
@@ -94,34 +94,34 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::HumanHas
 
-class [[nodiscard]] Human final
+class [[nodiscard("unnecessary construction")]] Human final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveFriends(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveAppearsIn(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveHomePlanet(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveFriends(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveAppearsIn(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveHomePlanet(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -129,7 +129,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::HumanHas::getIdWithParams<T>)
 			{
@@ -142,7 +142,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::HumanHas::getNameWithParams<T>)
 			{
@@ -155,7 +155,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Character>>>> getFriends(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::HumanHas::getFriendsWithParams<T>)
 			{
@@ -168,7 +168,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::vector<std::optional<Episode>>>> getAppearsIn(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::HumanHas::getAppearsInWithParams<T>)
 			{
@@ -181,7 +181,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::HumanHas::getHomePlanetWithParams<T>)
 			{
@@ -220,13 +220,13 @@ private:
 	friend Character;
 
 	template <class I>
-	[[nodiscard]] static constexpr bool implements() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr bool implements() noexcept
 	{
 		return implements::HumanIs<I>;
 	}
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -240,7 +240,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Human)gql" };
 	}

--- a/samples/learn/schema/MutationObject.h
+++ b/samples/learn/schema/MutationObject.h
@@ -39,26 +39,26 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutationHas
 
-class [[nodiscard]] Mutation final
+class [[nodiscard("unnecessary construction")]] Mutation final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveCreateReview(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveCreateReview(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Review>> applyCreateReview(service::FieldParams&& params, Episode&& epArg, ReviewInput&& reviewArg) const override
 		{
 			if constexpr (methods::MutationHas::applyCreateReviewWithParams<T>)
 			{
@@ -101,8 +101,8 @@ private:
 
 	explicit Mutation(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -116,7 +116,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Mutation)gql" };
 	}

--- a/samples/learn/schema/QueryObject.h
+++ b/samples/learn/schema/QueryObject.h
@@ -63,34 +63,34 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::QueryHas
 
-class [[nodiscard]] Query final
+class [[nodiscard("unnecessary construction")]] Query final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveHero(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveHuman(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDroid(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveHero(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveHuman(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDroid(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolve_schema(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolve_type(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_schema(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_type(service::ResolverParams&& params) const;
 
 	std::shared_ptr<schema::Schema> _schema;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, response::IdType&& idArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, response::IdType&& idArg) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -98,7 +98,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Character>> getHero(service::FieldParams&& params, std::optional<Episode>&& episodeArg) const override
 		{
 			if constexpr (methods::QueryHas::getHeroWithParams<T>)
 			{
@@ -111,7 +111,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, response::IdType&& idArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params, response::IdType&& idArg) const override
 		{
 			if constexpr (methods::QueryHas::getHumanWithParams<T>)
 			{
@@ -124,7 +124,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, response::IdType&& idArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Droid>> getDroid(service::FieldParams&& params, response::IdType&& idArg) const override
 		{
 			if constexpr (methods::QueryHas::getDroidWithParams<T>)
 			{
@@ -159,8 +159,8 @@ private:
 
 	explicit Query(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -174,7 +174,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Query)gql" };
 	}

--- a/samples/learn/schema/ReviewObject.h
+++ b/samples/learn/schema/ReviewObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::ReviewHas
 
-class [[nodiscard]] Review final
+class [[nodiscard("unnecessary construction")]] Review final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveStars(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveCommentary(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveStars(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveCommentary(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<int> getStars(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<int> getStars(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getStars(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<int> getStars(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::ReviewHas::getStarsWithParams<T>)
 			{
@@ -93,7 +93,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getCommentary(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::ReviewHas::getCommentaryWithParams<T>)
 			{
@@ -128,8 +128,8 @@ private:
 
 	explicit Review(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -143,7 +143,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Review)gql" };
 	}

--- a/samples/learn/schema/StarWarsSchema.cpp
+++ b/samples/learn/schema/StarWarsSchema.cpp
@@ -98,6 +98,7 @@ namespace learn {
 
 ReviewInput::ReviewInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 ReviewInput::ReviewInput(
@@ -120,6 +121,11 @@ ReviewInput::ReviewInput(ReviewInput&& other) noexcept
 {
 }
 
+ReviewInput::~ReviewInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 ReviewInput& ReviewInput::operator=(const ReviewInput& other)
 {
 	ReviewInput value { other };
@@ -135,10 +141,6 @@ ReviewInput& ReviewInput::operator=(ReviewInput&& other) noexcept
 	commentary = std::move(other.commentary);
 
 	return *this;
-}
-
-ReviewInput::~ReviewInput()
-{
 }
 
 Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<object::Mutation> mutation)

--- a/samples/learn/schema/StarWarsSchema.h
+++ b/samples/learn/schema/StarWarsSchema.h
@@ -22,14 +22,14 @@ static_assert(graphql::internal::MinorVersion == 5, "regenerate with schemagen: 
 namespace graphql {
 namespace learn {
 
-enum class [[nodiscard]] Episode
+enum class [[nodiscard("unnecessary conversion")]] Episode
 {
 	NEW_HOPE,
 	EMPIRE,
 	JEDI
 };
 
-[[nodiscard]] constexpr auto getEpisodeNames() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getEpisodeNames() noexcept
 {
 	using namespace std::literals;
 
@@ -40,7 +40,7 @@ enum class [[nodiscard]] Episode
 	};
 }
 
-[[nodiscard]] constexpr auto getEpisodeValues() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getEpisodeValues() noexcept
 {
 	using namespace std::literals;
 
@@ -51,7 +51,7 @@ enum class [[nodiscard]] Episode
 	};
 }
 
-struct [[nodiscard]] ReviewInput
+struct [[nodiscard("unnecessary construction")]] ReviewInput
 {
 	explicit ReviewInput() noexcept;
 	explicit ReviewInput(
@@ -80,7 +80,7 @@ class Mutation;
 
 } // namespace object
 
-class [[nodiscard]] Operations final
+class [[nodiscard("unnecessary construction")]] Operations final
 	: public service::Request
 {
 public:

--- a/samples/proxy/CMakeLists.txt
+++ b/samples/proxy/CMakeLists.txt
@@ -11,14 +11,13 @@ target_link_libraries(client PRIVATE
   proxy_schema
   proxy_client
   graphqljson)
-target_include_directories(client PRIVATE
-  proxy_schema
-  proxy_client)
+target_include_directories(client SYSTEM PRIVATE ${Boost_INCLUDE_DIR})
 
 add_executable(server server.cpp)
 target_link_libraries(server PRIVATE
   star_wars
   graphqljson)
+target_include_directories(server SYSTEM PRIVATE ${Boost_INCLUDE_DIR})
 
 if(MSVC)
   target_compile_options(client PRIVATE "-wd4702")

--- a/samples/proxy/query/ProxyClient.cpp
+++ b/samples/proxy/query/ProxyClient.cpp
@@ -92,27 +92,27 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
-[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetRequestText() noexcept
 {
 	return proxy::GetRequestText();
 }
 
-[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+[[nodiscard("unnecessary call")]] const peg::ast& Traits::GetRequestObject() noexcept
 {
 	return proxy::GetRequestObject();
 }
 
-[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetOperationName() noexcept
 {
 	return relayQuery::GetOperationName();
 }
 
-[[nodiscard]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
+[[nodiscard("unnecessary conversion")]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
 {
 	return relayQuery::serializeVariables(std::move(variables));
 }
 
-[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+[[nodiscard("unnecessary conversion")]] Traits::Response Traits::parseResponse(response::Value&& response)
 {
 	return relayQuery::parseResponse(std::move(response));
 }

--- a/samples/proxy/query/ProxyClient.h
+++ b/samples/proxy/query/ProxyClient.h
@@ -38,10 +38,10 @@ namespace graphql::client {
 namespace proxy {
 
 // Return the original text of the request document.
-[[nodiscard]] const std::string& GetRequestText() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetRequestText() noexcept;
 
 // Return a pre-parsed, pre-validated request object.
-[[nodiscard]] const peg::ast& GetRequestObject() noexcept;
+[[nodiscard("unnecessary call")]] const peg::ast& GetRequestObject() noexcept;
 
 } // namespace proxy
 
@@ -51,37 +51,37 @@ using proxy::GetRequestText;
 using proxy::GetRequestObject;
 
 // Return the name of this operation in the shared request document.
-[[nodiscard]] const std::string& GetOperationName() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetOperationName() noexcept;
 
-struct [[nodiscard]] Variables
+struct [[nodiscard("unnecessary construction")]] Variables
 {
 	std::string query {};
 	std::optional<std::string> operationName {};
 	std::optional<std::string> variables {};
 };
 
-[[nodiscard]] response::Value serializeVariables(Variables&& variables);
+[[nodiscard("unnecessary conversion")]] response::Value serializeVariables(Variables&& variables);
 
-struct [[nodiscard]] Response
+struct [[nodiscard("unnecessary construction")]] Response
 {
 	std::optional<std::string> relay {};
 };
 
-[[nodiscard]] Response parseResponse(response::Value&& response);
+[[nodiscard("unnecessary conversion")]] Response parseResponse(response::Value&& response);
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept;
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
-	[[nodiscard]] static const std::string& GetOperationName() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard("unnecessary call")]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetOperationName() noexcept;
 
 	using Variables = relayQuery::Variables;
 
-	[[nodiscard]] static response::Value serializeVariables(Variables&& variables);
+	[[nodiscard("unnecessary conversion")]] static response::Value serializeVariables(Variables&& variables);
 
 	using Response = relayQuery::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response);
+	[[nodiscard("unnecessary conversion")]] static Response parseResponse(response::Value&& response);
 };
 
 } // namespace query::relayQuery

--- a/samples/proxy/schema/ProxySchema.h
+++ b/samples/proxy/schema/ProxySchema.h
@@ -27,7 +27,7 @@ class Query;
 
 } // namespace object
 
-class [[nodiscard]] Operations final
+class [[nodiscard("unnecessary construction")]] Operations final
 	: public service::Request
 {
 public:

--- a/samples/proxy/schema/QueryObject.h
+++ b/samples/proxy/schema/QueryObject.h
@@ -39,30 +39,30 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::QueryHas
 
-class [[nodiscard]] Query final
+class [[nodiscard("unnecessary construction")]] Query final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveRelay(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveRelay(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolve_schema(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolve_type(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_schema(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_type(service::ResolverParams&& params) const;
 
 	std::shared_ptr<schema::Schema> _schema;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getRelay(service::FieldParams&& params, std::string&& queryArg, std::optional<std::string>&& operationNameArg, std::optional<std::string>&& variablesArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getRelay(service::FieldParams&& params, std::string&& queryArg, std::optional<std::string>&& operationNameArg, std::optional<std::string>&& variablesArg) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -70,7 +70,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getRelay(service::FieldParams&& params, std::string&& queryArg, std::optional<std::string>&& operationNameArg, std::optional<std::string>&& variablesArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getRelay(service::FieldParams&& params, std::string&& queryArg, std::optional<std::string>&& operationNameArg, std::optional<std::string>&& variablesArg) const override
 		{
 			if constexpr (methods::QueryHas::getRelayWithParams<T>)
 			{
@@ -105,8 +105,8 @@ private:
 
 	explicit Query(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -120,7 +120,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Query)gql" };
 	}

--- a/samples/today/nointrospection/AppointmentConnectionObject.h
+++ b/samples/today/nointrospection/AppointmentConnectionObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(AppointmentConnection::getPageInfo is not implemented)ex");
+				throw service::unimplemented_method(R"ex(AppointmentConnection::getPageInfo)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(AppointmentConnection::getEdges is not implemented)ex");
+				throw service::unimplemented_method(R"ex(AppointmentConnection::getEdges)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/AppointmentConnectionObject.h
+++ b/samples/today/nointrospection/AppointmentConnectionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentConnectionHas
 
-class [[nodiscard]] AppointmentConnection final
+class [[nodiscard("unnecessary construction")]] AppointmentConnection final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentConnectionHas::getEdgesWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit AppointmentConnection(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(AppointmentConnection)gql" };
 	}

--- a/samples/today/nointrospection/AppointmentEdgeObject.h
+++ b/samples/today/nointrospection/AppointmentEdgeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentEdgeHas
 
-class [[nodiscard]] AppointmentEdge final
+class [[nodiscard("unnecessary construction")]] AppointmentEdge final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentEdgeHas::getCursorWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit AppointmentEdge(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(AppointmentEdge)gql" };
 	}

--- a/samples/today/nointrospection/AppointmentEdgeObject.h
+++ b/samples/today/nointrospection/AppointmentEdgeObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(AppointmentEdge::getNode is not implemented)ex");
+				throw service::unimplemented_method(R"ex(AppointmentEdge::getNode)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(AppointmentEdge::getCursor is not implemented)ex");
+				throw service::unimplemented_method(R"ex(AppointmentEdge::getCursor)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/AppointmentObject.h
+++ b/samples/today/nointrospection/AppointmentObject.h
@@ -141,7 +141,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Appointment::getId is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Appointment::getId)ex");
 			}
 		}
 
@@ -157,7 +157,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Appointment::getWhen is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Appointment::getWhen)ex");
 			}
 		}
 
@@ -173,7 +173,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Appointment::getSubject is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Appointment::getSubject)ex");
 			}
 		}
 
@@ -189,7 +189,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Appointment::getIsNow is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Appointment::getIsNow)ex");
 			}
 		}
 
@@ -205,7 +205,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Appointment::getForceError is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Appointment::getForceError)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/AppointmentObject.h
+++ b/samples/today/nointrospection/AppointmentObject.h
@@ -94,34 +94,34 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentHas
 
-class [[nodiscard]] Appointment final
+class [[nodiscard("unnecessary construction")]] Appointment final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveWhen(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveSubject(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveIsNow(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveForceError(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveWhen(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveSubject(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveIsNow(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveForceError(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -129,7 +129,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentHas::getIdWithParams<T>)
 			{
@@ -145,7 +145,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentHas::getWhenWithParams<T>)
 			{
@@ -161,7 +161,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentHas::getSubjectWithParams<T>)
 			{
@@ -177,7 +177,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentHas::getIsNowWithParams<T>)
 			{
@@ -193,7 +193,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentHas::getForceErrorWithParams<T>)
 			{
@@ -238,13 +238,13 @@ private:
 	friend UnionType;
 
 	template <class I>
-	[[nodiscard]] static constexpr bool implements() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr bool implements() noexcept
 	{
 		return implements::AppointmentIs<I>;
 	}
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -258,7 +258,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Appointment)gql" };
 	}

--- a/samples/today/nointrospection/CompleteTaskPayloadObject.h
+++ b/samples/today/nointrospection/CompleteTaskPayloadObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(CompleteTaskPayload::getTask is not implemented)ex");
+				throw service::unimplemented_method(R"ex(CompleteTaskPayload::getTask)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(CompleteTaskPayload::getClientMutationId is not implemented)ex");
+				throw service::unimplemented_method(R"ex(CompleteTaskPayload::getClientMutationId)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/CompleteTaskPayloadObject.h
+++ b/samples/today/nointrospection/CompleteTaskPayloadObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::CompleteTaskPayloadHas
 
-class [[nodiscard]] CompleteTaskPayload final
+class [[nodiscard("unnecessary construction")]] CompleteTaskPayload final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveTask(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveClientMutationId(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveTask(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveClientMutationId(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getClientMutationIdWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit CompleteTaskPayload(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(CompleteTaskPayload)gql" };
 	}

--- a/samples/today/nointrospection/ExpensiveObject.h
+++ b/samples/today/nointrospection/ExpensiveObject.h
@@ -78,7 +78,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Expensive::getOrder is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Expensive::getOrder)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/ExpensiveObject.h
+++ b/samples/today/nointrospection/ExpensiveObject.h
@@ -39,26 +39,26 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::ExpensiveHas
 
-class [[nodiscard]] Expensive final
+class [[nodiscard("unnecessary construction")]] Expensive final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveOrder(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveOrder(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::ExpensiveHas::getOrderWithParams<T>)
 			{
@@ -104,8 +104,8 @@ private:
 
 	explicit Expensive(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -119,7 +119,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Expensive)gql" };
 	}

--- a/samples/today/nointrospection/FolderConnectionObject.h
+++ b/samples/today/nointrospection/FolderConnectionObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(FolderConnection::getPageInfo is not implemented)ex");
+				throw service::unimplemented_method(R"ex(FolderConnection::getPageInfo)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(FolderConnection::getEdges is not implemented)ex");
+				throw service::unimplemented_method(R"ex(FolderConnection::getEdges)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/FolderConnectionObject.h
+++ b/samples/today/nointrospection/FolderConnectionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderConnectionHas
 
-class [[nodiscard]] FolderConnection final
+class [[nodiscard("unnecessary construction")]] FolderConnection final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderConnectionHas::getEdgesWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit FolderConnection(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(FolderConnection)gql" };
 	}

--- a/samples/today/nointrospection/FolderEdgeObject.h
+++ b/samples/today/nointrospection/FolderEdgeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderEdgeHas
 
-class [[nodiscard]] FolderEdge final
+class [[nodiscard("unnecessary construction")]] FolderEdge final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderEdgeHas::getCursorWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit FolderEdge(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(FolderEdge)gql" };
 	}

--- a/samples/today/nointrospection/FolderEdgeObject.h
+++ b/samples/today/nointrospection/FolderEdgeObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(FolderEdge::getNode is not implemented)ex");
+				throw service::unimplemented_method(R"ex(FolderEdge::getNode)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(FolderEdge::getCursor is not implemented)ex");
+				throw service::unimplemented_method(R"ex(FolderEdge::getCursor)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/FolderObject.h
+++ b/samples/today/nointrospection/FolderObject.h
@@ -70,30 +70,30 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderHas
 
-class [[nodiscard]] Folder final
+class [[nodiscard("unnecessary construction")]] Folder final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveUnreadCount(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveUnreadCount(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -101,7 +101,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderHas::getNameWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderHas::getUnreadCountWithParams<T>)
 			{
@@ -178,13 +178,13 @@ private:
 	friend UnionType;
 
 	template <class I>
-	[[nodiscard]] static constexpr bool implements() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr bool implements() noexcept
 	{
 		return implements::FolderIs<I>;
 	}
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -198,7 +198,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Folder)gql" };
 	}

--- a/samples/today/nointrospection/FolderObject.h
+++ b/samples/today/nointrospection/FolderObject.h
@@ -113,7 +113,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Folder::getId is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Folder::getId)ex");
 			}
 		}
 
@@ -129,7 +129,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Folder::getName is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Folder::getName)ex");
 			}
 		}
 
@@ -145,7 +145,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Folder::getUnreadCount is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Folder::getUnreadCount)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/MutationObject.h
+++ b/samples/today/nointrospection/MutationObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutationHas
 
-class [[nodiscard]] Mutation final
+class [[nodiscard("unnecessary construction")]] Mutation final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveCompleteTask(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveSetFloat(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveCompleteTask(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveSetFloat(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const override
 		{
 			if constexpr (methods::MutationHas::applyCompleteTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const override
 		{
 			if constexpr (methods::MutationHas::applySetFloatWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit Mutation(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Mutation)gql" };
 	}

--- a/samples/today/nointrospection/MutationObject.h
+++ b/samples/today/nointrospection/MutationObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Mutation::applyCompleteTask is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Mutation::applyCompleteTask)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Mutation::applySetFloat is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Mutation::applySetFloat)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/NestedTypeObject.h
+++ b/samples/today/nointrospection/NestedTypeObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(NestedType::getDepth is not implemented)ex");
+				throw service::unimplemented_method(R"ex(NestedType::getDepth)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(NestedType::getNested is not implemented)ex");
+				throw service::unimplemented_method(R"ex(NestedType::getNested)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/NestedTypeObject.h
+++ b/samples/today/nointrospection/NestedTypeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::NestedTypeHas
 
-class [[nodiscard]] NestedType final
+class [[nodiscard("unnecessary construction")]] NestedType final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveDepth(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDepth(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::NestedTypeHas::getDepthWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::NestedTypeHas::getNestedWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit NestedType(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(NestedType)gql" };
 	}

--- a/samples/today/nointrospection/NodeObject.h
+++ b/samples/today/nointrospection/NodeObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::today::object {
 
-class [[nodiscard]] Node final
+class [[nodiscard("unnecessary construction")]] Node final
 	: public service::Object
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
-		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept override
+		[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept override
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept override
+		[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept override
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/today/nointrospection/PageInfoObject.h
+++ b/samples/today/nointrospection/PageInfoObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::PageInfoHas
 
-class [[nodiscard]] PageInfo final
+class [[nodiscard("unnecessary construction")]] PageInfo final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveHasNextPage(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveHasPreviousPage(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveHasNextPage(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveHasPreviousPage(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::PageInfoHas::getHasNextPageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::PageInfoHas::getHasPreviousPageWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit PageInfo(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(PageInfo)gql" };
 	}

--- a/samples/today/nointrospection/PageInfoObject.h
+++ b/samples/today/nointrospection/PageInfoObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(PageInfo::getHasNextPage is not implemented)ex");
+				throw service::unimplemented_method(R"ex(PageInfo::getHasNextPage)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(PageInfo::getHasPreviousPage is not implemented)ex");
+				throw service::unimplemented_method(R"ex(PageInfo::getHasPreviousPage)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/QueryObject.h
+++ b/samples/today/nointrospection/QueryObject.h
@@ -183,50 +183,50 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::QueryHas
 
-class [[nodiscard]] Query final
+class [[nodiscard("unnecessary construction")]] Query final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveAppointments(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveTasks(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveUnreadCounts(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveAppointmentsById(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveTasksById(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveUnreadCountsById(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveUnimplemented(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveExpensive(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveTestTaskState(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveAnyType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDefault(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveAppointments(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveTasks(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveUnreadCounts(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveAppointmentsById(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveTasksById(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveUnreadCountsById(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveUnimplemented(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveExpensive(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveTestTaskState(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveAnyType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDefault(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -234,7 +234,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const override
 		{
 			if constexpr (methods::QueryHas::getNodeWithParams<T>)
 			{
@@ -250,7 +250,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const override
 		{
 			if constexpr (methods::QueryHas::getAppointmentsWithParams<T>)
 			{
@@ -266,7 +266,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const override
 		{
 			if constexpr (methods::QueryHas::getTasksWithParams<T>)
 			{
@@ -282,7 +282,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const override
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsWithParams<T>)
 			{
@@ -298,7 +298,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
 		{
 			if constexpr (methods::QueryHas::getAppointmentsByIdWithParams<T>)
 			{
@@ -314,7 +314,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
 		{
 			if constexpr (methods::QueryHas::getTasksByIdWithParams<T>)
 			{
@@ -330,7 +330,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsByIdWithParams<T>)
 			{
@@ -346,7 +346,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getNestedWithParams<T>)
 			{
@@ -362,7 +362,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getUnimplementedWithParams<T>)
 			{
@@ -378,7 +378,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getExpensiveWithParams<T>)
 			{
@@ -394,7 +394,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getTestTaskStateWithParams<T>)
 			{
@@ -410,7 +410,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
 		{
 			if constexpr (methods::QueryHas::getAnyTypeWithParams<T>)
 			{
@@ -426,7 +426,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getDefaultWithParams<T>)
 			{
@@ -464,8 +464,8 @@ private:
 
 	explicit Query(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -479,7 +479,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Query)gql" };
 	}

--- a/samples/today/nointrospection/QueryObject.h
+++ b/samples/today/nointrospection/QueryObject.h
@@ -246,7 +246,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getNode is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getNode)ex");
 			}
 		}
 
@@ -262,7 +262,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getAppointments is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getAppointments)ex");
 			}
 		}
 
@@ -278,7 +278,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getTasks is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getTasks)ex");
 			}
 		}
 
@@ -294,7 +294,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getUnreadCounts is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getUnreadCounts)ex");
 			}
 		}
 
@@ -310,7 +310,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getAppointmentsById is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getAppointmentsById)ex");
 			}
 		}
 
@@ -326,7 +326,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getTasksById is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getTasksById)ex");
 			}
 		}
 
@@ -342,7 +342,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getUnreadCountsById is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getUnreadCountsById)ex");
 			}
 		}
 
@@ -358,7 +358,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getNested is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getNested)ex");
 			}
 		}
 
@@ -374,7 +374,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getUnimplemented is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getUnimplemented)ex");
 			}
 		}
 
@@ -390,7 +390,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getExpensive is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getExpensive)ex");
 			}
 		}
 
@@ -406,7 +406,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getTestTaskState is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getTestTaskState)ex");
 			}
 		}
 
@@ -422,7 +422,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getAnyType is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getAnyType)ex");
 			}
 		}
 
@@ -438,7 +438,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getDefault is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getDefault)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/SubscriptionObject.h
+++ b/samples/today/nointrospection/SubscriptionObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Subscription::getNextAppointmentChange is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Subscription::getNextAppointmentChange)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Subscription::getNodeChange is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Subscription::getNodeChange)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/SubscriptionObject.h
+++ b/samples/today/nointrospection/SubscriptionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::SubscriptionHas
 
-class [[nodiscard]] Subscription final
+class [[nodiscard("unnecessary construction")]] Subscription final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveNextAppointmentChange(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveNodeChange(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNextAppointmentChange(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNodeChange(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::SubscriptionHas::getNextAppointmentChangeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const override
 		{
 			if constexpr (methods::SubscriptionHas::getNodeChangeWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit Subscription(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Subscription)gql" };
 	}

--- a/samples/today/nointrospection/TaskConnectionObject.h
+++ b/samples/today/nointrospection/TaskConnectionObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(TaskConnection::getPageInfo is not implemented)ex");
+				throw service::unimplemented_method(R"ex(TaskConnection::getPageInfo)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(TaskConnection::getEdges is not implemented)ex");
+				throw service::unimplemented_method(R"ex(TaskConnection::getEdges)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/TaskConnectionObject.h
+++ b/samples/today/nointrospection/TaskConnectionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskConnectionHas
 
-class [[nodiscard]] TaskConnection final
+class [[nodiscard("unnecessary construction")]] TaskConnection final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskConnectionHas::getEdgesWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit TaskConnection(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(TaskConnection)gql" };
 	}

--- a/samples/today/nointrospection/TaskEdgeObject.h
+++ b/samples/today/nointrospection/TaskEdgeObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(TaskEdge::getNode is not implemented)ex");
+				throw service::unimplemented_method(R"ex(TaskEdge::getNode)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(TaskEdge::getCursor is not implemented)ex");
+				throw service::unimplemented_method(R"ex(TaskEdge::getCursor)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/TaskEdgeObject.h
+++ b/samples/today/nointrospection/TaskEdgeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskEdgeHas
 
-class [[nodiscard]] TaskEdge final
+class [[nodiscard("unnecessary construction")]] TaskEdge final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskEdgeHas::getCursorWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit TaskEdge(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(TaskEdge)gql" };
 	}

--- a/samples/today/nointrospection/TaskObject.h
+++ b/samples/today/nointrospection/TaskObject.h
@@ -113,7 +113,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Task::getId is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Task::getId)ex");
 			}
 		}
 
@@ -129,7 +129,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Task::getTitle is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Task::getTitle)ex");
 			}
 		}
 
@@ -145,7 +145,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Task::getIsComplete is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Task::getIsComplete)ex");
 			}
 		}
 

--- a/samples/today/nointrospection/TaskObject.h
+++ b/samples/today/nointrospection/TaskObject.h
@@ -70,30 +70,30 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskHas
 
-class [[nodiscard]] Task final
+class [[nodiscard("unnecessary construction")]] Task final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveTitle(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveIsComplete(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveTitle(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveIsComplete(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -101,7 +101,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskHas::getTitleWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskHas::getIsCompleteWithParams<T>)
 			{
@@ -178,13 +178,13 @@ private:
 	friend UnionType;
 
 	template <class I>
-	[[nodiscard]] static constexpr bool implements() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr bool implements() noexcept
 	{
 		return implements::TaskIs<I>;
 	}
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -198,7 +198,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Task)gql" };
 	}

--- a/samples/today/nointrospection/TodaySchema.cpp
+++ b/samples/today/nointrospection/TodaySchema.cpp
@@ -229,6 +229,7 @@ namespace today {
 
 CompleteTaskInput::CompleteTaskInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 CompleteTaskInput::CompleteTaskInput(
@@ -259,6 +260,11 @@ CompleteTaskInput::CompleteTaskInput(CompleteTaskInput&& other) noexcept
 {
 }
 
+CompleteTaskInput::~CompleteTaskInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 CompleteTaskInput& CompleteTaskInput::operator=(const CompleteTaskInput& other)
 {
 	CompleteTaskInput value { other };
@@ -278,12 +284,9 @@ CompleteTaskInput& CompleteTaskInput::operator=(CompleteTaskInput&& other) noexc
 	return *this;
 }
 
-CompleteTaskInput::~CompleteTaskInput()
-{
-}
-
 ThirdNestedInput::ThirdNestedInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 ThirdNestedInput::ThirdNestedInput(
@@ -306,6 +309,11 @@ ThirdNestedInput::ThirdNestedInput(ThirdNestedInput&& other) noexcept
 {
 }
 
+ThirdNestedInput::~ThirdNestedInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 ThirdNestedInput& ThirdNestedInput::operator=(const ThirdNestedInput& other)
 {
 	ThirdNestedInput value { other };
@@ -323,12 +331,9 @@ ThirdNestedInput& ThirdNestedInput::operator=(ThirdNestedInput&& other) noexcept
 	return *this;
 }
 
-ThirdNestedInput::~ThirdNestedInput()
-{
-}
-
 FourthNestedInput::FourthNestedInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 FourthNestedInput::FourthNestedInput(
@@ -347,6 +352,11 @@ FourthNestedInput::FourthNestedInput(FourthNestedInput&& other) noexcept
 {
 }
 
+FourthNestedInput::~FourthNestedInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 FourthNestedInput& FourthNestedInput::operator=(const FourthNestedInput& other)
 {
 	FourthNestedInput value { other };
@@ -363,12 +373,9 @@ FourthNestedInput& FourthNestedInput::operator=(FourthNestedInput&& other) noexc
 	return *this;
 }
 
-FourthNestedInput::~FourthNestedInput()
-{
-}
-
 IncludeNullableSelfInput::IncludeNullableSelfInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 IncludeNullableSelfInput::IncludeNullableSelfInput(
@@ -387,6 +394,11 @@ IncludeNullableSelfInput::IncludeNullableSelfInput(IncludeNullableSelfInput&& ot
 {
 }
 
+IncludeNullableSelfInput::~IncludeNullableSelfInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 IncludeNullableSelfInput& IncludeNullableSelfInput::operator=(const IncludeNullableSelfInput& other)
 {
 	IncludeNullableSelfInput value { other };
@@ -403,12 +415,9 @@ IncludeNullableSelfInput& IncludeNullableSelfInput::operator=(IncludeNullableSel
 	return *this;
 }
 
-IncludeNullableSelfInput::~IncludeNullableSelfInput()
-{
-}
-
 IncludeNonNullableListSelfInput::IncludeNonNullableListSelfInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 IncludeNonNullableListSelfInput::IncludeNonNullableListSelfInput(
@@ -427,6 +436,11 @@ IncludeNonNullableListSelfInput::IncludeNonNullableListSelfInput(IncludeNonNulla
 {
 }
 
+IncludeNonNullableListSelfInput::~IncludeNonNullableListSelfInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 IncludeNonNullableListSelfInput& IncludeNonNullableListSelfInput::operator=(const IncludeNonNullableListSelfInput& other)
 {
 	IncludeNonNullableListSelfInput value { other };
@@ -443,12 +457,9 @@ IncludeNonNullableListSelfInput& IncludeNonNullableListSelfInput::operator=(Incl
 	return *this;
 }
 
-IncludeNonNullableListSelfInput::~IncludeNonNullableListSelfInput()
-{
-}
-
 StringOperationFilterInput::StringOperationFilterInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 StringOperationFilterInput::StringOperationFilterInput(
@@ -511,6 +522,11 @@ StringOperationFilterInput::StringOperationFilterInput(StringOperationFilterInpu
 {
 }
 
+StringOperationFilterInput::~StringOperationFilterInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 StringOperationFilterInput& StringOperationFilterInput::operator=(const StringOperationFilterInput& other)
 {
 	StringOperationFilterInput value { other };
@@ -538,12 +554,9 @@ StringOperationFilterInput& StringOperationFilterInput::operator=(StringOperatio
 	return *this;
 }
 
-StringOperationFilterInput::~StringOperationFilterInput()
-{
-}
-
 SecondNestedInput::SecondNestedInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 SecondNestedInput::SecondNestedInput(
@@ -566,6 +579,11 @@ SecondNestedInput::SecondNestedInput(SecondNestedInput&& other) noexcept
 {
 }
 
+SecondNestedInput::~SecondNestedInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 SecondNestedInput& SecondNestedInput::operator=(const SecondNestedInput& other)
 {
 	SecondNestedInput value { other };
@@ -583,12 +601,9 @@ SecondNestedInput& SecondNestedInput::operator=(SecondNestedInput&& other) noexc
 	return *this;
 }
 
-SecondNestedInput::~SecondNestedInput()
-{
-}
-
 ForwardDeclaredInput::ForwardDeclaredInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 ForwardDeclaredInput::ForwardDeclaredInput(
@@ -611,6 +626,11 @@ ForwardDeclaredInput::ForwardDeclaredInput(ForwardDeclaredInput&& other) noexcep
 {
 }
 
+ForwardDeclaredInput::~ForwardDeclaredInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 ForwardDeclaredInput& ForwardDeclaredInput::operator=(const ForwardDeclaredInput& other)
 {
 	ForwardDeclaredInput value { other };
@@ -628,12 +648,9 @@ ForwardDeclaredInput& ForwardDeclaredInput::operator=(ForwardDeclaredInput&& oth
 	return *this;
 }
 
-ForwardDeclaredInput::~ForwardDeclaredInput()
-{
-}
-
 FirstNestedInput::FirstNestedInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 FirstNestedInput::FirstNestedInput(
@@ -660,6 +677,11 @@ FirstNestedInput::FirstNestedInput(FirstNestedInput&& other) noexcept
 {
 }
 
+FirstNestedInput::~FirstNestedInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 FirstNestedInput& FirstNestedInput::operator=(const FirstNestedInput& other)
 {
 	FirstNestedInput value { other };
@@ -676,10 +698,6 @@ FirstNestedInput& FirstNestedInput::operator=(FirstNestedInput&& other) noexcept
 	third = std::move(other.third);
 
 	return *this;
-}
-
-FirstNestedInput::~FirstNestedInput()
-{
 }
 
 Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<object::Mutation> mutation, std::shared_ptr<object::Subscription> subscription)

--- a/samples/today/nointrospection/TodaySchema.h
+++ b/samples/today/nointrospection/TodaySchema.h
@@ -22,7 +22,7 @@ static_assert(graphql::internal::MinorVersion == 5, "regenerate with schemagen: 
 namespace graphql {
 namespace today {
 
-enum class [[nodiscard]] TaskState
+enum class [[nodiscard("unnecessary conversion")]] TaskState
 {
 	Unassigned,
 	New,
@@ -30,7 +30,7 @@ enum class [[nodiscard]] TaskState
 	Complete
 };
 
-[[nodiscard]] constexpr auto getTaskStateNames() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getTaskStateNames() noexcept
 {
 	using namespace std::literals;
 
@@ -42,7 +42,7 @@ enum class [[nodiscard]] TaskState
 	};
 }
 
-[[nodiscard]] constexpr auto getTaskStateValues() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getTaskStateValues() noexcept
 {
 	using namespace std::literals;
 
@@ -54,7 +54,7 @@ enum class [[nodiscard]] TaskState
 	};
 }
 
-struct [[nodiscard]] CompleteTaskInput
+struct [[nodiscard("unnecessary construction")]] CompleteTaskInput
 {
 	explicit CompleteTaskInput() noexcept;
 	explicit CompleteTaskInput(
@@ -77,7 +77,7 @@ struct [[nodiscard]] CompleteTaskInput
 
 struct SecondNestedInput;
 
-struct [[nodiscard]] ThirdNestedInput
+struct [[nodiscard("unnecessary construction")]] ThirdNestedInput
 {
 	explicit ThirdNestedInput() noexcept;
 	explicit ThirdNestedInput(
@@ -94,7 +94,7 @@ struct [[nodiscard]] ThirdNestedInput
 	std::unique_ptr<SecondNestedInput> second {};
 };
 
-struct [[nodiscard]] FourthNestedInput
+struct [[nodiscard("unnecessary construction")]] FourthNestedInput
 {
 	explicit FourthNestedInput() noexcept;
 	explicit FourthNestedInput(
@@ -109,7 +109,7 @@ struct [[nodiscard]] FourthNestedInput
 	response::IdType id {};
 };
 
-struct [[nodiscard]] IncludeNullableSelfInput
+struct [[nodiscard("unnecessary construction")]] IncludeNullableSelfInput
 {
 	explicit IncludeNullableSelfInput() noexcept;
 	explicit IncludeNullableSelfInput(
@@ -124,7 +124,7 @@ struct [[nodiscard]] IncludeNullableSelfInput
 	std::unique_ptr<IncludeNullableSelfInput> self {};
 };
 
-struct [[nodiscard]] IncludeNonNullableListSelfInput
+struct [[nodiscard("unnecessary construction")]] IncludeNonNullableListSelfInput
 {
 	explicit IncludeNonNullableListSelfInput() noexcept;
 	explicit IncludeNonNullableListSelfInput(
@@ -139,7 +139,7 @@ struct [[nodiscard]] IncludeNonNullableListSelfInput
 	std::vector<IncludeNonNullableListSelfInput> selves {};
 };
 
-struct [[nodiscard]] StringOperationFilterInput
+struct [[nodiscard("unnecessary construction")]] StringOperationFilterInput
 {
 	explicit StringOperationFilterInput() noexcept;
 	explicit StringOperationFilterInput(
@@ -176,7 +176,7 @@ struct [[nodiscard]] StringOperationFilterInput
 	std::optional<std::string> notEndsWith {};
 };
 
-struct [[nodiscard]] SecondNestedInput
+struct [[nodiscard("unnecessary construction")]] SecondNestedInput
 {
 	explicit SecondNestedInput() noexcept;
 	explicit SecondNestedInput(
@@ -193,7 +193,7 @@ struct [[nodiscard]] SecondNestedInput
 	ThirdNestedInput third {};
 };
 
-struct [[nodiscard]] ForwardDeclaredInput
+struct [[nodiscard("unnecessary construction")]] ForwardDeclaredInput
 {
 	explicit ForwardDeclaredInput() noexcept;
 	explicit ForwardDeclaredInput(
@@ -210,7 +210,7 @@ struct [[nodiscard]] ForwardDeclaredInput
 	IncludeNonNullableListSelfInput listSelves {};
 };
 
-struct [[nodiscard]] FirstNestedInput
+struct [[nodiscard("unnecessary construction")]] FirstNestedInput
 {
 	explicit FirstNestedInput() noexcept;
 	explicit FirstNestedInput(
@@ -254,7 +254,7 @@ class Expensive;
 
 } // namespace object
 
-class [[nodiscard]] Operations final
+class [[nodiscard("unnecessary construction")]] Operations final
 	: public service::Request
 {
 public:

--- a/samples/today/nointrospection/UnionTypeObject.h
+++ b/samples/today/nointrospection/UnionTypeObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::today::object {
 
-class [[nodiscard]] UnionType final
+class [[nodiscard("unnecessary construction")]] UnionType final
 	: public service::Object
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
-		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept override
+		[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept override
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept override
+		[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept override
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/today/schema/AppointmentConnectionObject.h
+++ b/samples/today/schema/AppointmentConnectionObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(AppointmentConnection::getPageInfo is not implemented)ex");
+				throw service::unimplemented_method(R"ex(AppointmentConnection::getPageInfo)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(AppointmentConnection::getEdges is not implemented)ex");
+				throw service::unimplemented_method(R"ex(AppointmentConnection::getEdges)ex");
 			}
 		}
 

--- a/samples/today/schema/AppointmentConnectionObject.h
+++ b/samples/today/schema/AppointmentConnectionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentConnectionHas
 
-class [[nodiscard]] AppointmentConnection final
+class [[nodiscard("unnecessary construction")]] AppointmentConnection final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<AppointmentEdge>>>> getEdges(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentConnectionHas::getEdgesWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit AppointmentConnection(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(AppointmentConnection)gql" };
 	}

--- a/samples/today/schema/AppointmentEdgeObject.h
+++ b/samples/today/schema/AppointmentEdgeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentEdgeHas
 
-class [[nodiscard]] AppointmentEdge final
+class [[nodiscard("unnecessary construction")]] AppointmentEdge final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Appointment>> getNode(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentEdgeHas::getCursorWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit AppointmentEdge(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(AppointmentEdge)gql" };
 	}

--- a/samples/today/schema/AppointmentEdgeObject.h
+++ b/samples/today/schema/AppointmentEdgeObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(AppointmentEdge::getNode is not implemented)ex");
+				throw service::unimplemented_method(R"ex(AppointmentEdge::getNode)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(AppointmentEdge::getCursor is not implemented)ex");
+				throw service::unimplemented_method(R"ex(AppointmentEdge::getCursor)ex");
 			}
 		}
 

--- a/samples/today/schema/AppointmentObject.h
+++ b/samples/today/schema/AppointmentObject.h
@@ -141,7 +141,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Appointment::getId is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Appointment::getId)ex");
 			}
 		}
 
@@ -157,7 +157,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Appointment::getWhen is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Appointment::getWhen)ex");
 			}
 		}
 
@@ -173,7 +173,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Appointment::getSubject is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Appointment::getSubject)ex");
 			}
 		}
 
@@ -189,7 +189,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Appointment::getIsNow is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Appointment::getIsNow)ex");
 			}
 		}
 
@@ -205,7 +205,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Appointment::getForceError is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Appointment::getForceError)ex");
 			}
 		}
 

--- a/samples/today/schema/AppointmentObject.h
+++ b/samples/today/schema/AppointmentObject.h
@@ -94,34 +94,34 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AppointmentHas
 
-class [[nodiscard]] Appointment final
+class [[nodiscard("unnecessary construction")]] Appointment final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveWhen(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveSubject(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveIsNow(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveForceError(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveWhen(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveSubject(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveIsNow(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveForceError(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -129,7 +129,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentHas::getIdWithParams<T>)
 			{
@@ -145,7 +145,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<response::Value>> getWhen(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentHas::getWhenWithParams<T>)
 			{
@@ -161,7 +161,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getSubject(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentHas::getSubjectWithParams<T>)
 			{
@@ -177,7 +177,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getIsNow(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentHas::getIsNowWithParams<T>)
 			{
@@ -193,7 +193,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getForceError(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AppointmentHas::getForceErrorWithParams<T>)
 			{
@@ -238,13 +238,13 @@ private:
 	friend UnionType;
 
 	template <class I>
-	[[nodiscard]] static constexpr bool implements() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr bool implements() noexcept
 	{
 		return implements::AppointmentIs<I>;
 	}
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -258,7 +258,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Appointment)gql" };
 	}

--- a/samples/today/schema/CompleteTaskPayloadObject.h
+++ b/samples/today/schema/CompleteTaskPayloadObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(CompleteTaskPayload::getTask is not implemented)ex");
+				throw service::unimplemented_method(R"ex(CompleteTaskPayload::getTask)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(CompleteTaskPayload::getClientMutationId is not implemented)ex");
+				throw service::unimplemented_method(R"ex(CompleteTaskPayload::getClientMutationId)ex");
 			}
 		}
 

--- a/samples/today/schema/CompleteTaskPayloadObject.h
+++ b/samples/today/schema/CompleteTaskPayloadObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::CompleteTaskPayloadHas
 
-class [[nodiscard]] CompleteTaskPayload final
+class [[nodiscard("unnecessary construction")]] CompleteTaskPayload final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveTask(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveClientMutationId(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveTask(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveClientMutationId(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Task>> getTask(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getClientMutationId(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::CompleteTaskPayloadHas::getClientMutationIdWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit CompleteTaskPayload(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(CompleteTaskPayload)gql" };
 	}

--- a/samples/today/schema/ExpensiveObject.h
+++ b/samples/today/schema/ExpensiveObject.h
@@ -78,7 +78,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Expensive::getOrder is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Expensive::getOrder)ex");
 			}
 		}
 

--- a/samples/today/schema/ExpensiveObject.h
+++ b/samples/today/schema/ExpensiveObject.h
@@ -39,26 +39,26 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::ExpensiveHas
 
-class [[nodiscard]] Expensive final
+class [[nodiscard("unnecessary construction")]] Expensive final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveOrder(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveOrder(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<int> getOrder(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::ExpensiveHas::getOrderWithParams<T>)
 			{
@@ -104,8 +104,8 @@ private:
 
 	explicit Expensive(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -119,7 +119,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Expensive)gql" };
 	}

--- a/samples/today/schema/FolderConnectionObject.h
+++ b/samples/today/schema/FolderConnectionObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(FolderConnection::getPageInfo is not implemented)ex");
+				throw service::unimplemented_method(R"ex(FolderConnection::getPageInfo)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(FolderConnection::getEdges is not implemented)ex");
+				throw service::unimplemented_method(R"ex(FolderConnection::getEdges)ex");
 			}
 		}
 

--- a/samples/today/schema/FolderConnectionObject.h
+++ b/samples/today/schema/FolderConnectionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderConnectionHas
 
-class [[nodiscard]] FolderConnection final
+class [[nodiscard("unnecessary construction")]] FolderConnection final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<FolderEdge>>>> getEdges(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderConnectionHas::getEdgesWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit FolderConnection(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(FolderConnection)gql" };
 	}

--- a/samples/today/schema/FolderEdgeObject.h
+++ b/samples/today/schema/FolderEdgeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderEdgeHas
 
-class [[nodiscard]] FolderEdge final
+class [[nodiscard("unnecessary construction")]] FolderEdge final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Folder>> getNode(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderEdgeHas::getCursorWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit FolderEdge(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(FolderEdge)gql" };
 	}

--- a/samples/today/schema/FolderEdgeObject.h
+++ b/samples/today/schema/FolderEdgeObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(FolderEdge::getNode is not implemented)ex");
+				throw service::unimplemented_method(R"ex(FolderEdge::getNode)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(FolderEdge::getCursor is not implemented)ex");
+				throw service::unimplemented_method(R"ex(FolderEdge::getCursor)ex");
 			}
 		}
 

--- a/samples/today/schema/FolderObject.h
+++ b/samples/today/schema/FolderObject.h
@@ -70,30 +70,30 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::FolderHas
 
-class [[nodiscard]] Folder final
+class [[nodiscard("unnecessary construction")]] Folder final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveUnreadCount(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveUnreadCount(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -101,7 +101,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getName(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderHas::getNameWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<int> getUnreadCount(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::FolderHas::getUnreadCountWithParams<T>)
 			{
@@ -178,13 +178,13 @@ private:
 	friend UnionType;
 
 	template <class I>
-	[[nodiscard]] static constexpr bool implements() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr bool implements() noexcept
 	{
 		return implements::FolderIs<I>;
 	}
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -198,7 +198,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Folder)gql" };
 	}

--- a/samples/today/schema/FolderObject.h
+++ b/samples/today/schema/FolderObject.h
@@ -113,7 +113,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Folder::getId is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Folder::getId)ex");
 			}
 		}
 
@@ -129,7 +129,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Folder::getName is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Folder::getName)ex");
 			}
 		}
 
@@ -145,7 +145,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Folder::getUnreadCount is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Folder::getUnreadCount)ex");
 			}
 		}
 

--- a/samples/today/schema/MutationObject.h
+++ b/samples/today/schema/MutationObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutationHas
 
-class [[nodiscard]] Mutation final
+class [[nodiscard("unnecessary construction")]] Mutation final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveCompleteTask(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveSetFloat(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveCompleteTask(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveSetFloat(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<CompleteTaskPayload>> applyCompleteTask(service::FieldParams&& params, CompleteTaskInput&& inputArg) const override
 		{
 			if constexpr (methods::MutationHas::applyCompleteTaskWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<double> applySetFloat(service::FieldParams&& params, double&& valueArg) const override
 		{
 			if constexpr (methods::MutationHas::applySetFloatWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit Mutation(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Mutation)gql" };
 	}

--- a/samples/today/schema/MutationObject.h
+++ b/samples/today/schema/MutationObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Mutation::applyCompleteTask is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Mutation::applyCompleteTask)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Mutation::applySetFloat is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Mutation::applySetFloat)ex");
 			}
 		}
 

--- a/samples/today/schema/NestedTypeObject.h
+++ b/samples/today/schema/NestedTypeObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(NestedType::getDepth is not implemented)ex");
+				throw service::unimplemented_method(R"ex(NestedType::getDepth)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(NestedType::getNested is not implemented)ex");
+				throw service::unimplemented_method(R"ex(NestedType::getNested)ex");
 			}
 		}
 

--- a/samples/today/schema/NestedTypeObject.h
+++ b/samples/today/schema/NestedTypeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::NestedTypeHas
 
-class [[nodiscard]] NestedType final
+class [[nodiscard("unnecessary construction")]] NestedType final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveDepth(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDepth(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<int> getDepth(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::NestedTypeHas::getDepthWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::NestedTypeHas::getNestedWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit NestedType(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(NestedType)gql" };
 	}

--- a/samples/today/schema/NodeObject.h
+++ b/samples/today/schema/NodeObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::today::object {
 
-class [[nodiscard]] Node final
+class [[nodiscard("unnecessary construction")]] Node final
 	: public service::Object
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
-		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept override
+		[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept override
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept override
+		[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept override
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/today/schema/PageInfoObject.h
+++ b/samples/today/schema/PageInfoObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::PageInfoHas
 
-class [[nodiscard]] PageInfo final
+class [[nodiscard("unnecessary construction")]] PageInfo final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveHasNextPage(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveHasPreviousPage(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveHasNextPage(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveHasPreviousPage(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getHasNextPage(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::PageInfoHas::getHasNextPageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getHasPreviousPage(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::PageInfoHas::getHasPreviousPageWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit PageInfo(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(PageInfo)gql" };
 	}

--- a/samples/today/schema/PageInfoObject.h
+++ b/samples/today/schema/PageInfoObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(PageInfo::getHasNextPage is not implemented)ex");
+				throw service::unimplemented_method(R"ex(PageInfo::getHasNextPage)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(PageInfo::getHasPreviousPage is not implemented)ex");
+				throw service::unimplemented_method(R"ex(PageInfo::getHasPreviousPage)ex");
 			}
 		}
 

--- a/samples/today/schema/QueryObject.h
+++ b/samples/today/schema/QueryObject.h
@@ -250,7 +250,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getNode is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getNode)ex");
 			}
 		}
 
@@ -266,7 +266,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getAppointments is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getAppointments)ex");
 			}
 		}
 
@@ -282,7 +282,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getTasks is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getTasks)ex");
 			}
 		}
 
@@ -298,7 +298,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getUnreadCounts is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getUnreadCounts)ex");
 			}
 		}
 
@@ -314,7 +314,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getAppointmentsById is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getAppointmentsById)ex");
 			}
 		}
 
@@ -330,7 +330,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getTasksById is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getTasksById)ex");
 			}
 		}
 
@@ -346,7 +346,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getUnreadCountsById is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getUnreadCountsById)ex");
 			}
 		}
 
@@ -362,7 +362,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getNested is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getNested)ex");
 			}
 		}
 
@@ -378,7 +378,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getUnimplemented is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getUnimplemented)ex");
 			}
 		}
 
@@ -394,7 +394,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getExpensive is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getExpensive)ex");
 			}
 		}
 
@@ -410,7 +410,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getTestTaskState is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getTestTaskState)ex");
 			}
 		}
 
@@ -426,7 +426,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getAnyType is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getAnyType)ex");
 			}
 		}
 
@@ -442,7 +442,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getDefault is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getDefault)ex");
 			}
 		}
 

--- a/samples/today/schema/QueryObject.h
+++ b/samples/today/schema/QueryObject.h
@@ -183,54 +183,54 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::QueryHas
 
-class [[nodiscard]] Query final
+class [[nodiscard("unnecessary construction")]] Query final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveAppointments(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveTasks(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveUnreadCounts(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveAppointmentsById(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveTasksById(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveUnreadCountsById(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveUnimplemented(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveExpensive(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveTestTaskState(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveAnyType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDefault(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveAppointments(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveTasks(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveUnreadCounts(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveAppointmentsById(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveTasksById(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveUnreadCountsById(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNested(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveUnimplemented(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveExpensive(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveTestTaskState(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveAnyType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDefault(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolve_schema(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolve_type(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_schema(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_type(service::ResolverParams&& params) const;
 
 	std::shared_ptr<schema::Schema> _schema;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -238,7 +238,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Node>> getNode(service::FieldParams&& params, response::IdType&& idArg) const override
 		{
 			if constexpr (methods::QueryHas::getNodeWithParams<T>)
 			{
@@ -254,7 +254,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<AppointmentConnection>> getAppointments(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const override
 		{
 			if constexpr (methods::QueryHas::getAppointmentsWithParams<T>)
 			{
@@ -270,7 +270,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<TaskConnection>> getTasks(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const override
 		{
 			if constexpr (methods::QueryHas::getTasksWithParams<T>)
 			{
@@ -286,7 +286,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<FolderConnection>> getUnreadCounts(service::FieldParams&& params, std::optional<int>&& firstArg, std::optional<response::Value>&& afterArg, std::optional<int>&& lastArg, std::optional<response::Value>&& beforeArg) const override
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsWithParams<T>)
 			{
@@ -302,7 +302,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<Appointment>>> getAppointmentsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
 		{
 			if constexpr (methods::QueryHas::getAppointmentsByIdWithParams<T>)
 			{
@@ -318,7 +318,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<Task>>> getTasksById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
 		{
 			if constexpr (methods::QueryHas::getTasksByIdWithParams<T>)
 			{
@@ -334,7 +334,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<Folder>>> getUnreadCountsById(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
 		{
 			if constexpr (methods::QueryHas::getUnreadCountsByIdWithParams<T>)
 			{
@@ -350,7 +350,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<NestedType>> getNested(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getNestedWithParams<T>)
 			{
@@ -366,7 +366,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getUnimplemented(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getUnimplementedWithParams<T>)
 			{
@@ -382,7 +382,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<Expensive>>> getExpensive(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getExpensiveWithParams<T>)
 			{
@@ -398,7 +398,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<TaskState> getTestTaskState(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getTestTaskStateWithParams<T>)
 			{
@@ -414,7 +414,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<UnionType>>> getAnyType(service::FieldParams&& params, std::vector<response::IdType>&& idsArg) const override
 		{
 			if constexpr (methods::QueryHas::getAnyTypeWithParams<T>)
 			{
@@ -430,7 +430,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDefault(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getDefaultWithParams<T>)
 			{
@@ -468,8 +468,8 @@ private:
 
 	explicit Query(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -483,7 +483,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Query)gql" };
 	}

--- a/samples/today/schema/SubscriptionObject.h
+++ b/samples/today/schema/SubscriptionObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Subscription::getNextAppointmentChange is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Subscription::getNextAppointmentChange)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Subscription::getNodeChange is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Subscription::getNodeChange)ex");
 			}
 		}
 

--- a/samples/today/schema/SubscriptionObject.h
+++ b/samples/today/schema/SubscriptionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::SubscriptionHas
 
-class [[nodiscard]] Subscription final
+class [[nodiscard("unnecessary construction")]] Subscription final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveNextAppointmentChange(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveNodeChange(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNextAppointmentChange(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNodeChange(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Appointment>> getNextAppointmentChange(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::SubscriptionHas::getNextAppointmentChangeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Node>> getNodeChange(service::FieldParams&& params, response::IdType&& idArg) const override
 		{
 			if constexpr (methods::SubscriptionHas::getNodeChangeWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit Subscription(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Subscription)gql" };
 	}

--- a/samples/today/schema/TaskConnectionObject.h
+++ b/samples/today/schema/TaskConnectionObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(TaskConnection::getPageInfo is not implemented)ex");
+				throw service::unimplemented_method(R"ex(TaskConnection::getPageInfo)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(TaskConnection::getEdges is not implemented)ex");
+				throw service::unimplemented_method(R"ex(TaskConnection::getEdges)ex");
 			}
 		}
 

--- a/samples/today/schema/TaskConnectionObject.h
+++ b/samples/today/schema/TaskConnectionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskConnectionHas
 
-class [[nodiscard]] TaskConnection final
+class [[nodiscard("unnecessary construction")]] TaskConnection final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolvePageInfo(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveEdges(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<PageInfo>> getPageInfo(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskConnectionHas::getPageInfoWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<TaskEdge>>>> getEdges(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskConnectionHas::getEdgesWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit TaskConnection(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(TaskConnection)gql" };
 	}

--- a/samples/today/schema/TaskEdgeObject.h
+++ b/samples/today/schema/TaskEdgeObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(TaskEdge::getNode is not implemented)ex");
+				throw service::unimplemented_method(R"ex(TaskEdge::getNode)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(TaskEdge::getCursor is not implemented)ex");
+				throw service::unimplemented_method(R"ex(TaskEdge::getCursor)ex");
 			}
 		}
 

--- a/samples/today/schema/TaskEdgeObject.h
+++ b/samples/today/schema/TaskEdgeObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskEdgeHas
 
-class [[nodiscard]] TaskEdge final
+class [[nodiscard("unnecessary construction")]] TaskEdge final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNode(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveCursor(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Task>> getNode(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskEdgeHas::getNodeWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::Value> getCursor(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskEdgeHas::getCursorWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit TaskEdge(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(TaskEdge)gql" };
 	}

--- a/samples/today/schema/TaskObject.h
+++ b/samples/today/schema/TaskObject.h
@@ -113,7 +113,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Task::getId is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Task::getId)ex");
 			}
 		}
 
@@ -129,7 +129,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Task::getTitle is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Task::getTitle)ex");
 			}
 		}
 
@@ -145,7 +145,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Task::getIsComplete is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Task::getIsComplete)ex");
 			}
 		}
 

--- a/samples/today/schema/TaskObject.h
+++ b/samples/today/schema/TaskObject.h
@@ -70,30 +70,30 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::TaskHas
 
-class [[nodiscard]] Task final
+class [[nodiscard("unnecessary construction")]] Task final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveTitle(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveIsComplete(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveTitle(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveIsComplete(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -101,7 +101,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskHas::getIdWithParams<T>)
 			{
@@ -117,7 +117,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getTitle(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskHas::getTitleWithParams<T>)
 			{
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getIsComplete(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::TaskHas::getIsCompleteWithParams<T>)
 			{
@@ -178,13 +178,13 @@ private:
 	friend UnionType;
 
 	template <class I>
-	[[nodiscard]] static constexpr bool implements() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr bool implements() noexcept
 	{
 		return implements::TaskIs<I>;
 	}
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -198,7 +198,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Task)gql" };
 	}

--- a/samples/today/schema/TodaySchema.cpp
+++ b/samples/today/schema/TodaySchema.cpp
@@ -229,6 +229,7 @@ namespace today {
 
 CompleteTaskInput::CompleteTaskInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 CompleteTaskInput::CompleteTaskInput(
@@ -259,6 +260,11 @@ CompleteTaskInput::CompleteTaskInput(CompleteTaskInput&& other) noexcept
 {
 }
 
+CompleteTaskInput::~CompleteTaskInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 CompleteTaskInput& CompleteTaskInput::operator=(const CompleteTaskInput& other)
 {
 	CompleteTaskInput value { other };
@@ -278,12 +284,9 @@ CompleteTaskInput& CompleteTaskInput::operator=(CompleteTaskInput&& other) noexc
 	return *this;
 }
 
-CompleteTaskInput::~CompleteTaskInput()
-{
-}
-
 ThirdNestedInput::ThirdNestedInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 ThirdNestedInput::ThirdNestedInput(
@@ -306,6 +309,11 @@ ThirdNestedInput::ThirdNestedInput(ThirdNestedInput&& other) noexcept
 {
 }
 
+ThirdNestedInput::~ThirdNestedInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 ThirdNestedInput& ThirdNestedInput::operator=(const ThirdNestedInput& other)
 {
 	ThirdNestedInput value { other };
@@ -323,12 +331,9 @@ ThirdNestedInput& ThirdNestedInput::operator=(ThirdNestedInput&& other) noexcept
 	return *this;
 }
 
-ThirdNestedInput::~ThirdNestedInput()
-{
-}
-
 FourthNestedInput::FourthNestedInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 FourthNestedInput::FourthNestedInput(
@@ -347,6 +352,11 @@ FourthNestedInput::FourthNestedInput(FourthNestedInput&& other) noexcept
 {
 }
 
+FourthNestedInput::~FourthNestedInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 FourthNestedInput& FourthNestedInput::operator=(const FourthNestedInput& other)
 {
 	FourthNestedInput value { other };
@@ -363,12 +373,9 @@ FourthNestedInput& FourthNestedInput::operator=(FourthNestedInput&& other) noexc
 	return *this;
 }
 
-FourthNestedInput::~FourthNestedInput()
-{
-}
-
 IncludeNullableSelfInput::IncludeNullableSelfInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 IncludeNullableSelfInput::IncludeNullableSelfInput(
@@ -387,6 +394,11 @@ IncludeNullableSelfInput::IncludeNullableSelfInput(IncludeNullableSelfInput&& ot
 {
 }
 
+IncludeNullableSelfInput::~IncludeNullableSelfInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 IncludeNullableSelfInput& IncludeNullableSelfInput::operator=(const IncludeNullableSelfInput& other)
 {
 	IncludeNullableSelfInput value { other };
@@ -403,12 +415,9 @@ IncludeNullableSelfInput& IncludeNullableSelfInput::operator=(IncludeNullableSel
 	return *this;
 }
 
-IncludeNullableSelfInput::~IncludeNullableSelfInput()
-{
-}
-
 IncludeNonNullableListSelfInput::IncludeNonNullableListSelfInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 IncludeNonNullableListSelfInput::IncludeNonNullableListSelfInput(
@@ -427,6 +436,11 @@ IncludeNonNullableListSelfInput::IncludeNonNullableListSelfInput(IncludeNonNulla
 {
 }
 
+IncludeNonNullableListSelfInput::~IncludeNonNullableListSelfInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 IncludeNonNullableListSelfInput& IncludeNonNullableListSelfInput::operator=(const IncludeNonNullableListSelfInput& other)
 {
 	IncludeNonNullableListSelfInput value { other };
@@ -443,12 +457,9 @@ IncludeNonNullableListSelfInput& IncludeNonNullableListSelfInput::operator=(Incl
 	return *this;
 }
 
-IncludeNonNullableListSelfInput::~IncludeNonNullableListSelfInput()
-{
-}
-
 StringOperationFilterInput::StringOperationFilterInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 StringOperationFilterInput::StringOperationFilterInput(
@@ -511,6 +522,11 @@ StringOperationFilterInput::StringOperationFilterInput(StringOperationFilterInpu
 {
 }
 
+StringOperationFilterInput::~StringOperationFilterInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 StringOperationFilterInput& StringOperationFilterInput::operator=(const StringOperationFilterInput& other)
 {
 	StringOperationFilterInput value { other };
@@ -538,12 +554,9 @@ StringOperationFilterInput& StringOperationFilterInput::operator=(StringOperatio
 	return *this;
 }
 
-StringOperationFilterInput::~StringOperationFilterInput()
-{
-}
-
 SecondNestedInput::SecondNestedInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 SecondNestedInput::SecondNestedInput(
@@ -566,6 +579,11 @@ SecondNestedInput::SecondNestedInput(SecondNestedInput&& other) noexcept
 {
 }
 
+SecondNestedInput::~SecondNestedInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 SecondNestedInput& SecondNestedInput::operator=(const SecondNestedInput& other)
 {
 	SecondNestedInput value { other };
@@ -583,12 +601,9 @@ SecondNestedInput& SecondNestedInput::operator=(SecondNestedInput&& other) noexc
 	return *this;
 }
 
-SecondNestedInput::~SecondNestedInput()
-{
-}
-
 ForwardDeclaredInput::ForwardDeclaredInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 ForwardDeclaredInput::ForwardDeclaredInput(
@@ -611,6 +626,11 @@ ForwardDeclaredInput::ForwardDeclaredInput(ForwardDeclaredInput&& other) noexcep
 {
 }
 
+ForwardDeclaredInput::~ForwardDeclaredInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 ForwardDeclaredInput& ForwardDeclaredInput::operator=(const ForwardDeclaredInput& other)
 {
 	ForwardDeclaredInput value { other };
@@ -628,12 +648,9 @@ ForwardDeclaredInput& ForwardDeclaredInput::operator=(ForwardDeclaredInput&& oth
 	return *this;
 }
 
-ForwardDeclaredInput::~ForwardDeclaredInput()
-{
-}
-
 FirstNestedInput::FirstNestedInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 FirstNestedInput::FirstNestedInput(
@@ -660,6 +677,11 @@ FirstNestedInput::FirstNestedInput(FirstNestedInput&& other) noexcept
 {
 }
 
+FirstNestedInput::~FirstNestedInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 FirstNestedInput& FirstNestedInput::operator=(const FirstNestedInput& other)
 {
 	FirstNestedInput value { other };
@@ -676,10 +698,6 @@ FirstNestedInput& FirstNestedInput::operator=(FirstNestedInput&& other) noexcept
 	third = std::move(other.third);
 
 	return *this;
-}
-
-FirstNestedInput::~FirstNestedInput()
-{
 }
 
 Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<object::Mutation> mutation, std::shared_ptr<object::Subscription> subscription)

--- a/samples/today/schema/TodaySchema.h
+++ b/samples/today/schema/TodaySchema.h
@@ -22,7 +22,7 @@ static_assert(graphql::internal::MinorVersion == 5, "regenerate with schemagen: 
 namespace graphql {
 namespace today {
 
-enum class [[nodiscard]] TaskState
+enum class [[nodiscard("unnecessary conversion")]] TaskState
 {
 	Unassigned,
 	New,
@@ -30,7 +30,7 @@ enum class [[nodiscard]] TaskState
 	Complete
 };
 
-[[nodiscard]] constexpr auto getTaskStateNames() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getTaskStateNames() noexcept
 {
 	using namespace std::literals;
 
@@ -42,7 +42,7 @@ enum class [[nodiscard]] TaskState
 	};
 }
 
-[[nodiscard]] constexpr auto getTaskStateValues() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getTaskStateValues() noexcept
 {
 	using namespace std::literals;
 
@@ -54,7 +54,7 @@ enum class [[nodiscard]] TaskState
 	};
 }
 
-struct [[nodiscard]] CompleteTaskInput
+struct [[nodiscard("unnecessary construction")]] CompleteTaskInput
 {
 	explicit CompleteTaskInput() noexcept;
 	explicit CompleteTaskInput(
@@ -77,7 +77,7 @@ struct [[nodiscard]] CompleteTaskInput
 
 struct SecondNestedInput;
 
-struct [[nodiscard]] ThirdNestedInput
+struct [[nodiscard("unnecessary construction")]] ThirdNestedInput
 {
 	explicit ThirdNestedInput() noexcept;
 	explicit ThirdNestedInput(
@@ -94,7 +94,7 @@ struct [[nodiscard]] ThirdNestedInput
 	std::unique_ptr<SecondNestedInput> second {};
 };
 
-struct [[nodiscard]] FourthNestedInput
+struct [[nodiscard("unnecessary construction")]] FourthNestedInput
 {
 	explicit FourthNestedInput() noexcept;
 	explicit FourthNestedInput(
@@ -109,7 +109,7 @@ struct [[nodiscard]] FourthNestedInput
 	response::IdType id {};
 };
 
-struct [[nodiscard]] IncludeNullableSelfInput
+struct [[nodiscard("unnecessary construction")]] IncludeNullableSelfInput
 {
 	explicit IncludeNullableSelfInput() noexcept;
 	explicit IncludeNullableSelfInput(
@@ -124,7 +124,7 @@ struct [[nodiscard]] IncludeNullableSelfInput
 	std::unique_ptr<IncludeNullableSelfInput> self {};
 };
 
-struct [[nodiscard]] IncludeNonNullableListSelfInput
+struct [[nodiscard("unnecessary construction")]] IncludeNonNullableListSelfInput
 {
 	explicit IncludeNonNullableListSelfInput() noexcept;
 	explicit IncludeNonNullableListSelfInput(
@@ -139,7 +139,7 @@ struct [[nodiscard]] IncludeNonNullableListSelfInput
 	std::vector<IncludeNonNullableListSelfInput> selves {};
 };
 
-struct [[nodiscard]] StringOperationFilterInput
+struct [[nodiscard("unnecessary construction")]] StringOperationFilterInput
 {
 	explicit StringOperationFilterInput() noexcept;
 	explicit StringOperationFilterInput(
@@ -176,7 +176,7 @@ struct [[nodiscard]] StringOperationFilterInput
 	std::optional<std::string> notEndsWith {};
 };
 
-struct [[nodiscard]] SecondNestedInput
+struct [[nodiscard("unnecessary construction")]] SecondNestedInput
 {
 	explicit SecondNestedInput() noexcept;
 	explicit SecondNestedInput(
@@ -193,7 +193,7 @@ struct [[nodiscard]] SecondNestedInput
 	ThirdNestedInput third {};
 };
 
-struct [[nodiscard]] ForwardDeclaredInput
+struct [[nodiscard("unnecessary construction")]] ForwardDeclaredInput
 {
 	explicit ForwardDeclaredInput() noexcept;
 	explicit ForwardDeclaredInput(
@@ -210,7 +210,7 @@ struct [[nodiscard]] ForwardDeclaredInput
 	IncludeNonNullableListSelfInput listSelves {};
 };
 
-struct [[nodiscard]] FirstNestedInput
+struct [[nodiscard("unnecessary construction")]] FirstNestedInput
 {
 	explicit FirstNestedInput() noexcept;
 	explicit FirstNestedInput(
@@ -254,7 +254,7 @@ class Expensive;
 
 } // namespace object
 
-class [[nodiscard]] Operations final
+class [[nodiscard("unnecessary construction")]] Operations final
 	: public service::Request
 {
 public:

--- a/samples/today/schema/UnionTypeObject.h
+++ b/samples/today/schema/UnionTypeObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::today::object {
 
-class [[nodiscard]] UnionType final
+class [[nodiscard("unnecessary construction")]] UnionType final
 	: public service::Object
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
-		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept override
+		[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept override
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept override
+		[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept override
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/AlienObject.h
+++ b/samples/validation/schema/AlienObject.h
@@ -58,28 +58,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::AlienHas
 
-class [[nodiscard]] Alien final
+class [[nodiscard("unnecessary construction")]] Alien final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveHomePlanet(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveHomePlanet(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -87,7 +87,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AlienHas::getNameWithParams<T>)
 			{
@@ -103,7 +103,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getHomePlanet(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::AlienHas::getHomePlanetWithParams<T>)
 			{
@@ -148,13 +148,13 @@ private:
 	friend HumanOrAlien;
 
 	template <class I>
-	[[nodiscard]] static constexpr bool implements() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr bool implements() noexcept
 	{
 		return implements::AlienIs<I>;
 	}
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -168,7 +168,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Alien)gql" };
 	}

--- a/samples/validation/schema/AlienObject.h
+++ b/samples/validation/schema/AlienObject.h
@@ -99,7 +99,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Alien::getName is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Alien::getName)ex");
 			}
 		}
 
@@ -115,7 +115,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Alien::getHomePlanet is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Alien::getHomePlanet)ex");
 			}
 		}
 

--- a/samples/validation/schema/ArgumentsObject.h
+++ b/samples/validation/schema/ArgumentsObject.h
@@ -123,40 +123,40 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::ArgumentsHas
 
-class [[nodiscard]] Arguments final
+class [[nodiscard("unnecessary construction")]] Arguments final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveMultipleReqs(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveBooleanArgField(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveFloatArgField(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveIntArgField(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveNonNullBooleanArgField(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveNonNullBooleanListField(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveBooleanListArgField(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveOptionalNonNullBooleanArgField(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveMultipleReqs(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveBooleanArgField(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveFloatArgField(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveIntArgField(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNonNullBooleanArgField(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNonNullBooleanListField(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveBooleanListArgField(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveOptionalNonNullBooleanArgField(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -164,7 +164,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<int> getMultipleReqs(service::FieldParams&& params, int&& xArg, int&& yArg) const override
 		{
 			if constexpr (methods::ArgumentsHas::getMultipleReqsWithParams<T>)
 			{
@@ -180,7 +180,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<bool>> getBooleanArgField(service::FieldParams&& params, std::optional<bool>&& booleanArgArg) const override
 		{
 			if constexpr (methods::ArgumentsHas::getBooleanArgFieldWithParams<T>)
 			{
@@ -196,7 +196,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<double>> getFloatArgField(service::FieldParams&& params, std::optional<double>&& floatArgArg) const override
 		{
 			if constexpr (methods::ArgumentsHas::getFloatArgFieldWithParams<T>)
 			{
@@ -212,7 +212,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<int>> getIntArgField(service::FieldParams&& params, std::optional<int>&& intArgArg) const override
 		{
 			if constexpr (methods::ArgumentsHas::getIntArgFieldWithParams<T>)
 			{
@@ -228,7 +228,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getNonNullBooleanArgField(service::FieldParams&& params, bool&& nonNullBooleanArgArg) const override
 		{
 			if constexpr (methods::ArgumentsHas::getNonNullBooleanArgFieldWithParams<T>)
 			{
@@ -244,7 +244,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::vector<bool>>> getNonNullBooleanListField(service::FieldParams&& params, std::optional<std::vector<bool>>&& nonNullBooleanListArgArg) const override
 		{
 			if constexpr (methods::ArgumentsHas::getNonNullBooleanListFieldWithParams<T>)
 			{
@@ -260,7 +260,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::vector<std::optional<bool>>>> getBooleanListArgField(service::FieldParams&& params, std::vector<std::optional<bool>>&& booleanListArgArg) const override
 		{
 			if constexpr (methods::ArgumentsHas::getBooleanListArgFieldWithParams<T>)
 			{
@@ -276,7 +276,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getOptionalNonNullBooleanArgField(service::FieldParams&& params, bool&& optionalBooleanArgArg) const override
 		{
 			if constexpr (methods::ArgumentsHas::getOptionalNonNullBooleanArgFieldWithParams<T>)
 			{
@@ -314,8 +314,8 @@ private:
 
 	explicit Arguments(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -329,7 +329,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Arguments)gql" };
 	}

--- a/samples/validation/schema/ArgumentsObject.h
+++ b/samples/validation/schema/ArgumentsObject.h
@@ -176,7 +176,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Arguments::getMultipleReqs is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Arguments::getMultipleReqs)ex");
 			}
 		}
 
@@ -192,7 +192,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Arguments::getBooleanArgField is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Arguments::getBooleanArgField)ex");
 			}
 		}
 
@@ -208,7 +208,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Arguments::getFloatArgField is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Arguments::getFloatArgField)ex");
 			}
 		}
 
@@ -224,7 +224,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Arguments::getIntArgField is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Arguments::getIntArgField)ex");
 			}
 		}
 
@@ -240,7 +240,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Arguments::getNonNullBooleanArgField is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Arguments::getNonNullBooleanArgField)ex");
 			}
 		}
 
@@ -256,7 +256,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Arguments::getNonNullBooleanListField is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Arguments::getNonNullBooleanListField)ex");
 			}
 		}
 
@@ -272,7 +272,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Arguments::getBooleanListArgField is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Arguments::getBooleanListArgField)ex");
 			}
 		}
 
@@ -288,7 +288,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Arguments::getOptionalNonNullBooleanArgField is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Arguments::getOptionalNonNullBooleanArgField)ex");
 			}
 		}
 

--- a/samples/validation/schema/CatObject.h
+++ b/samples/validation/schema/CatObject.h
@@ -127,7 +127,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Cat::getName is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Cat::getName)ex");
 			}
 		}
 
@@ -143,7 +143,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Cat::getNickname is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Cat::getNickname)ex");
 			}
 		}
 
@@ -159,7 +159,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Cat::getDoesKnowCommand is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Cat::getDoesKnowCommand)ex");
 			}
 		}
 
@@ -175,7 +175,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Cat::getMeowVolume is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Cat::getMeowVolume)ex");
 			}
 		}
 

--- a/samples/validation/schema/CatObject.h
+++ b/samples/validation/schema/CatObject.h
@@ -82,32 +82,32 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::CatHas
 
-class [[nodiscard]] Cat final
+class [[nodiscard("unnecessary construction")]] Cat final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveNickname(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDoesKnowCommand(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveMeowVolume(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNickname(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDoesKnowCommand(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveMeowVolume(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -115,7 +115,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::CatHas::getNameWithParams<T>)
 			{
@@ -131,7 +131,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::CatHas::getNicknameWithParams<T>)
 			{
@@ -147,7 +147,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, CatCommand&& catCommandArg) const override
 		{
 			if constexpr (methods::CatHas::getDoesKnowCommandWithParams<T>)
 			{
@@ -163,7 +163,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<int>> getMeowVolume(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::CatHas::getMeowVolumeWithParams<T>)
 			{
@@ -208,13 +208,13 @@ private:
 	friend CatOrDog;
 
 	template <class I>
-	[[nodiscard]] static constexpr bool implements() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr bool implements() noexcept
 	{
 		return implements::CatIs<I>;
 	}
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -228,7 +228,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Cat)gql" };
 	}

--- a/samples/validation/schema/CatOrDogObject.h
+++ b/samples/validation/schema/CatOrDogObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class [[nodiscard]] CatOrDog final
+class [[nodiscard("unnecessary construction")]] CatOrDog final
 	: public service::Object
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
-		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept override
+		[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept override
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept override
+		[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept override
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/DogObject.h
+++ b/samples/validation/schema/DogObject.h
@@ -155,7 +155,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Dog::getName is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Dog::getName)ex");
 			}
 		}
 
@@ -171,7 +171,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Dog::getNickname is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Dog::getNickname)ex");
 			}
 		}
 
@@ -187,7 +187,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Dog::getBarkVolume is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Dog::getBarkVolume)ex");
 			}
 		}
 
@@ -203,7 +203,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Dog::getDoesKnowCommand is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Dog::getDoesKnowCommand)ex");
 			}
 		}
 
@@ -219,7 +219,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Dog::getIsHousetrained is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Dog::getIsHousetrained)ex");
 			}
 		}
 
@@ -235,7 +235,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Dog::getOwner is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Dog::getOwner)ex");
 			}
 		}
 

--- a/samples/validation/schema/DogObject.h
+++ b/samples/validation/schema/DogObject.h
@@ -106,36 +106,36 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::DogHas
 
-class [[nodiscard]] Dog final
+class [[nodiscard("unnecessary construction")]] Dog final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveNickname(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveBarkVolume(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDoesKnowCommand(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveIsHousetrained(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveOwner(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNickname(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveBarkVolume(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDoesKnowCommand(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveIsHousetrained(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveOwner(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -143,7 +143,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::DogHas::getNameWithParams<T>)
 			{
@@ -159,7 +159,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getNickname(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::DogHas::getNicknameWithParams<T>)
 			{
@@ -175,7 +175,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<int>> getBarkVolume(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::DogHas::getBarkVolumeWithParams<T>)
 			{
@@ -191,7 +191,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getDoesKnowCommand(service::FieldParams&& params, DogCommand&& dogCommandArg) const override
 		{
 			if constexpr (methods::DogHas::getDoesKnowCommandWithParams<T>)
 			{
@@ -207,7 +207,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getIsHousetrained(service::FieldParams&& params, std::optional<bool>&& atOtherHomesArg) const override
 		{
 			if constexpr (methods::DogHas::getIsHousetrainedWithParams<T>)
 			{
@@ -223,7 +223,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Human>> getOwner(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::DogHas::getOwnerWithParams<T>)
 			{
@@ -269,13 +269,13 @@ private:
 	friend DogOrHuman;
 
 	template <class I>
-	[[nodiscard]] static constexpr bool implements() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr bool implements() noexcept
 	{
 		return implements::DogIs<I>;
 	}
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -289,7 +289,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Dog)gql" };
 	}

--- a/samples/validation/schema/DogOrHumanObject.h
+++ b/samples/validation/schema/DogOrHumanObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class [[nodiscard]] DogOrHuman final
+class [[nodiscard("unnecessary construction")]] DogOrHuman final
 	: public service::Object
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
-		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept override
+		[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept override
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept override
+		[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept override
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/HumanObject.h
+++ b/samples/validation/schema/HumanObject.h
@@ -58,28 +58,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::HumanHas
 
-class [[nodiscard]] Human final
+class [[nodiscard("unnecessary construction")]] Human final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolvePets(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolvePets(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -87,7 +87,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getName(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::HumanHas::getNameWithParams<T>)
 			{
@@ -103,7 +103,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<Pet>>> getPets(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::HumanHas::getPetsWithParams<T>)
 			{
@@ -149,13 +149,13 @@ private:
 	friend HumanOrAlien;
 
 	template <class I>
-	[[nodiscard]] static constexpr bool implements() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr bool implements() noexcept
 	{
 		return implements::HumanIs<I>;
 	}
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -169,7 +169,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Human)gql" };
 	}

--- a/samples/validation/schema/HumanObject.h
+++ b/samples/validation/schema/HumanObject.h
@@ -99,7 +99,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Human::getName is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Human::getName)ex");
 			}
 		}
 
@@ -115,7 +115,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Human::getPets is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Human::getPets)ex");
 			}
 		}
 

--- a/samples/validation/schema/HumanOrAlienObject.h
+++ b/samples/validation/schema/HumanOrAlienObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class [[nodiscard]] HumanOrAlien final
+class [[nodiscard("unnecessary construction")]] HumanOrAlien final
 	: public service::Object
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
-		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept override
+		[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept override
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept override
+		[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept override
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/MessageObject.h
+++ b/samples/validation/schema/MessageObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Message::getBody is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Message::getBody)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Message::getSender is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Message::getSender)ex");
 			}
 		}
 

--- a/samples/validation/schema/MessageObject.h
+++ b/samples/validation/schema/MessageObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MessageHas
 
-class [[nodiscard]] Message final
+class [[nodiscard("unnecessary construction")]] Message final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveBody(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveSender(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveBody(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveSender(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getBody(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::MessageHas::getBodyWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::IdType> getSender(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::MessageHas::getSenderWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit Message(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Message)gql" };
 	}

--- a/samples/validation/schema/MutateDogResultObject.h
+++ b/samples/validation/schema/MutateDogResultObject.h
@@ -78,7 +78,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(MutateDogResult::getId is not implemented)ex");
+				throw service::unimplemented_method(R"ex(MutateDogResult::getId)ex");
 			}
 		}
 

--- a/samples/validation/schema/MutateDogResultObject.h
+++ b/samples/validation/schema/MutateDogResultObject.h
@@ -39,26 +39,26 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutateDogResultHas
 
-class [[nodiscard]] MutateDogResult final
+class [[nodiscard("unnecessary construction")]] MutateDogResult final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveId(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<response::IdType> getId(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::MutateDogResultHas::getIdWithParams<T>)
 			{
@@ -104,8 +104,8 @@ private:
 
 	explicit MutateDogResult(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -119,7 +119,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(MutateDogResult)gql" };
 	}

--- a/samples/validation/schema/MutationObject.h
+++ b/samples/validation/schema/MutationObject.h
@@ -78,7 +78,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Mutation::applyMutateDog is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Mutation::applyMutateDog)ex");
 			}
 		}
 

--- a/samples/validation/schema/MutationObject.h
+++ b/samples/validation/schema/MutationObject.h
@@ -39,26 +39,26 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::MutationHas
 
-class [[nodiscard]] Mutation final
+class [[nodiscard("unnecessary construction")]] Mutation final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveMutateDog(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveMutateDog(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -66,7 +66,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<MutateDogResult>> applyMutateDog(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::MutationHas::applyMutateDogWithParams<T>)
 			{
@@ -104,8 +104,8 @@ private:
 
 	explicit Mutation(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -119,7 +119,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Mutation)gql" };
 	}

--- a/samples/validation/schema/NodeObject.h
+++ b/samples/validation/schema/NodeObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class [[nodiscard]] Node final
+class [[nodiscard("unnecessary construction")]] Node final
 	: public service::Object
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
-		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept override
+		[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept override
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept override
+		[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept override
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/PetObject.h
+++ b/samples/validation/schema/PetObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class [[nodiscard]] Pet final
+class [[nodiscard("unnecessary construction")]] Pet final
 	: public service::Object
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
-		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept override
+		[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept override
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept override
+		[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept override
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/QueryObject.h
+++ b/samples/validation/schema/QueryObject.h
@@ -176,7 +176,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getDog is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getDog)ex");
 			}
 		}
 
@@ -192,7 +192,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getHuman is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getHuman)ex");
 			}
 		}
 
@@ -208,7 +208,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getPet is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getPet)ex");
 			}
 		}
 
@@ -224,7 +224,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getCatOrDog is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getCatOrDog)ex");
 			}
 		}
 
@@ -240,7 +240,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getArguments is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getArguments)ex");
 			}
 		}
 
@@ -256,7 +256,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getResource is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getResource)ex");
 			}
 		}
 
@@ -272,7 +272,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getFindDog is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getFindDog)ex");
 			}
 		}
 
@@ -288,7 +288,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Query::getBooleanList is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Query::getBooleanList)ex");
 			}
 		}
 

--- a/samples/validation/schema/QueryObject.h
+++ b/samples/validation/schema/QueryObject.h
@@ -123,40 +123,40 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::QueryHas
 
-class [[nodiscard]] Query final
+class [[nodiscard("unnecessary construction")]] Query final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveDog(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveHuman(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolvePet(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveCatOrDog(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveArguments(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveResource(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveFindDog(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveBooleanList(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDog(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveHuman(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolvePet(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveCatOrDog(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveArguments(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveResource(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveFindDog(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveBooleanList(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::unique_ptr<ComplexInput>&& complexArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::unique_ptr<ComplexInput>&& complexArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -164,7 +164,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Dog>> getDog(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getDogWithParams<T>)
 			{
@@ -180,7 +180,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Human>> getHuman(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getHumanWithParams<T>)
 			{
@@ -196,7 +196,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Pet>> getPet(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getPetWithParams<T>)
 			{
@@ -212,7 +212,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<CatOrDog>> getCatOrDog(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getCatOrDogWithParams<T>)
 			{
@@ -228,7 +228,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Arguments>> getArguments(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getArgumentsWithParams<T>)
 			{
@@ -244,7 +244,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Resource>> getResource(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::QueryHas::getResourceWithParams<T>)
 			{
@@ -260,7 +260,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::unique_ptr<ComplexInput>&& complexArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Dog>> getFindDog(service::FieldParams&& params, std::unique_ptr<ComplexInput>&& complexArg) const override
 		{
 			if constexpr (methods::QueryHas::getFindDogWithParams<T>)
 			{
@@ -276,7 +276,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<bool>> getBooleanList(service::FieldParams&& params, std::optional<std::vector<bool>>&& booleanListArgArg) const override
 		{
 			if constexpr (methods::QueryHas::getBooleanListWithParams<T>)
 			{
@@ -314,8 +314,8 @@ private:
 
 	explicit Query(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -329,7 +329,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Query)gql" };
 	}

--- a/samples/validation/schema/ResourceObject.h
+++ b/samples/validation/schema/ResourceObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class [[nodiscard]] Resource final
+class [[nodiscard("unnecessary construction")]] Resource final
 	: public service::Object
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
-		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept override
+		[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept override
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept override
+		[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept override
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/SentientObject.h
+++ b/samples/validation/schema/SentientObject.h
@@ -12,23 +12,23 @@
 
 namespace graphql::validation::object {
 
-class [[nodiscard]] Sentient final
+class [[nodiscard("unnecessary construction")]] Sentient final
 	: public service::Object
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
-		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -36,12 +36,12 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept override
+		[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept override
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept override
+		[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept override
 		{
 			return _pimpl->getResolvers();
 		}

--- a/samples/validation/schema/SubscriptionObject.h
+++ b/samples/validation/schema/SubscriptionObject.h
@@ -51,28 +51,28 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 
 } // namespace methods::SubscriptionHas
 
-class [[nodiscard]] Subscription final
+class [[nodiscard("unnecessary construction")]] Subscription final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveNewMessage(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDisallowedSecondRootField(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveNewMessage(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDisallowedSecondRootField(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -80,7 +80,7 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Message>> getNewMessage(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::SubscriptionHas::getNewMessageWithParams<T>)
 			{
@@ -96,7 +96,7 @@ private:
 			}
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getDisallowedSecondRootField(service::FieldParams&& params) const override
 		{
 			if constexpr (methods::SubscriptionHas::getDisallowedSecondRootFieldWithParams<T>)
 			{
@@ -134,8 +134,8 @@ private:
 
 	explicit Subscription(std::unique_ptr<const Concept> pimpl) noexcept;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -149,7 +149,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql(Subscription)gql" };
 	}

--- a/samples/validation/schema/SubscriptionObject.h
+++ b/samples/validation/schema/SubscriptionObject.h
@@ -92,7 +92,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Subscription::getNewMessage is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Subscription::getNewMessage)ex");
 			}
 		}
 
@@ -108,7 +108,7 @@ private:
 			}
 			else
 			{
-				throw std::runtime_error(R"ex(Subscription::getDisallowedSecondRootField is not implemented)ex");
+				throw service::unimplemented_method(R"ex(Subscription::getDisallowedSecondRootField)ex");
 			}
 		}
 

--- a/samples/validation/schema/ValidationSchema.cpp
+++ b/samples/validation/schema/ValidationSchema.cpp
@@ -155,6 +155,7 @@ namespace validation {
 
 ComplexInput::ComplexInput() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 ComplexInput::ComplexInput(
@@ -177,6 +178,11 @@ ComplexInput::ComplexInput(ComplexInput&& other) noexcept
 {
 }
 
+ComplexInput::~ComplexInput()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
 ComplexInput& ComplexInput::operator=(const ComplexInput& other)
 {
 	ComplexInput value { other };
@@ -192,10 +198,6 @@ ComplexInput& ComplexInput::operator=(ComplexInput&& other) noexcept
 	owner = std::move(other.owner);
 
 	return *this;
-}
-
-ComplexInput::~ComplexInput()
-{
 }
 
 Operations::Operations(std::shared_ptr<object::Query> query, std::shared_ptr<object::Mutation> mutation, std::shared_ptr<object::Subscription> subscription)

--- a/samples/validation/schema/ValidationSchema.h
+++ b/samples/validation/schema/ValidationSchema.h
@@ -22,14 +22,14 @@ static_assert(graphql::internal::MinorVersion == 5, "regenerate with schemagen: 
 namespace graphql {
 namespace validation {
 
-enum class [[nodiscard]] DogCommand
+enum class [[nodiscard("unnecessary conversion")]] DogCommand
 {
 	SIT,
 	DOWN,
 	HEEL
 };
 
-[[nodiscard]] constexpr auto getDogCommandNames() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getDogCommandNames() noexcept
 {
 	using namespace std::literals;
 
@@ -40,7 +40,7 @@ enum class [[nodiscard]] DogCommand
 	};
 }
 
-[[nodiscard]] constexpr auto getDogCommandValues() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getDogCommandValues() noexcept
 {
 	using namespace std::literals;
 
@@ -51,12 +51,12 @@ enum class [[nodiscard]] DogCommand
 	};
 }
 
-enum class [[nodiscard]] CatCommand
+enum class [[nodiscard("unnecessary conversion")]] CatCommand
 {
 	JUMP
 };
 
-[[nodiscard]] constexpr auto getCatCommandNames() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getCatCommandNames() noexcept
 {
 	using namespace std::literals;
 
@@ -65,7 +65,7 @@ enum class [[nodiscard]] CatCommand
 	};
 }
 
-[[nodiscard]] constexpr auto getCatCommandValues() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getCatCommandValues() noexcept
 {
 	using namespace std::literals;
 
@@ -74,7 +74,7 @@ enum class [[nodiscard]] CatCommand
 	};
 }
 
-struct [[nodiscard]] ComplexInput
+struct [[nodiscard("unnecessary construction")]] ComplexInput
 {
 	explicit ComplexInput() noexcept;
 	explicit ComplexInput(
@@ -115,7 +115,7 @@ class Arguments;
 
 } // namespace object
 
-class [[nodiscard]] Operations final
+class [[nodiscard("unnecessary construction")]] Operations final
 	: public service::Request
 {
 public:

--- a/src/ClientGenerator.cpp
+++ b/src/ClientGenerator.cpp
@@ -218,7 +218,8 @@ static_assert(graphql::internal::MinorVersion == )cpp"
 
 			pendingSeparator.reset();
 
-			headerFile << R"cpp(enum class [[nodiscard]] )cpp" << cppType << R"cpp(
+			headerFile << R"cpp(enum class [[nodiscard("unnecessary conversion")]] )cpp" << cppType
+					   << R"cpp(
 {
 )cpp";
 			for (const auto& enumValue : enumType->enumValues())
@@ -269,7 +270,8 @@ static_assert(graphql::internal::MinorVersion == )cpp"
 				pendingSeparator.reset();
 			}
 
-			headerFile << R"cpp(struct [[nodiscard]] )cpp" << cppType << R"cpp(
+			headerFile << R"cpp(struct [[nodiscard("unnecessary construction")]] )cpp" << cppType
+					   << R"cpp(
 {
 	explicit )cpp" << cppType
 					   << R"cpp(()cpp";
@@ -375,7 +377,7 @@ using )cpp" << _schemaLoader.getSchemaNamespace()
 
 		if (!variables.empty())
 		{
-			headerFile << R"cpp(struct [[nodiscard]] Variables
+			headerFile << R"cpp(struct [[nodiscard("unnecessary construction")]] Variables
 {
 )cpp";
 
@@ -390,7 +392,7 @@ using )cpp" << _schemaLoader.getSchemaNamespace()
 
 			headerFile << R"cpp(};
 
-[[nodiscard]] response::Value serializeVariables(Variables&& variables);
+[[nodiscard("unnecessary conversion")]] response::Value serializeVariables(Variables&& variables);
 )cpp";
 
 			pendingSeparator.add();
@@ -400,7 +402,7 @@ using )cpp" << _schemaLoader.getSchemaNamespace()
 
 		const auto& responseType = _requestLoader.getResponseType(operation);
 
-		headerFile << R"cpp(struct [[nodiscard]] Response
+		headerFile << R"cpp(struct [[nodiscard("unnecessary construction")]] Response
 {)cpp";
 
 		pendingSeparator.add();
@@ -428,13 +430,13 @@ using )cpp" << _schemaLoader.getSchemaNamespace()
 
 		headerFile << R"cpp(};
 
-[[nodiscard]] Response parseResponse(response::Value&& response);
+[[nodiscard("unnecessary conversion")]] Response parseResponse(response::Value&& response);
 
 struct Traits
 {
-	[[nodiscard]] static const std::string& GetRequestText() noexcept;
-	[[nodiscard]] static const peg::ast& GetRequestObject() noexcept;
-	[[nodiscard]] static const std::string& GetOperationName() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetRequestText() noexcept;
+	[[nodiscard("unnecessary call")]] static const peg::ast& GetRequestObject() noexcept;
+	[[nodiscard("unnecessary call")]] static const std::string& GetOperationName() noexcept;
 )cpp";
 
 		if (!variables.empty())
@@ -443,7 +445,7 @@ struct Traits
 	using Variables = )cpp"
 					   << _requestLoader.getOperationNamespace(operation) << R"cpp(::Variables;
 
-	[[nodiscard]] static response::Value serializeVariables(Variables&& variables);
+	[[nodiscard("unnecessary conversion")]] static response::Value serializeVariables(Variables&& variables);
 )cpp";
 		}
 
@@ -451,7 +453,7 @@ struct Traits
 	using Response = )cpp"
 				   << _requestLoader.getOperationNamespace(operation) << R"cpp(::Response;
 
-	[[nodiscard]] static Response parseResponse(response::Value&& response);
+	[[nodiscard("unnecessary conversion")]] static Response parseResponse(response::Value&& response);
 };
 
 )cpp";
@@ -512,10 +514,10 @@ void Generator::outputGetRequestDeclaration(std::ostream& headerFile) const noex
 {
 	headerFile << R"cpp(
 // Return the original text of the request document.
-[[nodiscard]] const std::string& GetRequestText() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetRequestText() noexcept;
 
 // Return a pre-parsed, pre-validated request object.
-[[nodiscard]] const peg::ast& GetRequestObject() noexcept;
+[[nodiscard("unnecessary call")]] const peg::ast& GetRequestObject() noexcept;
 )cpp";
 }
 
@@ -523,7 +525,7 @@ void Generator::outputGetOperationNameDeclaration(std::ostream& headerFile) cons
 {
 	headerFile << R"cpp(
 // Return the name of this operation in the shared request document.
-[[nodiscard]] const std::string& GetOperationName() noexcept;
+[[nodiscard("unnecessary call")]] const std::string& GetOperationName() noexcept;
 
 )cpp";
 }
@@ -548,7 +550,7 @@ bool Generator::outputResponseFieldType(std::ostream& headerFile,
 	std::unordered_set<std::string_view> fieldNames;
 	PendingBlankLine pendingSeparator { headerFile };
 
-	headerFile << indentTabs << R"cpp(struct [[nodiscard]] )cpp"
+	headerFile << indentTabs << R"cpp(struct [[nodiscard("unnecessary construction")]] )cpp"
 			   << getResponseFieldCppType(responseField) << R"cpp(
 )cpp" << indentTabs
 			   << R"cpp({)cpp";
@@ -648,6 +650,7 @@ using namespace std::literals;
 
 			sourceFile << cppType << R"cpp(::)cpp" << cppType << R"cpp(() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 )cpp" << cppType << R"cpp(::)cpp"
@@ -736,6 +739,7 @@ using namespace std::literals;
 )cpp" << cppType << R"cpp(::~)cpp"
 					   << cppType << R"cpp(()
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 )cpp" << cppType << R"cpp(& )cpp"
@@ -1045,19 +1049,19 @@ Response parseResponse(response::Value&& response)
 	return result;
 }
 
-[[nodiscard]] const std::string& Traits::GetRequestText() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetRequestText() noexcept
 {
 	return )cpp" << _schemaLoader.getSchemaNamespace()
 				   << R"cpp(::GetRequestText();
 }
 
-[[nodiscard]] const peg::ast& Traits::GetRequestObject() noexcept
+[[nodiscard("unnecessary call")]] const peg::ast& Traits::GetRequestObject() noexcept
 {
 	return )cpp" << _schemaLoader.getSchemaNamespace()
 				   << R"cpp(::GetRequestObject();
 }
 
-[[nodiscard]] const std::string& Traits::GetOperationName() noexcept
+[[nodiscard("unnecessary call")]] const std::string& Traits::GetOperationName() noexcept
 {
 	return )cpp" << _requestLoader.getOperationNamespace(operation)
 				   << R"cpp(::GetOperationName();
@@ -1067,7 +1071,7 @@ Response parseResponse(response::Value&& response)
 		if (!variables.empty())
 		{
 			sourceFile << R"cpp(
-[[nodiscard]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
+[[nodiscard("unnecessary conversion")]] response::Value Traits::serializeVariables(Traits::Variables&& variables)
 {
 	return )cpp" << _requestLoader.getOperationNamespace(operation)
 					   << R"cpp(::serializeVariables(std::move(variables));
@@ -1076,7 +1080,7 @@ Response parseResponse(response::Value&& response)
 		}
 
 		sourceFile << R"cpp(
-[[nodiscard]] Traits::Response Traits::parseResponse(response::Value&& response)
+[[nodiscard("unnecessary conversion")]] Traits::Response Traits::parseResponse(response::Value&& response)
 {
 	return )cpp" << _requestLoader.getOperationNamespace(operation)
 				   << R"cpp(::parseResponse(std::move(response));

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -163,6 +163,22 @@ response::Value schema_exception::getErrors()
 	return buildErrorValues(std::move(_structuredErrors));
 }
 
+unimplemented_method::unimplemented_method(std::string_view methodName)
+	: std::runtime_error { getMessage(methodName) }
+{
+}
+	
+std::string unimplemented_method::getMessage(std::string_view methodName) noexcept
+{
+	using namespace std::literals;
+
+	std::ostringstream oss;
+
+	oss << methodName << R"ex( is not implemented)ex"sv;
+
+	return oss.str();
+}
+
 void await_worker_thread::await_suspend(coro::coroutine_handle<> h) const
 {
 	std::thread(

--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -167,7 +167,7 @@ unimplemented_method::unimplemented_method(std::string_view methodName)
 	: std::runtime_error { getMessage(methodName) }
 {
 }
-	
+
 std::string unimplemented_method::getMessage(std::string_view methodName) noexcept
 {
 	using namespace std::literals;
@@ -232,7 +232,9 @@ void await_worker_queue::resumePending()
 			return _shutdown || !_pending.empty();
 		});
 
-		auto pending = std::move(_pending);
+		std::list<coro::coroutine_handle<>> pending;
+
+		std::swap(pending, _pending);
 
 		lock.unlock();
 
@@ -516,12 +518,11 @@ bool DirectiveVisitor::shouldSkip() const
 		std::make_pair(false, R"gql(include)gql"sv),
 	};
 
-	for (const auto& entry : c_skippedDirectives)
+	for (const auto& [skip, directiveName] : c_skippedDirectives)
 	{
-		const bool skip = entry.first;
 		auto itrDirective = std::find_if(_directives.cbegin(),
 			_directives.cend(),
-			[directiveName = entry.second](const auto& directive) noexcept {
+			[directiveName = directiveName](const auto& directive) noexcept {
 				return directive.first == directiveName;
 			});
 
@@ -536,7 +537,7 @@ bool DirectiveVisitor::shouldSkip() const
 		{
 			std::ostringstream error;
 
-			error << "Invalid arguments to directive: " << entry.second;
+			error << "Invalid arguments to directive: " << directiveName;
 
 			throw schema_exception { { error.str() } };
 		}
@@ -544,20 +545,20 @@ bool DirectiveVisitor::shouldSkip() const
 		bool argumentTrue = false;
 		bool argumentFalse = false;
 
-		for (auto& argument : arguments)
+		for (auto& [argumentName, argumentValue] : arguments)
 		{
-			if (argumentTrue || argumentFalse || argument.second.type() != response::Type::Boolean
-				|| argument.first != "if")
+			if (argumentTrue || argumentFalse || argumentValue.type() != response::Type::Boolean
+				|| argumentName != "if")
 			{
 				std::ostringstream error;
 
-				error << "Invalid argument to directive: " << entry.second
-					  << " name: " << argument.first;
+				error << "Invalid argument to directive: " << directiveName
+					  << " name: " << argumentName;
 
 				throw schema_exception { { error.str() } };
 			}
 
-			argumentTrue = argument.second.get<bool>();
+			argumentTrue = argumentValue.get<bool>();
 			argumentFalse = !argumentTrue;
 		}
 
@@ -573,7 +574,7 @@ bool DirectiveVisitor::shouldSkip() const
 		{
 			std::ostringstream error;
 
-			error << "Missing argument directive: " << entry.second << " name: if";
+			error << "Missing argument directive: " << directiveName << " name: if";
 
 			throw schema_exception { { error.str() } };
 		}
@@ -1312,10 +1313,12 @@ bool Object::matchesType(std::string_view typeName) const
 
 void Object::beginSelectionSet(const SelectionSetParams&) const
 {
+	// This virtual method may be overridden in a sub-class.
 }
 
 void Object::endSelectionSet(const SelectionSetParams&) const
 {
+	// This virtual method may be overridden in a sub-class.
 }
 
 OperationData::OperationData(std::shared_ptr<RequestState> state, response::Value variables,
@@ -1790,9 +1793,10 @@ response::AwaitableValue Request::resolve(RequestResolveParams params) const
 			});
 
 		auto fragments = fragmentVisitor.getFragments();
-		auto operationDefinition = findOperationDefinition(params.query, params.operationName);
+		auto [operationType, operationDefinition] =
+			findOperationDefinition(params.query, params.operationName);
 
-		if (!operationDefinition.second)
+		if (!operationDefinition)
 		{
 			std::ostringstream message;
 
@@ -1805,9 +1809,9 @@ response::AwaitableValue Request::resolve(RequestResolveParams params) const
 
 			throw schema_exception { { message.str() } };
 		}
-		else if (operationDefinition.first == strSubscription)
+		else if (operationType == strSubscription)
 		{
-			auto position = operationDefinition.second->begin();
+			auto position = operationDefinition->begin();
 			std::ostringstream message;
 
 			message << "Unexpected subscription";
@@ -1822,7 +1826,7 @@ response::AwaitableValue Request::resolve(RequestResolveParams params) const
 			};
 		}
 
-		const bool isMutation = (operationDefinition.first == strMutation);
+		const bool isMutation = (operationType == strMutation);
 		const auto resolverContext =
 			isMutation ? ResolverContext::Mutation : ResolverContext::Query;
 		// https://spec.graphql.org/October2021/#sec-Normal-and-Serial-Execution
@@ -1836,7 +1840,7 @@ response::AwaitableValue Request::resolve(RequestResolveParams params) const
 			std::move(fragments));
 
 		co_await params.launch;
-		operationVisitor.visit(operationDefinition.first, *operationDefinition.second);
+		operationVisitor.visit(operationType, *operationDefinition);
 
 		auto result = co_await operationVisitor.getValue();
 		response::Value document { response::Type::Map };
@@ -2067,9 +2071,10 @@ SubscriptionKey Request::addSubscription(RequestSubscribeParams&& params)
 		});
 
 	auto fragments = fragmentVisitor.getFragments();
-	auto operationDefinition = findOperationDefinition(params.query, params.operationName);
+	auto [operationType, operationDefinition] =
+		findOperationDefinition(params.query, params.operationName);
 
-	if (!operationDefinition.second)
+	if (!operationDefinition)
 	{
 		std::ostringstream message;
 
@@ -2082,12 +2087,12 @@ SubscriptionKey Request::addSubscription(RequestSubscribeParams&& params)
 
 		throw schema_exception { { message.str() } };
 	}
-	else if (operationDefinition.first != strSubscription)
+	else if (operationType != strSubscription)
 	{
-		auto position = operationDefinition.second->begin();
+		auto position = operationDefinition->begin();
 		std::ostringstream message;
 
-		message << "Unexpected operation type: " << operationDefinition.first;
+		message << "Unexpected operation type: " << operationType;
 
 		if (!params.operationName.empty())
 		{

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -1028,9 +1028,9 @@ private:
 				headerFile << R"cpp(
 			else
 			{
-				throw std::runtime_error(R"ex()cpp"
+				throw service::unimplemented_method(R"ex()cpp"
 						   << objectType.cppType << R"cpp(::)cpp" << accessorName
-						   << R"cpp( is not implemented)ex");
+						   << R"cpp()ex");
 			})cpp";
 			}
 		}

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -157,7 +157,7 @@ static_assert(graphql::internal::MinorVersion == )cpp"
 
 			if (!_loader.isIntrospection())
 			{
-				headerFile << R"cpp([[nodiscard]] )cpp";
+				headerFile << R"cpp([[nodiscard("unnecessary conversion")]] )cpp";
 			}
 
 			headerFile << enumType.cppType << R"cpp(
@@ -182,8 +182,8 @@ static_assert(graphql::internal::MinorVersion == )cpp"
 
 )cpp";
 
-			headerFile << R"cpp([[nodiscard]] constexpr auto get)cpp" << enumType.cppType
-					   << R"cpp(Names() noexcept
+			headerFile << R"cpp([[nodiscard("unnecessary call")]] constexpr auto get)cpp"
+					   << enumType.cppType << R"cpp(Names() noexcept
 {
 	using namespace std::literals;
 
@@ -209,7 +209,7 @@ static_assert(graphql::internal::MinorVersion == )cpp"
 	};
 }
 
-[[nodiscard]] constexpr auto get)cpp"
+[[nodiscard("unnecessary call")]] constexpr auto get)cpp"
 					   << enumType.cppType << R"cpp(Values() noexcept
 {
 	using namespace std::literals;
@@ -235,7 +235,7 @@ static_assert(graphql::internal::MinorVersion == )cpp"
 
 			firstValue = true;
 
-			for (const auto& value : sortedValues)
+			for (const auto& [enumName, enumValue] : sortedValues)
 			{
 				if (!firstValue)
 				{
@@ -244,9 +244,9 @@ static_assert(graphql::internal::MinorVersion == )cpp"
 				}
 
 				firstValue = false;
-				headerFile << R"cpp(		std::make_pair(R"gql()cpp" << value.first
-						   << R"cpp()gql"sv, )cpp" << enumType.cppType << R"cpp(::)cpp"
-						   << value.second << R"cpp())cpp";
+				headerFile << R"cpp(		std::make_pair(R"gql()cpp" << enumName
+						   << R"cpp()gql"sv, )cpp" << enumType.cppType << R"cpp(::)cpp" << enumValue
+						   << R"cpp())cpp";
 			}
 
 			headerFile << R"cpp(
@@ -286,7 +286,8 @@ static_assert(graphql::internal::MinorVersion == )cpp"
 				pendingSeparator.reset();
 			}
 
-			headerFile << R"cpp(struct [[nodiscard]] )cpp" << inputType.cppType << R"cpp(
+			headerFile << R"cpp(struct [[nodiscard("unnecessary construction")]] )cpp"
+					   << inputType.cppType << R"cpp(
 {
 	)cpp" << introspectionExport
 					   << R"cpp(explicit )cpp" << inputType.cppType << R"cpp(()cpp";
@@ -428,7 +429,7 @@ static_assert(graphql::internal::MinorVersion == )cpp"
 		bool hasSubscription = false;
 		bool firstOperation = true;
 
-		headerFile << R"cpp(class [[nodiscard]] Operations final
+		headerFile << R"cpp(class [[nodiscard("unnecessary construction")]] Operations final
 	: public service::Request
 {
 public:
@@ -666,23 +667,23 @@ GRAPHQLSERVICE_EXPORT )cpp" << _loader.getSchemaNamespace()
 void Generator::outputInterfaceDeclaration(std::ostream& headerFile, std::string_view cppType) const
 {
 	headerFile
-		<< R"cpp(class [[nodiscard]] )cpp" << cppType << R"cpp( final
+		<< R"cpp(class [[nodiscard("unnecessary construction")]] )cpp" << cppType << R"cpp( final
 	: public service::Object
 {
 private:
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::TypeNames getTypeNames() const noexcept = 0;
-		[[nodiscard]] virtual service::ResolverMap getResolvers() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::TypeNames getTypeNames() const noexcept = 0;
+		[[nodiscard("unnecessary call")]] virtual service::ResolverMap getResolvers() const noexcept = 0;
 
 		virtual void beginSelectionSet(const service::SelectionSetParams& params) const = 0;
 		virtual void endSelectionSet(const service::SelectionSetParams& params) const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -690,12 +691,12 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::TypeNames getTypeNames() const noexcept override
+		[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept override
 		{
 			return _pimpl->getTypeNames();
 		}
 
-		[[nodiscard]] service::ResolverMap getResolvers() const noexcept override
+		[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept override
 		{
 			return _pimpl->getResolvers();
 		}
@@ -752,7 +753,7 @@ concept )cpp" << objectType.cppType
 			headerFile << R"cpp( || )cpp";
 		}
 
-		headerFile << R"cpp(std::is_same_v<I, )cpp" << _loader.getSafeCppName(interfaceName)
+		headerFile << R"cpp(std::is_same_v<I, )cpp" << SchemaLoader::getSafeCppName(interfaceName)
 				   << R"cpp(>)cpp";
 		firstInterface = false;
 	}
@@ -764,7 +765,7 @@ concept )cpp" << objectType.cppType
 			headerFile << R"cpp( || )cpp";
 		}
 
-		headerFile << R"cpp(std::is_same_v<I, )cpp" << _loader.getSafeCppName(unionName)
+		headerFile << R"cpp(std::is_same_v<I, )cpp" << SchemaLoader::getSafeCppName(unionName)
 				   << R"cpp(>)cpp";
 		firstInterface = false;
 	}
@@ -861,7 +862,8 @@ concept endSelectionSet = requires (TImpl impl, const service::SelectionSetParam
 void Generator::outputObjectDeclaration(
 	std::ostream& headerFile, const ObjectType& objectType, bool isQueryType) const
 {
-	headerFile << R"cpp(class [[nodiscard]] )cpp" << objectType.cppType << R"cpp( final
+	headerFile << R"cpp(class [[nodiscard("unnecessary construction")]] )cpp" << objectType.cppType
+			   << R"cpp( final
 	: public service::Object
 {
 private:
@@ -873,21 +875,21 @@ private:
 	}
 
 	headerFile << R"cpp(
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 )cpp";
 
 	if (!_options.noIntrospection && isQueryType)
 	{
 		headerFile
-			<< R"cpp(	[[nodiscard]] service::AwaitableResolver resolve_schema(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolve_type(service::ResolverParams&& params) const;
+			<< R"cpp(	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_schema(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_type(service::ResolverParams&& params) const;
 
 	std::shared_ptr<schema::Schema> _schema;
 )cpp";
 	}
 
 	headerFile << R"cpp(
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
@@ -910,7 +912,7 @@ private:
 	headerFile << R"cpp(	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -924,7 +926,7 @@ private:
 		const auto accessorName = SchemaLoader::getOutputCppAccessor(outputField);
 
 		headerFile << R"cpp(
-		[[nodiscard]] )cpp"
+		[[nodiscard("unnecessary call")]] )cpp"
 				   << _loader.getOutputCppType(outputField) << R"cpp( )cpp" << accessorName
 				   << R"cpp(()cpp";
 
@@ -1029,8 +1031,7 @@ private:
 			else
 			{
 				throw service::unimplemented_method(R"ex()cpp"
-						   << objectType.cppType << R"cpp(::)cpp" << accessorName
-						   << R"cpp()ex");
+						   << objectType.cppType << R"cpp(::)cpp" << accessorName << R"cpp()ex");
 			})cpp";
 			}
 		}
@@ -1074,8 +1075,8 @@ private:
 	{
 		headerFile << R"cpp(	const std::unique_ptr<const Concept> _pimpl;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT explicit )cpp"
@@ -1101,7 +1102,7 @@ public:
 
 			for (auto interfaceName : objectType.interfaces)
 			{
-				headerFile << R"cpp(	friend )cpp" << _loader.getSafeCppName(interfaceName)
+				headerFile << R"cpp(	friend )cpp" << SchemaLoader::getSafeCppName(interfaceName)
 						   << R"cpp(;
 )cpp";
 			}
@@ -1116,7 +1117,7 @@ public:
 
 			for (auto unionName : objectType.unions)
 			{
-				headerFile << R"cpp(	friend )cpp" << _loader.getSafeCppName(unionName)
+				headerFile << R"cpp(	friend )cpp" << SchemaLoader::getSafeCppName(unionName)
 						   << R"cpp(;
 )cpp";
 			}
@@ -1128,7 +1129,7 @@ public:
 		{
 
 			headerFile << R"cpp(	template <class I>
-	[[nodiscard]] static constexpr bool implements() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr bool implements() noexcept
 	{
 		return implements::)cpp"
 					   << objectType.cppType << R"cpp(Is<I>;
@@ -1138,8 +1139,8 @@ public:
 		}
 
 		headerFile
-			<< R"cpp(	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+			<< R"cpp(	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 	void beginSelectionSet(const service::SelectionSetParams& params) const override;
 	void endSelectionSet(const service::SelectionSetParams& params) const override;
@@ -1156,7 +1157,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] static constexpr std::string_view getObjectType() noexcept
+	[[nodiscard("unnecessary call")]] static constexpr std::string_view getObjectType() noexcept
 	{
 		return { R"gql()cpp"
 			<< objectType.type << R"cpp()gql" };
@@ -1182,8 +1183,8 @@ std::string Generator::getFieldDeclaration(const OutputField& outputField) const
 	std::ostringstream output;
 	const auto accessorName = SchemaLoader::getOutputCppAccessor(outputField);
 
-	output << R"cpp(		[[nodiscard]] virtual )cpp" << _loader.getOutputCppType(outputField)
-		   << R"cpp( )cpp" << accessorName << R"cpp(()cpp";
+	output << R"cpp(		[[nodiscard("unnecessary call")]] virtual )cpp"
+		   << _loader.getOutputCppType(outputField) << R"cpp( )cpp" << accessorName << R"cpp(()cpp";
 
 	bool firstArgument = _loader.isIntrospection();
 
@@ -1214,8 +1215,8 @@ std::string Generator::getResolverDeclaration(const OutputField& outputField) co
 	std::ostringstream output;
 	const auto resolverName = SchemaLoader::getOutputCppResolver(outputField);
 
-	output << R"cpp(	[[nodiscard]] service::AwaitableResolver )cpp" << resolverName
-		   << R"cpp((service::ResolverParams&& params) const;
+	output << R"cpp(	[[nodiscard("unnecessary call")]] service::AwaitableResolver )cpp"
+		   << resolverName << R"cpp((service::ResolverParams&& params) const;
 )cpp";
 
 	return output.str();
@@ -1481,6 +1482,7 @@ void Result<)cpp" << _loader.getSchemaNamespace()
 		sourceFile << std::endl
 				   << inputType.cppType << R"cpp(::)cpp" << inputType.cppType << R"cpp(() noexcept
 {
+	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
 
 )cpp" << inputType.cppType
@@ -1590,6 +1592,12 @@ void Result<)cpp" << _loader.getSchemaNamespace()
 }
 
 )cpp" << inputType.cppType
+				   << R"cpp(::~)cpp" << inputType.cppType << R"cpp(()
+{
+	// Explicit definition to prevent ODR violations when LTO is enabled.
+}
+
+)cpp" << inputType.cppType
 				   << R"cpp(& )cpp" << inputType.cppType << R"cpp(::operator=(const )cpp"
 				   << inputType.cppType << R"cpp(& other)
 {
@@ -1616,11 +1624,6 @@ void Result<)cpp" << _loader.getSchemaNamespace()
 
 		sourceFile << R"cpp(
 	return *this;
-}
-
-)cpp" << inputType.cppType
-				   << R"cpp(::~)cpp" << inputType.cppType << R"cpp(()
-{
 }
 )cpp";
 	}
@@ -1708,10 +1711,10 @@ Operations::Operations()cpp";
 	if (_loader.isIntrospection())
 	{
 		// Add SCALAR types for each of the built-in types
-		for (const auto& builtinType : SchemaLoader::getBuiltinTypes())
+		for (const auto& [typeName, builtinType] : SchemaLoader::getBuiltinTypes())
 		{
-			sourceFile << R"cpp(	schema->AddType(R"gql()cpp" << builtinType.first
-					   << R"cpp()gql"sv, schema::ScalarType::Make(R"gql()cpp" << builtinType.first
+			sourceFile << R"cpp(	schema->AddType(R"gql()cpp" << typeName
+					   << R"cpp()gql"sv, schema::ScalarType::Make(R"gql()cpp" << typeName
 					   << R"cpp()gql"sv, R"md()cpp";
 
 			if (!_options.noIntrospection)
@@ -1723,8 +1726,7 @@ Operations::Operations()cpp";
 
 			if (!_options.noIntrospection)
 			{
-				sourceFile << R"cpp(https://spec.graphql.org/October2021/#sec-)cpp"
-						   << builtinType.first;
+				sourceFile << R"cpp(https://spec.graphql.org/October2021/#sec-)cpp" << typeName;
 			}
 
 			sourceFile << R"cpp()url"sv));
@@ -2314,7 +2316,7 @@ service::ResolverMap )cpp"
 
 	bool firstField = true;
 
-	for (const auto& resolver : resolvers)
+	for (const auto& [fieldName, resolver] : resolvers)
 	{
 		if (!firstField)
 		{
@@ -2323,7 +2325,7 @@ service::ResolverMap )cpp"
 		}
 
 		firstField = false;
-		sourceFile << resolver.second;
+		sourceFile << resolver;
 	}
 
 	sourceFile << R"cpp(
@@ -2646,10 +2648,10 @@ std::string Generator::getArgumentDefaultValue(
 
 )cpp";
 
-			for (const auto& entry : members)
+			for (const auto& [memberName, memberDefault] : members)
 			{
-				argumentDefaultValue << getArgumentDefaultValue(level + 1, entry.second) << padding
-									 << R"cpp(			members.emplace_back(")cpp" << entry.first
+				argumentDefaultValue << getArgumentDefaultValue(level + 1, memberDefault) << padding
+									 << R"cpp(			members.emplace_back(")cpp" << memberName
 									 << R"cpp(", std::move(entry));
 )cpp";
 			}
@@ -3239,7 +3241,8 @@ using namespace std::literals;
 						if (includedObjects.insert(field.type).second)
 						{
 							sourceFile << R"cpp(#include ")cpp"
-									   << _loader.getSafeCppName(field.type) << R"cpp(Object.h"
+									   << SchemaLoader::getSafeCppName(field.type)
+									   << R"cpp(Object.h"
 )cpp";
 						}
 						break;

--- a/src/SyntaxTree.cpp
+++ b/src/SyntaxTree.cpp
@@ -640,9 +640,9 @@ struct ast_action : nothing<Rule>
 {
 };
 
-struct [[nodiscard]] depth_guard
+struct [[nodiscard("unnecessary construction")]] depth_guard
 {
-	explicit depth_guard(size_t& depth) noexcept
+	explicit depth_guard(size_t & depth) noexcept
 		: _depth(depth)
 	{
 		++_depth;
@@ -653,7 +653,7 @@ struct [[nodiscard]] depth_guard
 		--_depth;
 	}
 
-	depth_guard(depth_guard&&) noexcept = delete;
+	depth_guard(depth_guard &&) noexcept = delete;
 	depth_guard(const depth_guard&) = delete;
 
 	depth_guard& operator=(depth_guard&&) noexcept = delete;
@@ -668,7 +668,7 @@ struct ast_action<selection_set> : maybe_nothing
 {
 	template <typename Rule, apply_mode A, rewind_mode M, template <typename...> class Action,
 		template <typename...> class Control, typename ParseInput, typename... States>
-	[[nodiscard]] static bool match(ParseInput& in, States&&... st)
+	[[nodiscard("unnecessary call")]] static bool match(ParseInput& in, States&&... st)
 	{
 		depth_guard guard(in.selectionSetDepth);
 		if (in.selectionSetDepth > in.depthLimit())
@@ -956,7 +956,7 @@ struct make_control<Selector>::state_handler<Rule, true, B> : ast_control<Rule>
 
 template <typename Rule, template <typename...> class Action, template <typename...> class Selector,
 	typename ParseInput>
-[[nodiscard]] std::unique_ptr<ast_node> parse(ParseInput&& in)
+[[nodiscard("unnecessary call")]] std::unique_ptr<ast_node> parse(ParseInput&& in)
 {
 	internal::ast_state state;
 	if (!tao::graphqlpeg::parse<Rule, Action, internal::make_control<Selector>::template type>(
@@ -977,11 +977,11 @@ template <typename Rule, template <typename...> class Action, template <typename
 } // namespace graphql_parse_tree
 
 template <class ParseInput>
-class [[nodiscard]] depth_limit_input : public ParseInput
+class [[nodiscard("unnecessary construction")]] depth_limit_input : public ParseInput
 {
 public:
 	template <typename... Args>
-	explicit depth_limit_input(size_t depthLimit, Args&&... args) noexcept
+	explicit depth_limit_input(size_t depthLimit, Args && ... args) noexcept
 		: ParseInput(std::forward<Args>(args)...)
 		, _depthLimit(depthLimit)
 	{
@@ -1001,19 +1001,19 @@ private:
 using ast_file = depth_limit_input<file_input<>>;
 using ast_memory = depth_limit_input<memory_input<>>;
 
-struct [[nodiscard]] ast_string
+struct [[nodiscard("unnecessary construction")]] ast_string
 {
 	std::vector<char> input;
 	std::unique_ptr<ast_memory> memory {};
 };
 
-struct [[nodiscard]] ast_string_view
+struct [[nodiscard("unnecessary construction")]] ast_string_view
 {
 	std::string_view input;
 	std::unique_ptr<memory_input<>> memory {};
 };
 
-struct [[nodiscard]] ast_input
+struct [[nodiscard("unnecessary construction")]] ast_input
 {
 	std::variant<ast_string, std::unique_ptr<ast_file>, ast_string_view> data;
 };

--- a/src/introspection/DirectiveObject.h
+++ b/src/introspection/DirectiveObject.h
@@ -12,31 +12,31 @@
 
 namespace graphql::introspection::object {
 
-class [[nodiscard]] Directive final
+class [[nodiscard("unnecessary construction")]] Directive final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveLocations(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveIsRepeatable(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveLocations(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveIsRepeatable(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsRepeatable() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getIsRepeatable() const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -44,27 +44,27 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getName() const override
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::vector<DirectiveLocation>> getLocations() const override
 		{
 			return { _pimpl->getLocations() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const override
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsRepeatable() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getIsRepeatable() const override
 		{
 			return { _pimpl->getIsRepeatable() };
 		}
@@ -75,8 +75,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT explicit Directive(std::shared_ptr<introspection::Directive> pimpl) noexcept;

--- a/src/introspection/EnumValueObject.h
+++ b/src/introspection/EnumValueObject.h
@@ -12,29 +12,29 @@
 
 namespace graphql::introspection::object {
 
-class [[nodiscard]] EnumValue final
+class [[nodiscard("unnecessary construction")]] EnumValue final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -42,22 +42,22 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getName() const override
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getIsDeprecated() const override
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const override
 		{
 			return { _pimpl->getDeprecationReason() };
 		}
@@ -68,8 +68,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT explicit EnumValue(std::shared_ptr<introspection::EnumValue> pimpl) noexcept;

--- a/src/introspection/FieldObject.h
+++ b/src/introspection/FieldObject.h
@@ -12,33 +12,33 @@
 
 namespace graphql::introspection::object {
 
-class [[nodiscard]] Field final
+class [[nodiscard("unnecessary construction")]] Field final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveArgs(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveIsDeprecated(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDeprecationReason(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<bool> getIsDeprecated() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -46,32 +46,32 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getName() const override
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<InputValue>>> getArgs() const override
 		{
 			return { _pimpl->getArgs() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Type>> getType() const override
 		{
 			return { _pimpl->getType() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<bool> getIsDeprecated() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<bool> getIsDeprecated() const override
 		{
 			return { _pimpl->getIsDeprecated() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDeprecationReason() const override
 		{
 			return { _pimpl->getDeprecationReason() };
 		}
@@ -82,8 +82,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT explicit Field(std::shared_ptr<introspection::Field> pimpl) noexcept;

--- a/src/introspection/InputValueObject.h
+++ b/src/introspection/InputValueObject.h
@@ -12,29 +12,29 @@
 
 namespace graphql::introspection::object {
 
-class [[nodiscard]] InputValue final
+class [[nodiscard("unnecessary construction")]] InputValue final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDefaultValue(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDefaultValue(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::string> getName() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::string> getName() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Type>> getType() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -42,22 +42,22 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::string> getName() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::string> getName() const override
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getType() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Type>> getType() const override
 		{
 			return { _pimpl->getType() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDefaultValue() const override
 		{
 			return { _pimpl->getDefaultValue() };
 		}
@@ -68,8 +68,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT explicit InputValue(std::shared_ptr<introspection::InputValue> pimpl) noexcept;

--- a/src/introspection/IntrospectionSchema.h
+++ b/src/introspection/IntrospectionSchema.h
@@ -34,7 +34,7 @@ enum class TypeKind
 	NON_NULL
 };
 
-[[nodiscard]] constexpr auto getTypeKindNames() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getTypeKindNames() noexcept
 {
 	using namespace std::literals;
 
@@ -50,7 +50,7 @@ enum class TypeKind
 	};
 }
 
-[[nodiscard]] constexpr auto getTypeKindValues() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getTypeKindValues() noexcept
 {
 	using namespace std::literals;
 
@@ -89,7 +89,7 @@ enum class DirectiveLocation
 	INPUT_FIELD_DEFINITION
 };
 
-[[nodiscard]] constexpr auto getDirectiveLocationNames() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getDirectiveLocationNames() noexcept
 {
 	using namespace std::literals;
 
@@ -116,7 +116,7 @@ enum class DirectiveLocation
 	};
 }
 
-[[nodiscard]] constexpr auto getDirectiveLocationValues() noexcept
+[[nodiscard("unnecessary call")]] constexpr auto getDirectiveLocationValues() noexcept
 {
 	using namespace std::literals;
 

--- a/src/introspection/SchemaObject.h
+++ b/src/introspection/SchemaObject.h
@@ -12,33 +12,33 @@
 
 namespace graphql::introspection::object {
 
-class [[nodiscard]] Schema final
+class [[nodiscard("unnecessary construction")]] Schema final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveTypes(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveQueryType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveMutationType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveSubscriptionType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDirectives(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveTypes(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveQueryType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveMutationType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveSubscriptionType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDirectives(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -46,32 +46,32 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<Type>>> getTypes() const override
 		{
 			return { _pimpl->getTypes() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Type>> getQueryType() const override
 		{
 			return { _pimpl->getQueryType() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Type>> getMutationType() const override
 		{
 			return { _pimpl->getMutationType() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Type>> getSubscriptionType() const override
 		{
 			return { _pimpl->getSubscriptionType() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::vector<std::shared_ptr<Directive>>> getDirectives() const override
 		{
 			return { _pimpl->getDirectives() };
 		}
@@ -82,8 +82,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT explicit Schema(std::shared_ptr<introspection::Schema> pimpl) noexcept;

--- a/src/introspection/TypeObject.h
+++ b/src/introspection/TypeObject.h
@@ -12,41 +12,41 @@
 
 namespace graphql::introspection::object {
 
-class [[nodiscard]] Type final
+class [[nodiscard("unnecessary construction")]] Type final
 	: public service::Object
 {
 private:
-	[[nodiscard]] service::AwaitableResolver resolveKind(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveFields(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveInterfaces(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolvePossibleTypes(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveEnumValues(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveInputFields(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveOfType(service::ResolverParams&& params) const;
-	[[nodiscard]] service::AwaitableResolver resolveSpecifiedByURL(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveKind(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveName(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveDescription(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveFields(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveInterfaces(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolvePossibleTypes(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveEnumValues(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveInputFields(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveOfType(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolveSpecifiedByURL(service::ResolverParams&& params) const;
 
-	[[nodiscard]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
+	[[nodiscard("unnecessary call")]] service::AwaitableResolver resolve_typename(service::ResolverParams&& params) const;
 
-	struct [[nodiscard]] Concept
+	struct [[nodiscard("unnecessary construction")]] Concept
 	{
 		virtual ~Concept() = default;
 
-		[[nodiscard]] virtual service::AwaitableScalar<TypeKind> getKind() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getName() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const = 0;
-		[[nodiscard]] virtual service::AwaitableObject<std::shared_ptr<Type>> getOfType() const = 0;
-		[[nodiscard]] virtual service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<TypeKind> getKind() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getName() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getDescription() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableObject<std::shared_ptr<Type>> getOfType() const = 0;
+		[[nodiscard("unnecessary call")]] virtual service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const = 0;
 	};
 
 	template <class T>
-	struct [[nodiscard]] Model final
+	struct [[nodiscard("unnecessary construction")]] Model final
 		: Concept
 	{
 		explicit Model(std::shared_ptr<T> pimpl) noexcept
@@ -54,52 +54,52 @@ private:
 		{
 		}
 
-		[[nodiscard]] service::AwaitableScalar<TypeKind> getKind() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<TypeKind> getKind() const override
 		{
 			return { _pimpl->getKind() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getName() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getName() const override
 		{
 			return { _pimpl->getName() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getDescription() const override
 		{
 			return { _pimpl->getDescription() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Field>>>> getFields(std::optional<bool>&& includeDeprecatedArg) const override
 		{
 			return { _pimpl->getFields(std::move(includeDeprecatedArg)) };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getInterfaces() const override
 		{
 			return { _pimpl->getInterfaces() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<Type>>>> getPossibleTypes() const override
 		{
 			return { _pimpl->getPossibleTypes() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<EnumValue>>>> getEnumValues(std::optional<bool>&& includeDeprecatedArg) const override
 		{
 			return { _pimpl->getEnumValues(std::move(includeDeprecatedArg)) };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::optional<std::vector<std::shared_ptr<InputValue>>>> getInputFields() const override
 		{
 			return { _pimpl->getInputFields() };
 		}
 
-		[[nodiscard]] service::AwaitableObject<std::shared_ptr<Type>> getOfType() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableObject<std::shared_ptr<Type>> getOfType() const override
 		{
 			return { _pimpl->getOfType() };
 		}
 
-		[[nodiscard]] service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const override
+		[[nodiscard("unnecessary call")]] service::AwaitableScalar<std::optional<std::string>> getSpecifiedByURL() const override
 		{
 			return { _pimpl->getSpecifiedByURL() };
 		}
@@ -110,8 +110,8 @@ private:
 
 	const std::unique_ptr<const Concept> _pimpl;
 
-	[[nodiscard]] service::TypeNames getTypeNames() const noexcept;
-	[[nodiscard]] service::ResolverMap getResolvers() const noexcept;
+	[[nodiscard("unnecessary call")]] service::TypeNames getTypeNames() const noexcept;
+	[[nodiscard("unnecessary call")]] service::ResolverMap getResolvers() const noexcept;
 
 public:
 	GRAPHQLSERVICE_EXPORT explicit Type(std::shared_ptr<introspection::Type> pimpl) noexcept;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,6 +67,7 @@ target_link_libraries(pegtl_combined_tests PRIVATE
   GTest::Main)
 target_include_directories(pegtl_combined_tests PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_compile_features(pegtl_combined_tests PRIVATE cxx_std_20)
 gtest_add_tests(TARGET pegtl_combined_tests)
 
 add_executable(pegtl_executable_tests PegtlExecutableTests.cpp)
@@ -85,6 +86,7 @@ target_link_libraries(pegtl_schema_tests PRIVATE
   GTest::Main)
 target_include_directories(pegtl_schema_tests PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_compile_features(pegtl_schema_tests PRIVATE cxx_std_20)
 gtest_add_tests(TARGET pegtl_schema_tests)
 
 add_executable(response_tests ResponseTests.cpp)


### PR DESCRIPTION
I don't have a subscription to SonarQube to test #286, but I installed SonarLint locally and started looking at some of its suggestions, particularly in the generated code.

I'm ignoring some of its suggestions, like using `= default`, because I've run into trouble with LTO and ODR before from that and I want to enforce putting the constructors and destructor definitions in a specific translation unit.