### PR TITLE
Fix operator overload attribute syntax in GraphQLParse.h

### DIFF
--- a/include/graphqlservice/GraphQLParse.h
+++ b/include/graphqlservice/GraphQLParse.h
@@ -50,7 +50,7 @@ constexpr size_t c_defaultDepthLimit = 25;
 
 } // namespace peg
 
-[[nodiscard("unnecessary parse")]] GRAPHQLPEG_EXPORT peg::ast operator"" _graphql(
+[[nodiscard("unnecessary parse")]] GRAPHQLPEG_EXPORT peg::ast operator""_graphql(
 	const char* text, size_t size);
 
 } // namespace graphql

--- a/src/SyntaxTree.cpp
+++ b/src/SyntaxTree.cpp
@@ -1148,7 +1148,7 @@ ast parseFile(std::string_view filename, size_t depthLimit)
 
 } // namespace peg
 
-peg::ast operator"" _graphql(const char* text, size_t size)
+peg::ast operator""_graphql(const char* text, size_t size)
 {
 	peg::ast result { std::make_shared<peg::ast_input>(
 						  peg::ast_input { peg::ast_string_view { { text, size } } }),


### PR DESCRIPTION
to fix identifier '_graphql' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   53 | [[nodiscard("unnecessary parse")]] GRAPHQLPEG_EXPORT peg::ast operator"" _graphql(
      |                                                               ~~~~~~~~~~~^~~~~~~~
      |                                                               operator""_graphql