### PR TITLE
fix: support multiple operation_definition in Request::addSubscription

### DIFF
--- a/src/GraphQLService.cpp
+++ b/src/GraphQLService.cpp
@@ -2274,10 +2274,7 @@ SubscriptionKey Request::addSubscription(RequestSubscribeParams&& params)
 		std::move(fragments),
 		itr->second);
 
-	peg::for_each_child<peg::operation_definition>(subscriptionVisitor.getRoot(),
-		[&subscriptionVisitor](const peg::ast_node& child) {
-			subscriptionVisitor.visit(child);
-		});
+	subscriptionVisitor.visit(*operationDefinition);
 
 	auto registration = subscriptionVisitor.getRegistration();
 	auto key = _nextKey++;


### PR DESCRIPTION
 _Request::addSubscription_ returns corrupted key when multiple **operation_definition** found in request. 
Solution uses result of _Request::findOperationDefinition_ method which chooses definition by **operation_name** or first definition when name is absent.