### PR TITLE
fix: #306

### DIFF
--- a/include/graphqlservice/internal/Grammar.h
+++ b/include/graphqlservice/internal/Grammar.h
@@ -234,8 +234,7 @@ struct exponent_part : if_must<exponent_indicator, exponent_part_content>
 };
 
 // https://spec.graphql.org/October2021/#FloatValue
-struct float_value
-	: seq<integer_part, sor<fractional_part, exponent_part, seq<fractional_part, exponent_part>>>
+struct float_value : seq<integer_part, sor<seq<fractional_part, opt<exponent_part>>, exponent_part>>
 {
 };
 

--- a/test/PegtlExecutableTests.cpp
+++ b/test/PegtlExecutableTests.cpp
@@ -230,3 +230,13 @@ TEST(PegtlExecutableCase, ParserDepthLimitExceeded)
 	EXPECT_TRUE(caughtException) << "should catch a parse exception";
 	EXPECT_FALSE(parsedQuery) << "should not successfully parse the query";
 }
+
+TEST(PegtlExecutableCase, ParseFloatWithFractionalAndExponentialParts)
+{
+	memory_input<> input(R"gql({ field(value: 1.1e1) })gql",
+		"ParseFloatWithFractionalAndExponentialParts");
+
+	const bool result = parse<executable_document>(input);
+
+	ASSERT_TRUE(result) << "we should be able to parse the doc";
+}


### PR DESCRIPTION
The grammar rule for `float_value` would not back up and retry the `seq<fractional_part, exponent_part>` once it had successfully matched the first `fractional_part`.