### PR TITLE
Make workflows work with vcpkg binary artifact caching

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,12 +20,14 @@ jobs:
       uses: actions/cache@v3
       id: cache-vcpkg
       with:
-        path: build/vcpkg_installed/
-        key: vcpkg-x64-osx
+        path: build/vcpkg_cache/
+        key: vcpkg-binaries-x64-osx
 
     - name: Create Build Environment
       if: ${{ !steps.cache-vcpkg.outputs.cache-hit }}
-      run: cmake -E make_directory build
+      run: |
+        cmake -E make_directory build
+        cmake -E make_directory build/vcpkg_cache
 
     - name: Configure
       shell: pwsh
@@ -33,6 +35,10 @@ jobs:
       run: |
         $vcpkgToolchain = Join-Path $env:VCPKG_INSTALLATION_ROOT './scripts/buildsystems/vcpkg.cmake' -Resolve
         $cmakeBuildType = '${{ matrix.config }}'
+
+        $cachedBinaries = Join-Path $(Get-Location) './vcpkg_cache/' -Resolve
+        $cacheAccess = $(if ('${{ steps.cache-vcpkg.outputs.cache-hit }}' -eq 'true') { 'read' } else { 'write' })
+        $env:VCPKG_BINARY_SOURCES = "clear;files,$cachedBinaries,$cacheAccess"
 
         cmake "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" "-DCMAKE_BUILD_TYPE=$cmakeBuildType" ${{ github.workspace }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,7 +47,7 @@ jobs:
         $msbuildArch = $(if ('${{ matrix.arch }}' -eq 'x64') { 'X64' } else { 'Win32' })
 
         $cachedBinaries = Join-Path $(Get-Location) './vcpkg_cache/' -Resolve
-        $cacheAccess = $(if ${{ steps.cache-vcpkg.outputs.cache-hit }} { 'r' } else { 'rw' })
+        $cacheAccess = $(if ('${{ steps.cache-vcpkg.outputs.cache-hit }}' -eq 'true') { 'r' } else { 'rw' })
         $env:VCPKG_BINARY_SOURCES = "clear;files,$cachedBinaries,$cacheAccess"
 
         cmake "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" "-DVCPKG_TARGET_TRIPLET=$vcpkgTriplet" "-DBUILD_SHARED_LIBS=$cmakeSharedLibs" -G "Visual Studio 17 2022" -A "$msbuildArch" ${{ github.workspace }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,13 +40,12 @@ jobs:
       id: configure-build
       shell: pwsh
       working-directory: build/
-      env:
-        VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.configure-build.working-directory }}/vcpkg_cache/,$(if ${{ steps.cache-vcpkg.outputs.cache-hit }} { "r" } else { "rw" })'
       run: |
         $vcpkgToolchain = Join-Path $env:VCPKG_INSTALLATION_ROOT '.\scripts\buildsystems\vcpkg.cmake' -Resolve
         $vcpkgTriplet = '${{ steps.set-variables.outputs.vcpkg_triplet }}'
         $cmakeSharedLibs = $(if ('${{ matrix.libs }}' -eq 'shared') { 'ON' } else { 'OFF' })
         $msbuildArch = $(if ('${{ matrix.arch }}' -eq 'x64') { 'X64' } else { 'Win32' })
+        $env:VCPKG_BINARY_SOURCES = "clear;files,${{ steps.configure-build.working-directory }}/vcpkg_cache/,$(if ${{ steps.cache-vcpkg.outputs.cache-hit }} { 'r' } else { 'rw' })"
 
         cmake "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" "-DVCPKG_TARGET_TRIPLET=$vcpkgTriplet" "-DBUILD_SHARED_LIBS=$cmakeSharedLibs" -G "Visual Studio 17 2022" -A "$msbuildArch" ${{ github.workspace }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,7 +47,7 @@ jobs:
         $msbuildArch = $(if ('${{ matrix.arch }}' -eq 'x64') { 'X64' } else { 'Win32' })
 
         $cachedBinaries = Join-Path $(Get-Location) './vcpkg_cache/' -Resolve
-        $cacheAccess = $(if ('${{ steps.cache-vcpkg.outputs.cache-hit }}' -eq 'true') { 'r' } else { 'rw' })
+        $cacheAccess = $(if ('${{ steps.cache-vcpkg.outputs.cache-hit }}' -eq 'true') { 'read' } else { 'write' })
         $env:VCPKG_BINARY_SOURCES = "clear;files,$cachedBinaries,$cacheAccess"
 
         cmake "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" "-DVCPKG_TARGET_TRIPLET=$vcpkgTriplet" "-DBUILD_SHARED_LIBS=$cmakeSharedLibs" -G "Visual Studio 17 2022" -A "$msbuildArch" ${{ github.workspace }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -45,7 +45,10 @@ jobs:
         $vcpkgTriplet = '${{ steps.set-variables.outputs.vcpkg_triplet }}'
         $cmakeSharedLibs = $(if ('${{ matrix.libs }}' -eq 'shared') { 'ON' } else { 'OFF' })
         $msbuildArch = $(if ('${{ matrix.arch }}' -eq 'x64') { 'X64' } else { 'Win32' })
-        $env:VCPKG_BINARY_SOURCES = "clear;files,${{ steps.configure-build.working-directory }}/vcpkg_cache/,$(if ${{ steps.cache-vcpkg.outputs.cache-hit }} { 'r' } else { 'rw' })"
+
+        $cachedBinaries = Join-Path $(Get-Location) './vcpkg_cache/' -Resolve
+        $cacheAccess = $(if ${{ steps.cache-vcpkg.outputs.cache-hit }} { 'r' } else { 'rw' })
+        $env:VCPKG_BINARY_SOURCES = "clear;files,$cachedBinaries,$cacheAccess"
 
         cmake "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" "-DVCPKG_TARGET_TRIPLET=$vcpkgTriplet" "-DBUILD_SHARED_LIBS=$cmakeSharedLibs" -G "Visual Studio 17 2022" -A "$msbuildArch" ${{ github.workspace }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
       id: cache-vcpkg
       with:
         path: build/vcpkg_cache/
-        key: vcpkg-${{ steps.set-variables.outputs.vcpkg_triplet }}
+        key: vcpkg-binaries-${{ steps.set-variables.outputs.vcpkg_triplet }}
 
     - name: Create Build Environment
       if: ${{ !steps.cache-vcpkg.outputs.cache-hit }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,16 +27,21 @@ jobs:
       uses: actions/cache@v3
       id: cache-vcpkg
       with:
-        path: build/vcpkg_installed/
+        path: build/vcpkg_cache/
         key: vcpkg-${{ steps.set-variables.outputs.vcpkg_triplet }}
 
     - name: Create Build Environment
       if: ${{ !steps.cache-vcpkg.outputs.cache-hit }}
-      run: cmake -E make_directory build
+      run: |
+        cmake -E make_directory build
+        cmake -E make_directory build/vcpkg_cache
 
     - name: Configure
+      id: configure-build
       shell: pwsh
       working-directory: build/
+      env:
+        VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.configure-build.working-directory }}/vcpkg_cache/,$(if ${{ steps.cache-vcpkg.outputs.cache-hit }} { "r" } else { "rw" })'
       run: |
         $vcpkgToolchain = Join-Path $env:VCPKG_INSTALLATION_ROOT '.\scripts\buildsystems\vcpkg.cmake' -Resolve
         $vcpkgTriplet = '${{ steps.set-variables.outputs.vcpkg_triplet }}'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,6 @@ jobs:
         cmake -E make_directory build/vcpkg_cache
 
     - name: Configure
-      id: configure-build
       shell: pwsh
       working-directory: build/
       run: |


### PR DESCRIPTION
The macos and windows PR/CI pipelines are not properly caching the dependencies automatically installed with `vcpkg`. Setting the `VCPKG_BINARY_SOURCES` environment variable seems to fix it.