### PR TITLE
fix: schema input type member default init error on clang 14

### DIFF
--- a/samples/learn/schema/StarWarsSchema.cpp
+++ b/samples/learn/schema/StarWarsSchema.cpp
@@ -97,6 +97,8 @@ learn::ReviewInput Argument<learn::ReviewInput>::convert(const response::Value& 
 namespace learn {
 
 ReviewInput::ReviewInput() noexcept
+	: stars {}
+	, commentary {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }

--- a/samples/learn/schema/StarWarsSchema.h
+++ b/samples/learn/schema/StarWarsSchema.h
@@ -64,8 +64,8 @@ struct [[nodiscard("unnecessary construction")]] ReviewInput
 	ReviewInput& operator=(const ReviewInput& other);
 	ReviewInput& operator=(ReviewInput&& other) noexcept;
 
-	int stars {};
-	std::optional<std::string> commentary {};
+	int stars;
+	std::optional<std::string> commentary;
 };
 
 namespace object {

--- a/samples/today/nointrospection/TodaySchema.cpp
+++ b/samples/today/nointrospection/TodaySchema.cpp
@@ -228,6 +228,10 @@ today::FirstNestedInput Argument<today::FirstNestedInput>::convert(const respons
 namespace today {
 
 CompleteTaskInput::CompleteTaskInput() noexcept
+	: id {}
+	, testTaskState {}
+	, isComplete {}
+	, clientMutationId {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -285,6 +289,8 @@ CompleteTaskInput& CompleteTaskInput::operator=(CompleteTaskInput&& other) noexc
 }
 
 ThirdNestedInput::ThirdNestedInput() noexcept
+	: id {}
+	, second {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -332,6 +338,7 @@ ThirdNestedInput& ThirdNestedInput::operator=(ThirdNestedInput&& other) noexcept
 }
 
 FourthNestedInput::FourthNestedInput() noexcept
+	: id {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -374,6 +381,7 @@ FourthNestedInput& FourthNestedInput::operator=(FourthNestedInput&& other) noexc
 }
 
 IncludeNullableSelfInput::IncludeNullableSelfInput() noexcept
+	: self {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -416,6 +424,7 @@ IncludeNullableSelfInput& IncludeNullableSelfInput::operator=(IncludeNullableSel
 }
 
 IncludeNonNullableListSelfInput::IncludeNonNullableListSelfInput() noexcept
+	: selves {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -458,6 +467,18 @@ IncludeNonNullableListSelfInput& IncludeNonNullableListSelfInput::operator=(Incl
 }
 
 StringOperationFilterInput::StringOperationFilterInput() noexcept
+	: and_ {}
+	, or_ {}
+	, equal {}
+	, notEqual {}
+	, contains {}
+	, notContains {}
+	, in {}
+	, notIn {}
+	, startsWith {}
+	, notStartsWith {}
+	, endsWith {}
+	, notEndsWith {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -555,6 +576,8 @@ StringOperationFilterInput& StringOperationFilterInput::operator=(StringOperatio
 }
 
 SecondNestedInput::SecondNestedInput() noexcept
+	: id {}
+	, third {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -602,6 +625,8 @@ SecondNestedInput& SecondNestedInput::operator=(SecondNestedInput&& other) noexc
 }
 
 ForwardDeclaredInput::ForwardDeclaredInput() noexcept
+	: nullableSelf {}
+	, listSelves {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -649,6 +674,9 @@ ForwardDeclaredInput& ForwardDeclaredInput::operator=(ForwardDeclaredInput&& oth
 }
 
 FirstNestedInput::FirstNestedInput() noexcept
+	: id {}
+	, second {}
+	, third {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }

--- a/samples/today/nointrospection/TodaySchema.h
+++ b/samples/today/nointrospection/TodaySchema.h
@@ -69,10 +69,10 @@ struct [[nodiscard("unnecessary construction")]] CompleteTaskInput
 	CompleteTaskInput& operator=(const CompleteTaskInput& other);
 	CompleteTaskInput& operator=(CompleteTaskInput&& other) noexcept;
 
-	response::IdType id {};
-	std::optional<TaskState> testTaskState {};
-	std::optional<bool> isComplete {};
-	std::optional<std::string> clientMutationId {};
+	response::IdType id;
+	std::optional<TaskState> testTaskState;
+	std::optional<bool> isComplete;
+	std::optional<std::string> clientMutationId;
 };
 
 struct SecondNestedInput;
@@ -90,8 +90,8 @@ struct [[nodiscard("unnecessary construction")]] ThirdNestedInput
 	ThirdNestedInput& operator=(const ThirdNestedInput& other);
 	ThirdNestedInput& operator=(ThirdNestedInput&& other) noexcept;
 
-	response::IdType id {};
-	std::unique_ptr<SecondNestedInput> second {};
+	response::IdType id;
+	std::unique_ptr<SecondNestedInput> second;
 };
 
 struct [[nodiscard("unnecessary construction")]] FourthNestedInput
@@ -106,7 +106,7 @@ struct [[nodiscard("unnecessary construction")]] FourthNestedInput
 	FourthNestedInput& operator=(const FourthNestedInput& other);
 	FourthNestedInput& operator=(FourthNestedInput&& other) noexcept;
 
-	response::IdType id {};
+	response::IdType id;
 };
 
 struct [[nodiscard("unnecessary construction")]] IncludeNullableSelfInput
@@ -121,7 +121,7 @@ struct [[nodiscard("unnecessary construction")]] IncludeNullableSelfInput
 	IncludeNullableSelfInput& operator=(const IncludeNullableSelfInput& other);
 	IncludeNullableSelfInput& operator=(IncludeNullableSelfInput&& other) noexcept;
 
-	std::unique_ptr<IncludeNullableSelfInput> self {};
+	std::unique_ptr<IncludeNullableSelfInput> self;
 };
 
 struct [[nodiscard("unnecessary construction")]] IncludeNonNullableListSelfInput
@@ -136,7 +136,7 @@ struct [[nodiscard("unnecessary construction")]] IncludeNonNullableListSelfInput
 	IncludeNonNullableListSelfInput& operator=(const IncludeNonNullableListSelfInput& other);
 	IncludeNonNullableListSelfInput& operator=(IncludeNonNullableListSelfInput&& other) noexcept;
 
-	std::vector<IncludeNonNullableListSelfInput> selves {};
+	std::vector<IncludeNonNullableListSelfInput> selves;
 };
 
 struct [[nodiscard("unnecessary construction")]] StringOperationFilterInput
@@ -162,18 +162,18 @@ struct [[nodiscard("unnecessary construction")]] StringOperationFilterInput
 	StringOperationFilterInput& operator=(const StringOperationFilterInput& other);
 	StringOperationFilterInput& operator=(StringOperationFilterInput&& other) noexcept;
 
-	std::optional<std::vector<StringOperationFilterInput>> and_ {};
-	std::optional<std::vector<StringOperationFilterInput>> or_ {};
-	std::optional<std::string> equal {};
-	std::optional<std::string> notEqual {};
-	std::optional<std::string> contains {};
-	std::optional<std::string> notContains {};
-	std::optional<std::vector<std::string>> in {};
-	std::optional<std::vector<std::string>> notIn {};
-	std::optional<std::string> startsWith {};
-	std::optional<std::string> notStartsWith {};
-	std::optional<std::string> endsWith {};
-	std::optional<std::string> notEndsWith {};
+	std::optional<std::vector<StringOperationFilterInput>> and_;
+	std::optional<std::vector<StringOperationFilterInput>> or_;
+	std::optional<std::string> equal;
+	std::optional<std::string> notEqual;
+	std::optional<std::string> contains;
+	std::optional<std::string> notContains;
+	std::optional<std::vector<std::string>> in;
+	std::optional<std::vector<std::string>> notIn;
+	std::optional<std::string> startsWith;
+	std::optional<std::string> notStartsWith;
+	std::optional<std::string> endsWith;
+	std::optional<std::string> notEndsWith;
 };
 
 struct [[nodiscard("unnecessary construction")]] SecondNestedInput
@@ -189,8 +189,8 @@ struct [[nodiscard("unnecessary construction")]] SecondNestedInput
 	SecondNestedInput& operator=(const SecondNestedInput& other);
 	SecondNestedInput& operator=(SecondNestedInput&& other) noexcept;
 
-	response::IdType id {};
-	ThirdNestedInput third {};
+	response::IdType id;
+	ThirdNestedInput third;
 };
 
 struct [[nodiscard("unnecessary construction")]] ForwardDeclaredInput
@@ -206,8 +206,8 @@ struct [[nodiscard("unnecessary construction")]] ForwardDeclaredInput
 	ForwardDeclaredInput& operator=(const ForwardDeclaredInput& other);
 	ForwardDeclaredInput& operator=(ForwardDeclaredInput&& other) noexcept;
 
-	std::unique_ptr<IncludeNullableSelfInput> nullableSelf {};
-	IncludeNonNullableListSelfInput listSelves {};
+	std::unique_ptr<IncludeNullableSelfInput> nullableSelf;
+	IncludeNonNullableListSelfInput listSelves;
 };
 
 struct [[nodiscard("unnecessary construction")]] FirstNestedInput
@@ -224,9 +224,9 @@ struct [[nodiscard("unnecessary construction")]] FirstNestedInput
 	FirstNestedInput& operator=(const FirstNestedInput& other);
 	FirstNestedInput& operator=(FirstNestedInput&& other) noexcept;
 
-	response::IdType id {};
-	SecondNestedInput second {};
-	ThirdNestedInput third {};
+	response::IdType id;
+	SecondNestedInput second;
+	ThirdNestedInput third;
 };
 
 namespace object {

--- a/samples/today/schema/TodaySchema.cpp
+++ b/samples/today/schema/TodaySchema.cpp
@@ -228,6 +228,10 @@ today::FirstNestedInput Argument<today::FirstNestedInput>::convert(const respons
 namespace today {
 
 CompleteTaskInput::CompleteTaskInput() noexcept
+	: id {}
+	, testTaskState {}
+	, isComplete {}
+	, clientMutationId {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -285,6 +289,8 @@ CompleteTaskInput& CompleteTaskInput::operator=(CompleteTaskInput&& other) noexc
 }
 
 ThirdNestedInput::ThirdNestedInput() noexcept
+	: id {}
+	, second {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -332,6 +338,7 @@ ThirdNestedInput& ThirdNestedInput::operator=(ThirdNestedInput&& other) noexcept
 }
 
 FourthNestedInput::FourthNestedInput() noexcept
+	: id {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -374,6 +381,7 @@ FourthNestedInput& FourthNestedInput::operator=(FourthNestedInput&& other) noexc
 }
 
 IncludeNullableSelfInput::IncludeNullableSelfInput() noexcept
+	: self {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -416,6 +424,7 @@ IncludeNullableSelfInput& IncludeNullableSelfInput::operator=(IncludeNullableSel
 }
 
 IncludeNonNullableListSelfInput::IncludeNonNullableListSelfInput() noexcept
+	: selves {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -458,6 +467,18 @@ IncludeNonNullableListSelfInput& IncludeNonNullableListSelfInput::operator=(Incl
 }
 
 StringOperationFilterInput::StringOperationFilterInput() noexcept
+	: and_ {}
+	, or_ {}
+	, equal {}
+	, notEqual {}
+	, contains {}
+	, notContains {}
+	, in {}
+	, notIn {}
+	, startsWith {}
+	, notStartsWith {}
+	, endsWith {}
+	, notEndsWith {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -555,6 +576,8 @@ StringOperationFilterInput& StringOperationFilterInput::operator=(StringOperatio
 }
 
 SecondNestedInput::SecondNestedInput() noexcept
+	: id {}
+	, third {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -602,6 +625,8 @@ SecondNestedInput& SecondNestedInput::operator=(SecondNestedInput&& other) noexc
 }
 
 ForwardDeclaredInput::ForwardDeclaredInput() noexcept
+	: nullableSelf {}
+	, listSelves {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -649,6 +674,9 @@ ForwardDeclaredInput& ForwardDeclaredInput::operator=(ForwardDeclaredInput&& oth
 }
 
 FirstNestedInput::FirstNestedInput() noexcept
+	: id {}
+	, second {}
+	, third {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }

--- a/samples/today/schema/TodaySchema.h
+++ b/samples/today/schema/TodaySchema.h
@@ -69,10 +69,10 @@ struct [[nodiscard("unnecessary construction")]] CompleteTaskInput
 	CompleteTaskInput& operator=(const CompleteTaskInput& other);
 	CompleteTaskInput& operator=(CompleteTaskInput&& other) noexcept;
 
-	response::IdType id {};
-	std::optional<TaskState> testTaskState {};
-	std::optional<bool> isComplete {};
-	std::optional<std::string> clientMutationId {};
+	response::IdType id;
+	std::optional<TaskState> testTaskState;
+	std::optional<bool> isComplete;
+	std::optional<std::string> clientMutationId;
 };
 
 struct SecondNestedInput;
@@ -90,8 +90,8 @@ struct [[nodiscard("unnecessary construction")]] ThirdNestedInput
 	ThirdNestedInput& operator=(const ThirdNestedInput& other);
 	ThirdNestedInput& operator=(ThirdNestedInput&& other) noexcept;
 
-	response::IdType id {};
-	std::unique_ptr<SecondNestedInput> second {};
+	response::IdType id;
+	std::unique_ptr<SecondNestedInput> second;
 };
 
 struct [[nodiscard("unnecessary construction")]] FourthNestedInput
@@ -106,7 +106,7 @@ struct [[nodiscard("unnecessary construction")]] FourthNestedInput
 	FourthNestedInput& operator=(const FourthNestedInput& other);
 	FourthNestedInput& operator=(FourthNestedInput&& other) noexcept;
 
-	response::IdType id {};
+	response::IdType id;
 };
 
 struct [[nodiscard("unnecessary construction")]] IncludeNullableSelfInput
@@ -121,7 +121,7 @@ struct [[nodiscard("unnecessary construction")]] IncludeNullableSelfInput
 	IncludeNullableSelfInput& operator=(const IncludeNullableSelfInput& other);
 	IncludeNullableSelfInput& operator=(IncludeNullableSelfInput&& other) noexcept;
 
-	std::unique_ptr<IncludeNullableSelfInput> self {};
+	std::unique_ptr<IncludeNullableSelfInput> self;
 };
 
 struct [[nodiscard("unnecessary construction")]] IncludeNonNullableListSelfInput
@@ -136,7 +136,7 @@ struct [[nodiscard("unnecessary construction")]] IncludeNonNullableListSelfInput
 	IncludeNonNullableListSelfInput& operator=(const IncludeNonNullableListSelfInput& other);
 	IncludeNonNullableListSelfInput& operator=(IncludeNonNullableListSelfInput&& other) noexcept;
 
-	std::vector<IncludeNonNullableListSelfInput> selves {};
+	std::vector<IncludeNonNullableListSelfInput> selves;
 };
 
 struct [[nodiscard("unnecessary construction")]] StringOperationFilterInput
@@ -162,18 +162,18 @@ struct [[nodiscard("unnecessary construction")]] StringOperationFilterInput
 	StringOperationFilterInput& operator=(const StringOperationFilterInput& other);
 	StringOperationFilterInput& operator=(StringOperationFilterInput&& other) noexcept;
 
-	std::optional<std::vector<StringOperationFilterInput>> and_ {};
-	std::optional<std::vector<StringOperationFilterInput>> or_ {};
-	std::optional<std::string> equal {};
-	std::optional<std::string> notEqual {};
-	std::optional<std::string> contains {};
-	std::optional<std::string> notContains {};
-	std::optional<std::vector<std::string>> in {};
-	std::optional<std::vector<std::string>> notIn {};
-	std::optional<std::string> startsWith {};
-	std::optional<std::string> notStartsWith {};
-	std::optional<std::string> endsWith {};
-	std::optional<std::string> notEndsWith {};
+	std::optional<std::vector<StringOperationFilterInput>> and_;
+	std::optional<std::vector<StringOperationFilterInput>> or_;
+	std::optional<std::string> equal;
+	std::optional<std::string> notEqual;
+	std::optional<std::string> contains;
+	std::optional<std::string> notContains;
+	std::optional<std::vector<std::string>> in;
+	std::optional<std::vector<std::string>> notIn;
+	std::optional<std::string> startsWith;
+	std::optional<std::string> notStartsWith;
+	std::optional<std::string> endsWith;
+	std::optional<std::string> notEndsWith;
 };
 
 struct [[nodiscard("unnecessary construction")]] SecondNestedInput
@@ -189,8 +189,8 @@ struct [[nodiscard("unnecessary construction")]] SecondNestedInput
 	SecondNestedInput& operator=(const SecondNestedInput& other);
 	SecondNestedInput& operator=(SecondNestedInput&& other) noexcept;
 
-	response::IdType id {};
-	ThirdNestedInput third {};
+	response::IdType id;
+	ThirdNestedInput third;
 };
 
 struct [[nodiscard("unnecessary construction")]] ForwardDeclaredInput
@@ -206,8 +206,8 @@ struct [[nodiscard("unnecessary construction")]] ForwardDeclaredInput
 	ForwardDeclaredInput& operator=(const ForwardDeclaredInput& other);
 	ForwardDeclaredInput& operator=(ForwardDeclaredInput&& other) noexcept;
 
-	std::unique_ptr<IncludeNullableSelfInput> nullableSelf {};
-	IncludeNonNullableListSelfInput listSelves {};
+	std::unique_ptr<IncludeNullableSelfInput> nullableSelf;
+	IncludeNonNullableListSelfInput listSelves;
 };
 
 struct [[nodiscard("unnecessary construction")]] FirstNestedInput
@@ -224,9 +224,9 @@ struct [[nodiscard("unnecessary construction")]] FirstNestedInput
 	FirstNestedInput& operator=(const FirstNestedInput& other);
 	FirstNestedInput& operator=(FirstNestedInput&& other) noexcept;
 
-	response::IdType id {};
-	SecondNestedInput second {};
-	ThirdNestedInput third {};
+	response::IdType id;
+	SecondNestedInput second;
+	ThirdNestedInput third;
 };
 
 namespace object {

--- a/samples/validation/schema/ValidationSchema.cpp
+++ b/samples/validation/schema/ValidationSchema.cpp
@@ -154,6 +154,8 @@ validation::ComplexInput Argument<validation::ComplexInput>::convert(const respo
 namespace validation {
 
 ComplexInput::ComplexInput() noexcept
+	: name {}
+	, owner {}
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }

--- a/samples/validation/schema/ValidationSchema.h
+++ b/samples/validation/schema/ValidationSchema.h
@@ -87,8 +87,8 @@ struct [[nodiscard("unnecessary construction")]] ComplexInput
 	ComplexInput& operator=(const ComplexInput& other);
 	ComplexInput& operator=(ComplexInput&& other) noexcept;
 
-	std::optional<std::string> name {};
-	std::optional<std::string> owner {};
+	std::optional<std::string> name;
+	std::optional<std::string> owner;
 };
 
 namespace object {

--- a/src/SchemaGenerator.cpp
+++ b/src/SchemaGenerator.cpp
@@ -1172,7 +1172,7 @@ std::string Generator::getFieldDeclaration(const InputField& inputField) const n
 	std::ostringstream output;
 
 	output << R"cpp(	)cpp" << _loader.getInputCppType(inputField) << R"cpp( )cpp"
-		   << inputField.cppName << R"cpp( {};
+		   << inputField.cppName << R"cpp(;
 )cpp";
 
 	return output.str();
@@ -1480,7 +1480,20 @@ void Result<)cpp" << _loader.getSchemaNamespace()
 	for (const auto& inputType : _loader.getInputTypes())
 	{
 		sourceFile << std::endl
-				   << inputType.cppType << R"cpp(::)cpp" << inputType.cppType << R"cpp(() noexcept
+				   << inputType.cppType << R"cpp(::)cpp" << inputType.cppType
+				   << R"cpp(() noexcept)cpp";
+
+		bool firstField = true;
+
+		for (const auto& inputField : inputType.fields)
+		{
+			sourceFile << R"cpp(
+	)cpp" << (firstField ? R"cpp(:)cpp" : R"cpp(,)cpp")
+					   << R"cpp( )cpp" << inputField.cppName << R"cpp( {})cpp";
+			firstField = false;
+		}
+
+		sourceFile << R"cpp(
 {
 	// Explicit definition to prevent ODR violations when LTO is enabled.
 }
@@ -1488,7 +1501,7 @@ void Result<)cpp" << _loader.getSchemaNamespace()
 )cpp" << inputType.cppType
 				   << R"cpp(::)cpp" << inputType.cppType << R"cpp(()cpp";
 
-		bool firstField = true;
+		firstField = true;
 
 		for (const auto& inputField : inputType.fields)
 		{


### PR DESCRIPTION
The same issue exists in the schema input types as in the client input types, although I never actually saw that with any of the schema samples.

The error I saw once with clang 14 on an `Ubuntu 22.04` derived image (`Pop OS!`, specifically) had to do with not having a constructor for nested input type members available in the header when compiling the default member initializers using `{}` at the end of the member declaration. Since we've already pulled the default constructor for the type itself into the source file to fix ODR violations, it makes sense to move the default member initialization into the constructor's initializer list.